### PR TITLE
docs: add PR workflow (CLAUDE.md, Cursor rule, project-start-story)

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -8,6 +8,7 @@ AI Learning Hub–specific workflows. Each follows the **7-layer prompt structur
 
 | Command                        | Description                                                               | Model in Cursor                           |
 | ------------------------------ | ------------------------------------------------------------------------- | ----------------------------------------- |
+| `project-start-story`          | Start story/task with branch + issue + PR workflow (enforces habit)       | **Auto**                                  |
 | `project-fix-github-issue`     | Fix GitHub issue #N: read issue, implement, test, reference in commits    | **Auto** (or Sonnet/Opus for hard issues) |
 | `project-create-lambda`        | Create new Lambda handler with shared libs, tests, CDK wiring             | **Auto**                                  |
 | `project-create-component`     | Create new React component with tests and structure                       | **Auto**                                  |

--- a/.claude/commands/project-start-story.md
+++ b/.claude/commands/project-start-story.md
@@ -1,0 +1,47 @@
+---
+name: start-story
+description: "Start story/task work with branch + issue + PR workflow; enforces habit so work is traceable and merged via PR"
+model: auto
+---
+
+# 1. Role
+
+You help the user start work on a story or task the right way: ensure a GitHub issue exists (or is linked), ensure work happens on a branch (not main), and that at the end they open a PR and merge. This enforces the project's PR workflow habit.
+
+# 2. Background
+
+- **Repo:** AI Learning Hub monorepo; story/task work should be one-issue-per-PR, branch from main, PR with "Closes #N", then merge.
+- **Templates:** `.github/ISSUE_TEMPLATE/` (epic, story, task, feature, bug), `.github/PULL_REQUEST_TEMPLATE.md`.
+- **Docs:** Workflow is in CLAUDE.md "Workflow (PRs & branches)" and in `.cursor/rules/pr-workflow.mdc`.
+
+# 3. Rules
+
+- **NEVER** suggest committing story/task implementation directly to `main`; always use a branch and PR.
+- **ALWAYS** ensure one issue is linked to the work (create one if the user has none).
+- **ALWAYS** remind at the end of the session to push, open PR with "Closes #issue-number", fill the PR template, run tests/lint, and merge.
+- Do not modify `CLAUDE.md` without explicit user approval.
+
+# 4. Context
+
+_(User may provide: story ref e.g. 1.6, issue number, or "starting story X". If none, ask what they're working on and whether they have an issue yet.)_
+
+# 5. Task
+
+**Immediate task:** Set up (or confirm) the PR workflow for the current story/task.
+
+1. **Identify scope** — What story/task is the user starting? (e.g. Story 1.6, issue #42, "add login page"). If unclear, ask.
+2. **Issue** — Is there a GitHub issue? If not, suggest creating one from `.github/ISSUE_TEMPLATE/` (story or task) and paste the link or number. If yes, note the issue number for branch name and "Closes #N".
+3. **Branch** — Check current branch. If on `main`, create and checkout a branch (e.g. `story-1-6-github-templates`, `fix/42-save-error`). Suggest the exact `git checkout -b <branch>` command; do not run destructive git commands without user approval.
+4. **Remind at end** — Before considering any follow-up work "done", remind: push branch, open PR with "Closes #issue-number", fill PR template, run `npm test` and `npm run lint`, then merge (self-review is fine).
+
+If the user is **only** asking to "start" and not yet to implement, output the checklist above and the exact git command. If they are starting and will implement in this session, do the checklist then proceed with implementation on the branch.
+
+# 6. Output Format
+
+- State the story/task and issue number (or "create issue first: …").
+- State current branch and, if needed, the branch to create and the exact `git checkout -b …` command.
+- If implementing in this session: after implementation, end with a short "Before you're done: push, open PR (Closes #N), fill template, test/lint, merge."
+
+# 7. Prefill (optional)
+
+Start by asking or confirming: "What story or task are you starting, and do you already have a GitHub issue?" Then run through issue → branch → work → PR reminder.

--- a/.cursor/rules/pr-workflow.mdc
+++ b/.cursor/rules/pr-workflow.mdc
@@ -1,0 +1,19 @@
+---
+description: PR and branch workflow for stories and tasks; use branch + issue + PR before merge
+alwaysApply: true
+---
+
+# PR & Branch Workflow
+
+When working on **story/task work** (epic implementation, BMAD stories, features, bugs):
+
+1. **Issue** — One GitHub issue per scope. Create or link before coding.
+2. **Branch** — Work on a branch from `main` (e.g. `story-1-6-github-templates`, `fix/42-save-error`). Do not commit story/task work directly to `main`.
+3. **Commits** — Reference the issue in commit messages (e.g. `feat: add PR template #17`).
+4. **PR before merge** — Push branch, open Pull Request with "Closes #issue-number", fill `.github/PULL_REQUEST_TEMPLATE.md` (summary, changes, testing, checklist). Run `npm test` and `npm run lint` before considering done. Merge after review (self-review is fine when solo).
+
+**When starting a story or task:** If the user has not already created a branch or linked an issue, remind them to use `/project-start-story` or to create/link an issue and create a branch before making changes.
+
+**Before marking work complete:** If changes were made on a branch, remind to push, open the PR (with "Closes #N"), fill the template, run tests/lint, and merge. Do not say the task is done until the PR is opened (or user confirms they will do it).
+
+**Exclusions:** Typo-only or trivial doc edits do not require a branch/PR. Use judgment for "real" implementation work vs. tiny fixes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ All Lambdas MUST import from `@ai-learning-hub/*`:
 
 ## Commands
 
+- `/project-start-story` - Start story/task work with branch + issue + PR workflow (enforces habit)
 - `/project-fix-github-issue N` - Fix issue #N
 - `/project-create-lambda name` - Create new Lambda
 - `/project-create-component Name` - Create React component
@@ -75,6 +76,17 @@ For detailed docs, read from `.claude/docs/`:
 - Read `docs/progress/epic-N.md` for current epic status
 - Read `docs/stories/N.M/progress.md` for story status
 - Update progress.md as you complete tasks
+
+## Workflow (PRs & branches)
+
+For **story/task work** (epic implementation, BMAD stories, features, bugs), use a branch and PR so work is traceable and the PR checklist runs before merge.
+
+1. **Issue** — Create or link a GitHub issue (story/task/feature/bug). One issue = one PR.
+2. **Branch** — Create a branch from `main` (e.g. `story-1-6-github-templates`, `fix/42-save-error`). Do not commit story/task work directly to `main`.
+3. **Work** — Implement, test, and reference the issue in commits (e.g. `feat: add PR template #17`).
+4. **PR** — Push the branch, open a Pull Request with "Closes #issue-number", fill the PR template (summary, changes, testing, checklist), run tests/lint/build. Merge after review (self-review is fine when solo).
+
+**Light habit:** When starting a BMAD story or a task, run `/project-start-story` (or ensure issue + branch yourself) so the session begins with the right workflow. Before considering the task done, remind to open the PR and merge.
 
 ## NEVER
 


### PR DESCRIPTION
Closes #69

## Summary
Add documentation and enforcement for branch + issue + PR + merge when doing story/task work.

## Changes
- **CLAUDE.md:** New "Workflow (PRs & branches)" section and `/project-start-story` in Commands.
- **Cursor rule:** `.cursor/rules/pr-workflow.mdc` (always-on) — reminds agent to use branch + issue + PR and to remind user to open PR before marking done.
- **Command:** `.claude/commands/project-start-story.md` — start story/task with issue + branch; remind at end to push, open PR (Closes #N), fill template, merge.
- **Docs:** `.claude/commands/README.md` — added `project-start-story` to command table.

## Testing
- [x] No code changes; docs and rule/command only.
- [x] PR template filled; checklist applies to future code PRs.