### PR TITLE
fix: resolve validation findings in bmad-bmm-auto-epic decomposition

### DIFF
--- a/.claude/agents/epic-reviewer.md
+++ b/.claude/agents/epic-reviewer.md
@@ -29,7 +29,7 @@ The orchestrator passes you:
    git diff origin/{base_branch}...{branch_name}
    ```
 
-2. **Review all changed files** thoroughly using the code review methodology from your preloaded skill
+2. **Review all changed files** thoroughly. Your preloaded `bmad-bmm-code-review` skill provides review categories and best practices as background knowledge. Use the structured findings format defined below (not the skill's own output format) since the orchestrator parses findings by the Critical/Important/Minor structure
 
 3. **Write findings** to the specified output path using this exact format:
 

--- a/.claude/skills/epic-orchestrator/review-loop.md
+++ b/.claude/skills/epic-orchestrator/review-loop.md
@@ -6,9 +6,11 @@ Supporting reference for the epic orchestrator. Read this file when entering Ste
 
 Execute up to 3 review-fix cycles to achieve code quality convergence. The orchestrator coordinates between a **reviewer subagent** (fresh context, read-only) and a **fixer subagent** (implementation context, full edit tools).
 
-**Max rounds:** 3
+**Max rounds:** 3 (review rounds, meaning up to 2 fix cycles + 1 final review)
 **Clean state:** 0 MUST-FIX findings (Critical + Important)
 **Exit conditions:** Clean state reached OR max rounds exceeded
+
+**Round progression:** Round 1 review → fix → Round 2 review → fix → Round 3 review → escalate if still unclean. This gives 2 fix attempts before escalation.
 
 ## Step A: Spawn Reviewer Subagent
 
@@ -153,6 +155,8 @@ Task tool invocation:
 3. Repeat until MUST-FIX count == 0 or round exceeds limit
 
 **Key:** Each reviewer round gets a FRESH context. The reviewer never sees previous review rounds or fixer actions. It only sees the current state of the code.
+
+**Branch locality:** The fixer commits locally but does NOT push during the review loop. The reviewer diffs against the local branch ref (`{branch_name}`), which includes fixer commits since it's in the same local repo. The triple-dot diff `origin/{base_branch}...{branch_name}` resolves `{branch_name}` as a local ref (not `origin/{branch_name}`), so fixer commits are visible to the reviewer. No push is needed until the review loop exits cleanly (push happens in Phase 2.3/2.6).
 
 ## Dry Run Behavior
 


### PR DESCRIPTION
## Summary

- Fix all Critical (6/6) and Major (8/8) issues from the adversarial validation audit of the decomposed auto-epic workflow
- Fix 7/9 Moderate issues where the fix was straightforward
- Fix 2/6 Minor issues that fell out naturally from other fixes

Closes #89

## Changes

### Critical fixes (6/6)
| Finding | Fix | Files |
|---------|-----|-------|
| C1: `paused` not in status enum | Added to enum, status table, resume matrix | state-file.md, story-runner.md, SKILL.md |
| C2: `skipped` not in status enum | Added to enum, status table, resume matrix + skip operation now sets status | state-file.md, story-runner.md, SKILL.md |
| C3: `getStoryStatus` undefined | Defined function in state-file.md reading from YAML frontmatter | state-file.md |
| C4: `coverage` never computed | Added coverage parsing from `npm test` output before `getOrCreatePR` | SKILL.md, story-runner.md |
| C5: Dry-run invokes dev-story | Added dry-run gate: skip implementation, log message, set coverage=null | SKILL.md |
| C6: Integration checkpoint wrong baseline | Added branch checkout guarantee, clarified runs before user prompt | SKILL.md |

### Major fixes (8/8)
| Finding | Fix | Files |
|---------|-----|-------|
| M1: Resume case 5 undefined checkpoints | Replaced with "reset to pending, restart from beginning" | state-file.md |
| M2: `getExportedTypes`/`getExpectedImports` undefined | Replaced with `git diff` based TypeScript export analysis | integration-checkpoint.md |
| M3: `runTests(testFiles)` undefined | Replaced with `npm test` (full suite) | integration-checkpoint.md |
| M4: Stale remote-tracking ref | Added `git fetch origin ${baseBranch}` before dependency checks | SKILL.md |
| M5: Story path "typically" | Made definitive path with glob fallback + error message | SKILL.md |
| M6: Fixer commits local-only ambiguity | Clarified reviewer uses local refs, no push needed during review loop | review-loop.md |
| M7: `createBranch` from HEAD | Changed to `git checkout -b ${branchName} origin/${baseBranch}` | story-runner.md |
| M8: No merge-sync error recovery | Added test failure recovery options after merge with main | SKILL.md |

### Moderate fixes (7/9)
- A1: Fixed by C2 (skip status tracking)
- A2: Specified `/bmad-bmm-dev-story` invocation via Skill tool
- A3: Defined `updateStatus` for GitHubCLIRunner (issue label sync)
- A4: Clarified review round progression (2 fix cycles + 1 final review)
- A6: Made atomic write protocol realistic for agent tooling (Write + mv)
- A7: Fixed by C6 (integration checkpoint ordering clarified)
- A8: Clarified reviewer uses inline findings format, not BMAD workflow output
- A9: Added blocked dependency handling with user options

### Minor fixes (2/6)
- N5: Defined `slugify` function
- N6: Aligned max-attempts to 2 consistently

### Skipped
- A5: Resume doesn't validate `--stories` subset (needs scope recording in state file — more complex)
- N1-N4: Minor improvements, not blocking

## Test plan

- [ ] Review each finding against the diff to verify resolution
- [ ] Run `/bmad-bmm-auto-epic Epic-1 --dry-run` to smoke-test the spec is parseable
- [ ] Verify status enum consistency across all files

🤖 Generated with [Claude Code](https://claude.com/claude-code)