### PR TITLE
Story 1.13: Subagent library + pipeline hook wiring

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -6,20 +6,22 @@ Deterministic enforcement layer for AI Learning Hub. Hooks run at PreToolUse, Po
 
 ## Scripts
 
-| Script                    | Phase                               | Purpose                                                                                                                                                                                                                                    |
-| ------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **bash-guard.js**         | PreToolUse (Bash)                   | Blocks catastrophic/high-risk commands (e.g. `rm -rf /`, force push, credential echo, exfiltration). Escalates `git push main`, `cdk deploy`, `rm -rf`. Tiered safety: `critical` / `high` (default) / `strict` via `CLAUDE_SAFETY_LEVEL`. |
-| **file-guard.js**         | PreToolUse (Read\|Edit\|Write)      | Blocks auto-modification of CLAUDE.md, .env, lock files, .git/, node_modules/, \_bmad-output/planning-artifacts/. Allows .env.example etc. Escalates infra/, .github/, .claude/hooks/.                                                     |
-| **architecture-guard.sh** | PreToolUse (Edit\|Write)            | Enforces ADR-007 (no Lambda-to-Lambda), ADR-006 (DynamoDB key patterns), ADR-014 (handlers use @ai-learning-hub/db).                                                                                                                       |
-| **import-guard.sh**       | PreToolUse (Edit\|Write)            | Denies Lambda/backend TS files using DynamoDB/Logger/Zod/middleware without @ai-learning-hub/\*. Skips shared/ and non-TS.                                                                                                                 |
-| **tdd-guard.js**          | PreToolUse (Write\|Edit\|MultiEdit) | Optional: blocks implementation file writes when no failing tests in .claude/tdd-guard/data/test.json; test file writes always allowed.                                                                                                    |
-| **auto-format.sh**        | PostToolUse (Edit\|Write)           | Runs Prettier and ESLint --fix for TS/JS/JSON/MD (and YAML).                                                                                                                                                                               |
-| **type-check.sh**         | PostToolUse (Edit\|Write)           | Runs `tsc --noEmit` for TS files; outputs hookSpecificOutput with errors (context only, does not block).                                                                                                                                   |
-| **Stop**                  | Stop                                | Agent prompt: verify npm test (and 80%+ coverage where enforced), npm run lint, npm run build; block stop if any fails.                                                                                                                    |
+| Script                        | Phase                               | Purpose                                                                                                                                                                                                                                                                                        |
+| ----------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **bash-guard.js**             | PreToolUse (Bash)                   | Blocks catastrophic/high-risk commands (e.g. `rm -rf /`, force push, credential echo, exfiltration). Escalates `git push main`, `cdk deploy`, `rm -rf`. Tiered safety: `critical` / `high` (default) / `strict` via `CLAUDE_SAFETY_LEVEL`.                                                     |
+| **file-guard.js**             | PreToolUse (Read\|Edit\|Write)      | Blocks auto-modification of CLAUDE.md, .env, lock files, .git/, node_modules/, \_bmad-output/planning-artifacts/. Allows .env.example etc. Escalates infra/, .github/, .claude/hooks/.                                                                                                         |
+| **architecture-guard.sh**     | PreToolUse (Edit\|Write)            | Enforces ADR-007 (no Lambda-to-Lambda), ADR-006 (DynamoDB key patterns), ADR-014 (handlers use @ai-learning-hub/db).                                                                                                                                                                           |
+| **import-guard.sh**           | PreToolUse (Edit\|Write)            | Denies Lambda/backend TS files using DynamoDB/Logger/Zod/middleware without @ai-learning-hub/\*. Skips shared/ and non-TS.                                                                                                                                                                     |
+| **pipeline-guard.cjs**        | PreToolUse (Edit\|Write)            | Protects writing pipeline integrity: (1) denies writes to guides/, agents/, templates/ (always); (2) denies overwrites of previous artifacts; (3) warns on non-standard filenames; (4) denies artifact writes if required guides were not Read. Reads `state.yaml` for current step and agent. |
+| **pipeline-read-tracker.cjs** | PostToolUse (Read)                  | Records breadcrumbs when pipeline guide files are Read. Used by pipeline-guard.cjs to verify guides were actually loaded (not just claimed). Breadcrumbs expire after 2 hours. Stored in `.claude/.pipeline-reads.json`.                                                                       |
+| **tdd-guard.js**              | PreToolUse (Write\|Edit\|MultiEdit) | Optional: blocks implementation file writes when no failing tests in .claude/tdd-guard/data/test.json; test file writes always allowed.                                                                                                                                                        |
+| **auto-format.sh**            | PostToolUse (Edit\|Write)           | Runs Prettier and ESLint --fix for TS/JS/JSON/MD (and YAML).                                                                                                                                                                                                                                   |
+| **type-check.sh**             | PostToolUse (Edit\|Write)           | Runs `tsc --noEmit` for TS files; outputs hookSpecificOutput with errors (context only, does not block).                                                                                                                                                                                       |
+| **Stop**                      | Stop                                | Agent prompt: verify npm test (and 80%+ coverage where enforced), npm run lint, npm run build; block stop if any fails.                                                                                                                                                                        |
 
 ## Requirements
 
-- **Node.js** — for `bash-guard.js`, `file-guard.js`, `tdd-guard.js`
+- **Node.js** — for `bash-guard.js`, `file-guard.js`, `pipeline-guard.cjs`, `pipeline-read-tracker.cjs`, `tdd-guard.js`
 - **jq** — for shell hooks (`architecture-guard.sh`, `import-guard.sh`, `auto-format.sh`, `type-check.sh`). Install: `brew install jq` (macOS), or your system package manager
 
 ## How to test hooks
@@ -66,6 +68,28 @@ echo '{"tool_input":{"file_path":"x.ts","content":"lambda.invoke()"}}' | .claude
 ```bash
 echo '{"tool_input":{"file_path":"backend/functions/foo/handler.ts","content":"new DynamoDBClient()"}}' | .claude/hooks/import-guard.sh
 # Expected: exit 0, JSON with permissionDecision: "deny"
+```
+
+**pipeline-guard (deny infrastructure write):**
+
+```bash
+echo '{"tool_input":{"file_path":"docs/writing-pipeline/guides/style-guide.md"},"tool_name":"Write"}' | node .claude/hooks/pipeline-guard.cjs
+# Expected: exit 0, JSON with permissionDecision: "deny"
+```
+
+**pipeline-guard (deny previous artifact overwrite):**
+
+```bash
+# Requires an active project with state.yaml showing current_step: 6
+echo '{"tool_input":{"file_path":"docs/writing-pipeline/projects/my-guide/04-draft-v1.md"},"tool_name":"Edit"}' | node .claude/hooks/pipeline-guard.cjs
+# Expected: exit 0, JSON with permissionDecision: "deny" (artifact 04 is before step 6's output 08)
+```
+
+**pipeline-guard (allow current artifact):**
+
+```bash
+echo '{"tool_input":{"file_path":"docs/writing-pipeline/projects/my-guide/08-draft-v2.md"},"tool_name":"Write"}' | node .claude/hooks/pipeline-guard.cjs
+# Expected: exit 0, no deny (08 matches step 6's expected output)
 ```
 
 **tdd-guard (allow when tests failing):** Ensure `.claude/tdd-guard/data/test.json` has `"failed": 1` (or more), then write an impl file; should allow. With `"failed": 0`, impl writes can be blocked (test writes always allowed).

--- a/.claude/hooks/pipeline-guard.cjs
+++ b/.claude/hooks/pipeline-guard.cjs
@@ -1,0 +1,341 @@
+#!/usr/bin/env node
+/**
+ * pipeline-guard.cjs - Protect writing pipeline integrity
+ *
+ * Enforces four invariants during pipeline runs:
+ *   1. Pipeline infrastructure (guides, agents, templates) is read-only
+ *   2. Previous pipeline artifacts cannot be overwritten
+ *   3. Artifact filenames must match expected numbering
+ *   4. Required guides must be actually Read before artifacts are written
+ *      (works with pipeline-read-tracker.cjs which records breadcrumbs)
+ *
+ * Activation: Rules 1 always active. Rules 2-4 only during active runs
+ *   (state.yaml with status: in-progress).
+ *
+ * Part of AI Learning Hub's deterministic enforcement layer
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const PIPELINE_ROOT = "docs/writing-pipeline";
+
+// Infrastructure files — never modified by subagents during a run
+const PROTECTED_INFRASTRUCTURE = [
+  `${PIPELINE_ROOT}/guides/`,
+  `${PIPELINE_ROOT}/agents/`,
+  `${PIPELINE_ROOT}/templates/`,
+  `${PIPELINE_ROOT}/config.yaml`,
+  `${PIPELINE_ROOT}/README.md`,
+];
+
+// Valid artifact filename patterns (prefix number → filename)
+const ARTIFACT_PATTERNS = [
+  /^00-request\.md$/,
+  /^01-research\.md$/,
+  /^02-outline\.md$/,
+  /^03-outline-review\.md$/,
+  /^04-draft-v1\.md$/,
+  /^05-editorial-review-v1\.md$/,
+  /^06-draft-v1r1\.md$/,
+  /^07-sme-review-v1\.md$/,
+  /^08-draft-v2\.md$/,
+  /^09-editorial-review-v2\.md$/,
+  /^10-diagrams-v1\.md$/,
+  /^11-sme-review-v2\.md$/,
+  /^12-draft-v3\.md$/,
+  /^13-editorial-review-v3\.md$/,
+  /^14-diagrams-v2\.md$/,
+  /^15-qa-read-v1\.md$/,
+  /^16-draft-v3r1\.md$/,
+  /^17-qa-read-v2\.md$/,
+  /^18-draft-v3r2\.md$/,
+  /^19-final-review\.md$/,
+  /^20-final\.md$/,
+  /^21-final-with-diagrams\.md$/,
+  /^state\.yaml$/,
+];
+
+// Which guides each agent must have Read before writing artifacts
+// Keyed by agent name as it appears in state.yaml
+const REQUIRED_GUIDES = {
+  "tech-writer": ["style-guide.md", "review-taxonomy.md"],
+  editor: ["style-guide.md", "review-taxonomy.md"],
+  sme: ["review-taxonomy.md"],
+  designer: ["diagram-guide.md"],
+  "qa-reader": [], // Intentionally blank — cold reader, no guides
+};
+
+// Breadcrumb staleness threshold (2 hours in ms)
+const BREADCRUMB_MAX_AGE_MS = 2 * 60 * 60 * 1000;
+
+// Map step numbers to their expected output artifact prefix
+const STEP_TO_ARTIFACT_PREFIX = {
+  1: 2, // Step 1 → 02-outline.md (also 01-research.md)
+  2: 3, // Step 2 → 03-outline-review.md
+  3: 4, // Step 3 → 04-draft-v1.md
+  4: 5, // Step 4 → 05-editorial-review-v1.md
+  "4b": 6, // Step 4b → 06-draft-v1r1.md
+  5: 7, // Step 5 → 07-sme-review-v1.md
+  6: 8, // Step 6 → 08-draft-v2.md
+  "7a": 9, // Step 7a → 09-editorial-review-v2.md
+  "7b": 10, // Step 7b → 10-diagrams-v1.md
+  8: 11, // Step 8 → 11-sme-review-v2.md
+  9: 12, // Step 9 → 12-draft-v3.md
+  10: 13, // Step 10 → 13-editorial-review-v3.md (also 14-diagrams-v2.md)
+  11: 15, // Step 11 → 15-qa-read-v1.md
+  "11b": 16, // Step 11b → 16-draft-v3r1.md
+  "11c": 17, // Step 11c → 17-qa-read-v2.md
+  "11d": 18, // Step 11d → 18-draft-v3r2.md
+  12: 19, // Step 12 → 19-final-review.md (also 20-final.md)
+  13: 21, // Step 13 → 21-final-with-diagrams.md
+};
+
+// Read input from stdin
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => (input += chunk));
+process.stdin.on("end", () => {
+  try {
+    const data = JSON.parse(input);
+    const toolName = data.tool_name || "";
+
+    // Only guard write operations
+    const writeTools = ["Write", "Edit", "NotebookEdit"];
+    if (!writeTools.includes(toolName)) {
+      process.exit(0);
+    }
+
+    const filePath = data.tool_input?.file_path || data.tool_input?.path || "";
+    const result = checkPipelineWrite(filePath);
+
+    if (result.decision) {
+      console.log(
+        JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: result.decision,
+            permissionDecisionReason: result.reason,
+          },
+        })
+      );
+    }
+
+    if (result.context) {
+      console.log(
+        JSON.stringify({
+          hookSpecificOutput: {
+            additionalContext: result.context,
+          },
+        })
+      );
+    }
+
+    process.exit(0);
+  } catch (err) {
+    // Fail CLOSED on parse error
+    console.error(
+      `📝 pipeline-guard: Failed to parse input (${err.message}). Blocking write for safety.`
+    );
+    process.exit(2);
+  }
+});
+
+function checkPipelineWrite(filePath) {
+  if (!filePath) return {};
+
+  const normalizedPath = filePath.replace(/\\/g, "/");
+
+  // Only care about writes inside the pipeline directory
+  if (!normalizedPath.includes(PIPELINE_ROOT)) {
+    return {};
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Rule 1: Protect pipeline infrastructure (ALWAYS, not just during runs)
+  // ═══════════════════════════════════════════════════════════════════
+
+  for (const protected_ of PROTECTED_INFRASTRUCTURE) {
+    if (normalizedPath.includes(protected_)) {
+      return {
+        decision: "deny",
+        reason: `📝 Pipeline Guard: ${getInfraType(protected_)} are protected and cannot be modified by pipeline agents. These files are human-owned infrastructure.`,
+      };
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Rule 2 & 3: Artifact protection (only during active pipeline runs)
+  // ═══════════════════════════════════════════════════════════════════
+
+  // Check if this is a write to a project directory
+  const projectMatch = normalizedPath.match(
+    new RegExp(`${PIPELINE_ROOT}/projects/([^/]+)/(.+)$`)
+  );
+  if (!projectMatch) {
+    return {}; // Not a project artifact write
+  }
+
+  const projectSlug = projectMatch[1];
+  const artifactName = projectMatch[2];
+
+  // Try to read state.yaml for this project
+  const state = readProjectState(projectSlug);
+  if (!state) {
+    return {}; // No active pipeline, allow (initial setup)
+  }
+
+  // Allow state.yaml writes (the Manager updates this)
+  if (artifactName === "state.yaml") {
+    return {};
+  }
+
+  // Allow 00-request.md writes (initial project setup)
+  if (artifactName === "00-request.md") {
+    return {};
+  }
+
+  // Rule 2: Check if writing to a previous artifact
+  const artifactNumber = getArtifactNumber(artifactName);
+  const currentStepMaxArtifact = getCurrentStepMaxArtifact(state);
+
+  if (
+    artifactNumber !== null &&
+    currentStepMaxArtifact !== null &&
+    artifactNumber < currentStepMaxArtifact
+  ) {
+    return {
+      decision: "deny",
+      reason: `📝 Pipeline Guard: Cannot overwrite previous artifact "${artifactName}". The pipeline is at step ${state.current_step}, which produces artifact ${String(currentStepMaxArtifact).padStart(2, "0")}-*. Previous artifacts are immutable.`,
+    };
+  }
+
+  // Rule 3: Validate artifact naming
+  const isValidName = ARTIFACT_PATTERNS.some((pattern) =>
+    pattern.test(artifactName)
+  );
+  if (!isValidName) {
+    return {
+      context: `⚠️ Pipeline Guard: "${artifactName}" does not match expected pipeline artifact naming. Expected patterns: 00-request.md through 21-final-with-diagrams.md. Verify this is the correct output file.`,
+    };
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Rule 4: Verify required guides were actually Read (not just claimed)
+  // Uses breadcrumbs from pipeline-read-tracker.cjs
+  // ═══════════════════════════════════════════════════════════════════
+
+  const agentName = state.current_agent;
+  if (agentName) {
+    const missingGuides = checkRequiredGuides(agentName);
+    if (missingGuides.length > 0) {
+      return {
+        decision: "deny",
+        reason: `📝 Pipeline Guard: Cannot write artifact before loading required guides. Read these files first:\n${missingGuides.map((g) => `  - docs/writing-pipeline/guides/${g}`).join("\n")}\nUse the Read tool to load each guide, then retry writing "${artifactName}".`,
+      };
+    }
+  }
+
+  return {};
+}
+
+function getInfraType(protectedPath) {
+  if (protectedPath.includes("/guides/")) return "Style guides and references";
+  if (protectedPath.includes("/agents/")) return "Agent definitions";
+  if (protectedPath.includes("/templates/")) return "Pipeline templates";
+  if (protectedPath.includes("config.yaml")) return "Pipeline configuration";
+  if (protectedPath.includes("README.md")) return "Pipeline README";
+  return "Pipeline infrastructure files";
+}
+
+function checkRequiredGuides(agentName) {
+  const required = REQUIRED_GUIDES[agentName];
+  if (!required || required.length === 0) {
+    return []; // No guides required for this agent
+  }
+
+  const projectRoot = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  const breadcrumbFile = path.join(projectRoot, ".claude", ".pipeline-reads.json");
+
+  let reads = {};
+  try {
+    if (!fs.existsSync(breadcrumbFile)) {
+      return required; // No breadcrumbs at all — all guides are missing
+    }
+    reads = JSON.parse(fs.readFileSync(breadcrumbFile, "utf8"));
+  } catch {
+    return required; // Can't read breadcrumbs — assume nothing was loaded
+  }
+
+  const now = Date.now();
+  const missing = [];
+
+  for (const guide of required) {
+    const entry = reads[guide];
+    if (!entry || !entry.timestamp) {
+      missing.push(guide);
+      continue;
+    }
+
+    // Check staleness — breadcrumb older than threshold means it's from a previous session
+    if (now - entry.timestamp > BREADCRUMB_MAX_AGE_MS) {
+      missing.push(guide);
+    }
+  }
+
+  return missing;
+}
+
+function readProjectState(projectSlug) {
+  const projectRoot = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  const statePath = path.join(
+    projectRoot,
+    PIPELINE_ROOT,
+    "projects",
+    projectSlug,
+    "state.yaml"
+  );
+
+  try {
+    if (!fs.existsSync(statePath)) {
+      return null;
+    }
+
+    const content = fs.readFileSync(statePath, "utf8");
+
+    // Simple YAML parsing for the fields we need
+    const statusMatch = content.match(/^status:\s*(.+)$/m);
+    const stepMatch = content.match(/^current_step:\s*(.+)$/m);
+    const agentMatch = content.match(/^current_agent:\s*(.+)$/m);
+
+    if (!statusMatch || statusMatch[1].trim() !== "in-progress") {
+      return null; // Pipeline not active
+    }
+
+    return {
+      status: statusMatch[1].trim(),
+      current_step: stepMatch ? stepMatch[1].trim() : null,
+      current_agent: agentMatch ? agentMatch[1].trim() : null,
+    };
+  } catch {
+    return null; // Can't read state, don't enforce artifact rules
+  }
+}
+
+function getArtifactNumber(artifactName) {
+  const match = artifactName.match(/^(\d{2})-/);
+  if (!match) return null;
+  return parseInt(match[1], 10);
+}
+
+function getCurrentStepMaxArtifact(state) {
+  if (!state.current_step) return null;
+
+  const step = state.current_step;
+  const artifactPrefix = STEP_TO_ARTIFACT_PREFIX[step];
+  if (artifactPrefix === undefined) return null;
+
+  // The current step can write its own artifact and anything at that number.
+  // Everything below that number is a previous artifact.
+  return artifactPrefix;
+}

--- a/.claude/hooks/pipeline-read-tracker.cjs
+++ b/.claude/hooks/pipeline-read-tracker.cjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * pipeline-read-tracker.cjs - Track guide file reads for pipeline enforcement
+ *
+ * PostToolUse hook on Read. When a pipeline guide or agent definition is read,
+ * records a breadcrumb so pipeline-guard.cjs can verify guides were actually
+ * loaded before artifacts are written.
+ *
+ * Breadcrumbs are stored in .claude/.pipeline-reads.json with timestamps.
+ * Stale breadcrumbs (>2 hours) are ignored by the guard.
+ *
+ * Part of AI Learning Hub's deterministic enforcement layer
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const PIPELINE_ROOT = "docs/writing-pipeline";
+
+// Files we track reads for
+const TRACKED_GUIDES = [
+  `${PIPELINE_ROOT}/guides/style-guide.md`,
+  `${PIPELINE_ROOT}/guides/review-taxonomy.md`,
+  `${PIPELINE_ROOT}/guides/diagram-guide.md`,
+];
+
+const BREADCRUMB_DIR = path.join(
+  process.env.CLAUDE_PROJECT_DIR || process.cwd(),
+  ".claude"
+);
+const BREADCRUMB_FILE = path.join(BREADCRUMB_DIR, ".pipeline-reads.json");
+
+// Read input from stdin
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => (input += chunk));
+process.stdin.on("end", () => {
+  try {
+    const data = JSON.parse(input);
+    const toolName = data.tool_name || "";
+
+    // Only track Read operations
+    if (toolName !== "Read") {
+      process.exit(0);
+    }
+
+    const filePath =
+      data.tool_input?.file_path || data.tool_input?.path || "";
+    if (!filePath) {
+      process.exit(0);
+    }
+
+    const normalizedPath = filePath.replace(/\\/g, "/");
+
+    // Check if this read is for a tracked guide
+    const isTrackedGuide = TRACKED_GUIDES.some((guide) =>
+      normalizedPath.includes(guide)
+    );
+
+    if (!isTrackedGuide) {
+      process.exit(0);
+    }
+
+    // Record the breadcrumb
+    let reads = {};
+    try {
+      if (fs.existsSync(BREADCRUMB_FILE)) {
+        reads = JSON.parse(fs.readFileSync(BREADCRUMB_FILE, "utf8"));
+      }
+    } catch {
+      reads = {}; // Corrupt file, start fresh
+    }
+
+    // Find which guide was read and record it by its short name
+    for (const guide of TRACKED_GUIDES) {
+      if (normalizedPath.includes(guide)) {
+        const shortName = path.basename(guide);
+        reads[shortName] = {
+          path: normalizedPath,
+          timestamp: Date.now(),
+        };
+        break;
+      }
+    }
+
+    // Write breadcrumbs
+    fs.mkdirSync(BREADCRUMB_DIR, { recursive: true });
+    fs.writeFileSync(BREADCRUMB_FILE, JSON.stringify(reads, null, 2));
+
+    process.exit(0);
+  } catch (err) {
+    // Read tracker should never block — fail open
+    process.exit(0);
+  }
+});

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,6 +33,11 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/import-guard.sh\"",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/pipeline-guard.cjs\"",
+            "timeout": 5000
           }
         ]
       },
@@ -60,6 +65,16 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/type-check.sh\"",
             "timeout": 60000
+          }
+        ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/pipeline-read-tracker.cjs\"",
+            "timeout": 3000
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ cdk.context.json
 # Misc
 .cache/
 *.tgz
+.pipeline-reads.json
 
 # Large research PDFs (keep text extracts only)
 _bmad-output/planning-artifacts/research/*.pdf

--- a/_bmad-output/implementation-artifacts/1-13-subagent-library.md
+++ b/_bmad-output/implementation-artifacts/1-13-subagent-library.md
@@ -1,0 +1,133 @@
+---
+id: "1.13"
+title: "Specialist Subagent Library (Agent System Documentation)"
+depends_on: ["1.4", "1.5", "1.7"]
+touches: [".claude/agents", ".claude/docs", ".claude/commands"]
+risk: low
+---
+
+# Story 1.13: Specialist Subagent Library (Agent System Documentation)
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a **developer (human or AI agent)**,  
+I want **a clear, discoverable “agent system” with documented subagents and usage patterns**,  
+so that **we consistently use the right specialist at the right time (review, fix, testing, architecture) without reinventing prompts or misusing tools (FR90)**.
+
+## Acceptance Criteria
+
+1. **AC1: `.claude/agents/README.md` exists and is the primary entrypoint**
+   - GIVEN the repo has multiple “agent-like” entrypoints (BMAD agents in `.claude/commands/`, orchestrator subagents in `.claude/agents/`)
+     WHEN a developer wants to “use a specialist”
+     THEN `.claude/agents/README.md` clearly explains:
+     - What a **subagent** is (fresh conversational context; shared repo state)
+     - The difference between **subagents** vs **commands/workflows** (e.g., `.claude/commands/*`)
+     - How to **choose**: spawn a subagent vs run a workflow/command vs work inline
+     - How to **add** a new subagent (naming, frontmatter fields, tool restrictions, output format)
+     - Where enforcement lives (hooks/rules) that subagents must respect
+
+2. **AC2: Inventory of the current system is explicit (no guessing)**
+   - GIVEN the repository already includes orchestrator subagents
+     WHEN a reader opens `.claude/agents/README.md`
+     THEN it lists, at minimum:
+     - `epic-reviewer` — fresh-context adversarial code review (read-only + findings output)
+     - `epic-fixer` — guided fixes based on findings (full edit tools)
+     AND it links to relevant orchestration docs explaining how/when these are spawned.
+
+3. **AC3: Clear mapping from “roles” to existing assets**
+   - GIVEN the PRD and epics mention roles like “code-reviewer”, “test-expert”, “debugger”, “architect”, “production-validator”
+     WHEN a developer searches for those roles
+     THEN the docs provide an explicit mapping table:
+     - what we already have (subagent, BMAD agent command, workflow)
+     - what to use instead of creating duplicates
+     - when to create a *new* subagent prompt (and when not to)
+
+4. **AC4: Subagent configuration conventions are documented and consistent**
+   - GIVEN `.claude/agents/*.md` use YAML frontmatter to configure behavior
+     WHEN a new subagent is added
+     THEN the README documents the required frontmatter fields and conventions:
+     - `name`, `description`
+     - `tools` + `disallowedTools` (and which roles should be read-only vs full-edit)
+     - `model` selection guidance (if/when specified)
+     - required output structure (so orchestrators can parse it)
+     AND existing subagents remain consistent with the documented conventions.
+
+5. **AC5: Practical examples are included**
+   - GIVEN people learn by copying patterns
+     WHEN reading `.claude/agents/README.md`
+     THEN it includes copy/paste examples for:
+     - Spawning a **fresh-context reviewer** to review a branch and write a findings doc
+     - Spawning a **fixer** to address a findings doc
+     - Using BMAD agent commands as “specialists” (without needing new subagent prompts)
+     - (If applicable) Using Claude Code’s `/agents` command for creating/using custom agents
+
+## Tasks / Subtasks
+
+- [ ] **Task 1: Write `.claude/agents/README.md` (the entrypoint)** (AC: 1–5)
+  - Include: definitions, decision tree (“spawn subagent vs run workflow”), inventory, role-to-asset mapping table, examples, and contribution guidelines.
+
+- [ ] **Task 2: Add an “agent system overview” doc under `.claude/docs/`** (AC: 2–4)
+  - Create `.claude/docs/agent-system.md` that:
+    - Explains how the epic orchestrator uses subagents (review loop, fresh context)
+    - Links out to `orchestrator-safety.md`, `safety-architecture.md`, and the relevant skill docs
+    - Documents the invariants that matter for subagents (never bypass hooks, never force push, etc.)
+  - Keep it scannable and aligned with the progressive disclosure strategy (no mega-doc).
+
+- [ ] **Task 3: Ensure discoverability (optional but recommended)** (AC: 1–3)
+  - Add a small section to `.claude/docs/README.md` pointing to:
+    - `.claude/agents/README.md`
+    - `.claude/docs/agent-system.md`
+  - Do not duplicate content; only add the pointer.
+
+## Dev Notes
+
+- **Evolving scope is intentional**: Story 1.13 is tracked as “subagent library” but the repo already has a sophisticated agent ecosystem (BMAD commands + epic orchestrator + existing subagents). The highest value is **documenting what exists** and how to extend it safely, not creating redundant new prompts.
+- **Avoid duplication**: Prefer referencing existing BMAD agent entrypoints in `.claude/commands/` rather than creating new `.claude/agents/*` prompts that do the same job.
+- **Fresh-context semantics**: “Fresh context” means fresh conversational history, not a separate checkout/runtime. Subagents should assume they share repo state and git history but not prior chat.
+
+### Project Structure Notes
+
+- `.claude/agents/` is for **subagent prompts** used by the orchestrator or manual spawning for isolated review/fix tasks.
+- `.claude/commands/` is for **workflow entrypoints** and BMAD “agent” commands (loaded via command docs).
+- `.claude/docs/` is for **progressive disclosure** reference docs. Prefer linking over copying.
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics.md] Epic 1 Story 1.13 description
+- [Source: _bmad-output/implementation-artifacts/sprint-status.yaml] Story key `1-13-subagent-library`
+- [Source: _bmad-output/planning-artifacts/prd.md] FR90 (specialist subagent prompt library requirement)
+- [Source: docs/research/epic-1-remaining-stories-analysis.md] Recommended evolution of Story 1.13 into agent-system documentation
+- [Source: .claude/docs/orchestrator-safety.md] Orchestrator invariants + subagent usage
+- [Source: .claude/docs/safety-architecture.md] Three-layer defense model referencing subagents
+- [Source: .claude/agents/epic-reviewer.md] Existing reviewer prompt conventions
+- [Source: .claude/agents/epic-fixer.md] Existing fixer prompt conventions
+
+## Developer Context (Dev Agent Guardrails)
+
+### Technical Requirements
+
+- Keep docs **short, scannable, and actionable** (progressive disclosure).
+- All examples must align with current enforcement posture (hooks + Cursor rules):
+  - no force push, no bypassing hooks, no committing secrets, protected paths require approval.
+- Do not introduce symlinks for “agent aliases” unless you’ve validated they behave well across environments and tooling.
+
+### Testing Requirements
+
+- Documentation-only story: **no tests required**.
+
+---
+
+## Dev Agent Record
+
+### Agent Model Used
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List
+

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -54,7 +54,7 @@ development_status:
   1-10-tool-risk-classification: done  # Refactored to comprehensive safety architecture docs (4 files)
   1-11-prompt-evaluation-tests: dropped  # Premature optimization, defer to Epic 12 (agentic workflow maturity)
   1-12-model-selection-guide: dropped  # Defaults work fine, added note to CLAUDE.md
-  1-13-subagent-library: backlog  # Will evolve to agent system documentation
+  1-13-subagent-library: ready-for-dev  # Will evolve to agent system documentation
   1-14-context-management-guide: dropped  # Orchestrator handles it, added note to README
   epic-1-retrospective: optional
 


### PR DESCRIPTION
## Summary
- Adds writing-pipeline guard hooks (write guard + read tracker) and their hook scripts/docs.
- Marks Story 1-13 as ready-for-dev and adds the Story 1.13 spec artifact.
- Ignores  (local breadcrumb file).

## Testing
- [x] 
> format
> prettier --write "**/*.{ts,tsx,json,md}"

.claude/agents/epic-fixer.md 24ms (unchanged)
.claude/agents/epic-reviewer.md 8ms (unchanged)
.claude/commands/bmad-agent-bmad-master.md 2ms (unchanged)
.claude/commands/bmad-agent-bmb-agent-builder.md 1ms (unchanged)
.claude/commands/bmad-agent-bmb-module-builder.md 1ms (unchanged)
.claude/commands/bmad-agent-bmb-workflow-builder.md 1ms (unchanged)
.claude/commands/bmad-agent-bmm-analyst.md 1ms (unchanged)
.claude/commands/bmad-agent-bmm-architect.md 1ms (unchanged)
.claude/commands/bmad-agent-bmm-dev.md 1ms (unchanged)
.claude/commands/bmad-agent-bmm-pm.md 1ms (unchanged)
.claude/commands/bmad-agent-bmm-quick-flow-solo-dev.md 1ms (unchanged)
.claude/commands/bmad-agent-bmm-quinn.md 1ms (unchanged)
.claude/commands/bmad-agent-bmm-sm.md 1ms (unchanged)
.claude/commands/bmad-agent-bmm-tech-writer.md 1ms (unchanged)
.claude/commands/bmad-agent-bmm-ux-designer.md 1ms (unchanged)
.claude/commands/bmad-agent-cis-brainstorming-coach.md 1ms (unchanged)
.claude/commands/bmad-agent-cis-creative-problem-solver.md 1ms (unchanged)
.claude/commands/bmad-agent-cis-design-thinking-coach.md 1ms (unchanged)
.claude/commands/bmad-agent-cis-innovation-strategist.md 1ms (unchanged)
.claude/commands/bmad-agent-cis-presentation-master.md 1ms (unchanged)
.claude/commands/bmad-agent-cis-storyteller.md 1ms (unchanged)
.claude/commands/bmad-agent-tea-tea.md 1ms (unchanged)
.claude/commands/bmad-bmb-agent.md 1ms (unchanged)
.claude/commands/bmad-bmb-module.md 1ms (unchanged)
.claude/commands/bmad-bmb-workflow.md 1ms (unchanged)
.claude/commands/bmad-bmm-auto-epic.md 4ms (unchanged)
.claude/commands/bmad-bmm-check-implementation-readiness.md 1ms (unchanged)
.claude/commands/bmad-bmm-code-review.md 1ms (unchanged)
.claude/commands/bmad-bmm-correct-course.md 1ms (unchanged)
.claude/commands/bmad-bmm-create-architecture.md 1ms (unchanged)
.claude/commands/bmad-bmm-create-epics-and-stories.md 1ms (unchanged)
.claude/commands/bmad-bmm-create-excalidraw-dataflow.md 1ms (unchanged)
.claude/commands/bmad-bmm-create-excalidraw-diagram.md 1ms (unchanged)
.claude/commands/bmad-bmm-create-excalidraw-flowchart.md 1ms (unchanged)
.claude/commands/bmad-bmm-create-excalidraw-wireframe.md 1ms (unchanged)
.claude/commands/bmad-bmm-create-prd.md 1ms (unchanged)
.claude/commands/bmad-bmm-create-product-brief.md 1ms (unchanged)
.claude/commands/bmad-bmm-create-story.md 1ms (unchanged)
.claude/commands/bmad-bmm-create-ux-design.md 1ms (unchanged)
.claude/commands/bmad-bmm-dev-story.md 1ms (unchanged)
.claude/commands/bmad-bmm-document-project.md 1ms (unchanged)
.claude/commands/bmad-bmm-qa-automate.md 1ms (unchanged)
.claude/commands/bmad-bmm-quick-dev.md 1ms (unchanged)
.claude/commands/bmad-bmm-quick-spec.md 1ms (unchanged)
.claude/commands/bmad-bmm-research.md 1ms (unchanged)
.claude/commands/bmad-bmm-retrospective.md 1ms (unchanged)
.claude/commands/bmad-bmm-sprint-planning.md 0ms (unchanged)
.claude/commands/bmad-bmm-sprint-status.md 1ms (unchanged)
.claude/commands/bmad-brainstorming.md 1ms (unchanged)
.claude/commands/bmad-cis-design-thinking.md 1ms (unchanged)
.claude/commands/bmad-cis-innovation-strategy.md 1ms (unchanged)
.claude/commands/bmad-cis-problem-solving.md 1ms (unchanged)
.claude/commands/bmad-cis-storytelling.md 1ms (unchanged)
.claude/commands/bmad-editorial-review-prose.md 1ms (unchanged)
.claude/commands/bmad-editorial-review-structure.md 1ms (unchanged)
.claude/commands/bmad-help.md 1ms (unchanged)
.claude/commands/bmad-index-docs.md 1ms (unchanged)
.claude/commands/bmad-party-mode.md 1ms (unchanged)
.claude/commands/bmad-review-adversarial-general.md 1ms (unchanged)
.claude/commands/bmad-shard-doc.md 1ms (unchanged)
.claude/commands/bmad-tea-teach-me-testing.md 1ms (unchanged)
.claude/commands/bmad-tea-testarch-atdd.md 1ms (unchanged)
.claude/commands/bmad-tea-testarch-automate.md 1ms (unchanged)
.claude/commands/bmad-tea-testarch-ci.md 1ms (unchanged)
.claude/commands/bmad-tea-testarch-framework.md 1ms (unchanged)
.claude/commands/bmad-tea-testarch-nfr.md 1ms (unchanged)
.claude/commands/bmad-tea-testarch-test-design.md 1ms (unchanged)
.claude/commands/bmad-tea-testarch-test-review.md 1ms (unchanged)
.claude/commands/bmad-tea-testarch-trace.md 1ms (unchanged)
.claude/commands/project-check-secrets-config.md 4ms (unchanged)
.claude/commands/project-create-component.md 5ms (unchanged)
.claude/commands/project-create-lambda.md 5ms (unchanged)
.claude/commands/project-deploy.md 4ms (unchanged)
.claude/commands/project-fix-github-issue.md 4ms (unchanged)
.claude/commands/project-run-tests.md 4ms (unchanged)
.claude/commands/project-start-story.md 4ms (unchanged)
.claude/commands/README.md 3ms (unchanged)
.claude/docs/api-patterns.md 8ms (unchanged)
.claude/docs/architecture.md 3ms (unchanged)
.claude/docs/branch-commit-conventions.md 2ms (unchanged)
.claude/docs/database-schema.md 3ms (unchanged)
.claude/docs/hook-system.md 20ms (unchanged)
.claude/docs/observability.md 34ms (unchanged)
.claude/docs/orchestrator-safety.md 21ms (unchanged)
.claude/docs/README.md 2ms (unchanged)
.claude/docs/safety-architecture.md 17ms (unchanged)
.claude/docs/secrets-and-config.md 3ms (unchanged)
.claude/docs/testing-guide.md 2ms (unchanged)
.claude/docs/tool-risk.md 16ms (unchanged)
.claude/hooks/README.md 3ms (unchanged)
.claude/settings.json 1ms (unchanged)
.claude/settings.local.json 1ms (unchanged)
.claude/skills/epic-orchestrator/dependency-analysis.md 12ms (unchanged)
.claude/skills/epic-orchestrator/integration-checkpoint.md 8ms (unchanged)
.claude/skills/epic-orchestrator/review-loop.md 6ms (unchanged)
.claude/skills/epic-orchestrator/SKILL.md 19ms (unchanged)
.claude/skills/epic-orchestrator/state-file.md 13ms (unchanged)
.claude/skills/epic-orchestrator/story-runner.md 15ms (unchanged)
.claude/tdd-guard/data/test.json 0ms (unchanged)
.cursor/commands/bmad-agent-bmad-master.md 1ms (unchanged)
.cursor/commands/bmad-agent-bmb-agent-builder.md 1ms (unchanged)
.cursor/commands/bmad-agent-bmb-module-builder.md 1ms (unchanged)
.cursor/commands/bmad-agent-bmb-workflow-builder.md 1ms (unchanged)
.cursor/commands/bmad-agent-bmm-analyst.md 1ms (unchanged)
.cursor/commands/bmad-agent-bmm-architect.md 1ms (unchanged)
.cursor/commands/bmad-agent-bmm-dev.md 1ms (unchanged)
.cursor/commands/bmad-agent-bmm-pm.md 1ms (unchanged)
.cursor/commands/bmad-agent-bmm-quick-flow-solo-dev.md 1ms (unchanged)
.cursor/commands/bmad-agent-bmm-quinn.md 1ms (unchanged)
.cursor/commands/bmad-agent-bmm-sm.md 1ms (unchanged)
.cursor/commands/bmad-agent-bmm-tech-writer.md 0ms (unchanged)
.cursor/commands/bmad-agent-bmm-ux-designer.md 1ms (unchanged)
.cursor/commands/bmad-agent-cis-brainstorming-coach.md 1ms (unchanged)
.cursor/commands/bmad-agent-cis-creative-problem-solver.md 0ms (unchanged)
.cursor/commands/bmad-agent-cis-design-thinking-coach.md 1ms (unchanged)
.cursor/commands/bmad-agent-cis-innovation-strategist.md 1ms (unchanged)
.cursor/commands/bmad-agent-cis-presentation-master.md 0ms (unchanged)
.cursor/commands/bmad-agent-cis-storyteller.md 1ms (unchanged)
.cursor/commands/bmad-agent-tea-tea.md 1ms (unchanged)
.cursor/commands/bmad-bmb-agent.md 1ms (unchanged)
.cursor/commands/bmad-bmb-module.md 1ms (unchanged)
.cursor/commands/bmad-bmb-workflow.md 1ms (unchanged)
.cursor/commands/bmad-bmm-check-implementation-readiness.md 1ms (unchanged)
.cursor/commands/bmad-bmm-code-review.md 1ms (unchanged)
.cursor/commands/bmad-bmm-correct-course.md 1ms (unchanged)
.cursor/commands/bmad-bmm-create-architecture.md 1ms (unchanged)
.cursor/commands/bmad-bmm-create-epics-and-stories.md 1ms (unchanged)
.cursor/commands/bmad-bmm-create-excalidraw-dataflow.md 0ms (unchanged)
.cursor/commands/bmad-bmm-create-excalidraw-diagram.md 1ms (unchanged)
.cursor/commands/bmad-bmm-create-excalidraw-flowchart.md 0ms (unchanged)
.cursor/commands/bmad-bmm-create-excalidraw-wireframe.md 1ms (unchanged)
.cursor/commands/bmad-bmm-create-prd.md 1ms (unchanged)
.cursor/commands/bmad-bmm-create-product-brief.md 0ms (unchanged)
.cursor/commands/bmad-bmm-create-story.md 1ms (unchanged)
.cursor/commands/bmad-bmm-create-ux-design.md 1ms (unchanged)
.cursor/commands/bmad-bmm-dev-story.md 0ms (unchanged)
.cursor/commands/bmad-bmm-document-project.md 0ms (unchanged)
.cursor/commands/bmad-bmm-qa-automate.md 1ms (unchanged)
.cursor/commands/bmad-bmm-quick-dev.md 1ms (unchanged)
.cursor/commands/bmad-bmm-quick-spec.md 1ms (unchanged)
.cursor/commands/bmad-bmm-research.md 0ms (unchanged)
.cursor/commands/bmad-bmm-retrospective.md 0ms (unchanged)
.cursor/commands/bmad-bmm-sprint-planning.md 1ms (unchanged)
.cursor/commands/bmad-bmm-sprint-status.md 1ms (unchanged)
.cursor/commands/bmad-brainstorming.md 1ms (unchanged)
.cursor/commands/bmad-cis-design-thinking.md 0ms (unchanged)
.cursor/commands/bmad-cis-innovation-strategy.md 1ms (unchanged)
.cursor/commands/bmad-cis-problem-solving.md 1ms (unchanged)
.cursor/commands/bmad-cis-storytelling.md 1ms (unchanged)
.cursor/commands/bmad-editorial-review-prose.md 1ms (unchanged)
.cursor/commands/bmad-editorial-review-structure.md 1ms (unchanged)
.cursor/commands/bmad-help.md 1ms (unchanged)
.cursor/commands/bmad-index-docs.md 1ms (unchanged)
.cursor/commands/bmad-party-mode.md 1ms (unchanged)
.cursor/commands/bmad-review-adversarial-general.md 1ms (unchanged)
.cursor/commands/bmad-shard-doc.md 1ms (unchanged)
.cursor/commands/bmad-tea-teach-me-testing.md 1ms (unchanged)
.cursor/commands/bmad-tea-testarch-atdd.md 1ms (unchanged)
.cursor/commands/bmad-tea-testarch-automate.md 0ms (unchanged)
.cursor/commands/bmad-tea-testarch-ci.md 1ms (unchanged)
.cursor/commands/bmad-tea-testarch-framework.md 1ms (unchanged)
.cursor/commands/bmad-tea-testarch-nfr.md 1ms (unchanged)
.cursor/commands/bmad-tea-testarch-test-design.md 1ms (unchanged)
.cursor/commands/bmad-tea-testarch-test-review.md 0ms (unchanged)
.cursor/commands/bmad-tea-testarch-trace.md 1ms (unchanged)
.github/ISSUE_TEMPLATE/bug.md 2ms (unchanged)
.github/ISSUE_TEMPLATE/epic.md 2ms (unchanged)
.github/ISSUE_TEMPLATE/feature.md 2ms (unchanged)
.github/ISSUE_TEMPLATE/story.md 1ms (unchanged)
.github/ISSUE_TEMPLATE/task.md 1ms (unchanged)
.github/PULL_REQUEST_TEMPLATE.md 1ms (unchanged)
.github/README.md 13ms (unchanged)
.github/story-1-2-review-issues.md 9ms (unchanged)
.github/story-1-3-review-issues.md 8ms (unchanged)
.github/story-1-4-review-issues.md 9ms (unchanged)
.github/story-1-5-completion.md 1ms (unchanged)
.github/story-1-6-review-issues.md 6ms (unchanged)
backend/package.json 1ms (unchanged)
backend/shared/db/package.json 0ms (unchanged)
backend/shared/db/src/client.ts 3ms (unchanged)
backend/shared/db/src/helpers.ts 10ms (unchanged)
backend/shared/db/src/index.ts 2ms (unchanged)
backend/shared/db/test/client.test.ts 3ms (unchanged)
backend/shared/db/test/helpers.test.ts 7ms (unchanged)
backend/shared/db/tsconfig.json 0ms (unchanged)
backend/shared/db/vitest.config.ts 2ms (unchanged)
backend/shared/logging/package.json 0ms (unchanged)
backend/shared/logging/src/index.ts 1ms (unchanged)
backend/shared/logging/src/logger.ts 7ms (unchanged)
backend/shared/logging/test/logger.test.ts 8ms (unchanged)
backend/shared/logging/tsconfig.json 0ms (unchanged)
backend/shared/logging/vitest.config.ts 1ms (unchanged)
backend/shared/middleware/package.json 0ms (unchanged)
backend/shared/middleware/src/auth.ts 2ms (unchanged)
backend/shared/middleware/src/error-handler.ts 2ms (unchanged)
backend/shared/middleware/src/index.ts 1ms (unchanged)
backend/shared/middleware/src/wrapper.ts 4ms (unchanged)
backend/shared/middleware/test/auth.test.ts 8ms (unchanged)
backend/shared/middleware/test/error-handler.test.ts 4ms (unchanged)
backend/shared/middleware/test/wrapper.test.ts 6ms (unchanged)
backend/shared/middleware/tsconfig.json 1ms (unchanged)
backend/shared/middleware/vitest.config.ts 1ms (unchanged)
backend/shared/types/package.json 0ms (unchanged)
backend/shared/types/src/api.ts 1ms (unchanged)
backend/shared/types/src/entities.ts 2ms (unchanged)
backend/shared/types/src/errors.ts 2ms (unchanged)
backend/shared/types/src/index.ts 1ms (unchanged)
backend/shared/types/test/api.test.ts 2ms (unchanged)
backend/shared/types/test/entities.test.ts 2ms (unchanged)
backend/shared/types/test/errors.test.ts 2ms (unchanged)
backend/shared/types/test/index.test.ts 1ms (unchanged)
backend/shared/types/tsconfig.json 0ms (unchanged)
backend/shared/types/vitest.config.ts 0ms (unchanged)
backend/shared/validation/package.json 0ms (unchanged)
backend/shared/validation/src/index.ts 1ms (unchanged)
backend/shared/validation/src/schemas.ts 3ms (unchanged)
backend/shared/validation/src/validator.ts 2ms (unchanged)
backend/shared/validation/test/schemas.test.ts 5ms (unchanged)
backend/shared/validation/test/validator.test.ts 6ms (unchanged)
backend/shared/validation/tsconfig.json 0ms (unchanged)
backend/shared/validation/vitest.config.ts 1ms (unchanged)
backend/test/placeholder.test.ts 0ms (unchanged)
backend/tsconfig.json 0ms (unchanged)
backend/vitest.config.ts 1ms (unchanged)
CLAUDE.md 4ms (unchanged)
docs/ARCHITECTURE.md 1ms (unchanged)
docs/auto-epic-architecture.md 12ms (unchanged)
docs/auto-epic-diagram.md 3ms (unchanged)
docs/auto-epic-future-enhancements.md 4ms (unchanged)
docs/epics/000-project-foundation.md 2ms (unchanged)
docs/PRD.md 1ms (unchanged)
docs/progress/aws-setup-complete.md 7ms (unchanged)
docs/progress/epic-1-auto-run.md 2ms (unchanged)
docs/progress/epic-1-story-1-7-completion-report.md 6ms (unchanged)
docs/research/auto-epic-validation-findings.md 16ms (unchanged)
docs/research/auto-epic-validation-findings1.md 23ms (unchanged)
docs/research/epic-1-remaining-stories-analysis.md 21ms (unchanged)
docs/research/story-1-10-analysis.md 19ms (unchanged)
docs/writing-pipeline/agents/tech-writer.md 19ms (unchanged)
docs/writing-pipeline/guides/diagram-guide.md 20ms (unchanged)
docs/writing-pipeline/guides/review-taxonomy.md 21ms (unchanged)
docs/writing-pipeline/guides/style-guide.md 22ms (unchanged)
frontend/package.json 0ms (unchanged)
frontend/src/App.tsx 2ms (unchanged)
frontend/src/main.tsx 1ms (unchanged)
frontend/src/vite-env.d.ts 1ms (unchanged)
frontend/test/App.test.tsx 1ms (unchanged)
frontend/test/setup.ts 0ms (unchanged)
frontend/tsconfig.json 1ms (unchanged)
frontend/tsconfig.node.json 0ms (unchanged)
frontend/vite.config.ts 1ms (unchanged)
frontend/vitest.config.ts 1ms (unchanged)
infra/bin/app.ts 2ms (unchanged)
infra/cdk.json 0ms (unchanged)
infra/code-review-story-1-8-round-1.md 19ms (unchanged)
infra/code-review-story-1-8-round-2.md 27ms (unchanged)
infra/config/aws-env.ts 1ms (unchanged)
infra/config/environments.ts 1ms (unchanged)
infra/lib/stacks/core/buckets.stack.ts 2ms (unchanged)
infra/lib/stacks/core/tables.stack.ts 6ms (unchanged)
infra/lib/stacks/observability/observability.stack.ts 2ms (unchanged)
infra/package.json 0ms (unchanged)
infra/README.md 3ms (unchanged)
infra/test/app.test.ts 1ms (unchanged)
infra/test/bin/app-structure.test.ts 2ms (unchanged)
infra/test/config/aws-env.test.ts 5ms (unchanged)
infra/test/config/environments.test.ts 4ms (unchanged)
infra/test/secrets-scan.test.ts 4ms (unchanged)
infra/test/stacks/core/buckets.stack.test.ts 2ms (unchanged)
infra/test/stacks/core/tables.stack.test.ts 7ms (unchanged)
infra/test/stacks/observability/observability.stack.test.ts 2ms (unchanged)
infra/tsconfig.json 0ms (unchanged)
infra/vitest.config.ts 1ms (unchanged)
package-lock.json 28ms (unchanged)
package.json 0ms (unchanged)
plan.md 11ms (unchanged)
README.md 10ms (unchanged)
secrets-report.json 2ms (unchanged)
test/ci-workflow.test.ts 4ms (unchanged)
test/eslint-rule.test.ts 1ms (unchanged)
tsconfig.base.json 0ms (unchanged)
tsconfig.json 0ms (unchanged)
vitest.config.ts 0ms (unchanged)
- [x] 
> type-check
> tsc --build
- [x] 
> test
> vitest run && npm run test --workspaces --if-present


 RUN  v3.2.4 /Users/stephen/Documents/ai-learning-hub

 ✓ test/ci-workflow.test.ts (13 tests) 38ms
 ✓ test/eslint-rule.test.ts (2 tests) 259ms

 Test Files  2 passed (2)
      Tests  15 passed (15)
   Start at  15:41:04
   Duration  496ms (transform 32ms, setup 0ms, collect 108ms, tests 298ms, environment 0ms, prepare 67ms)


> @ai-learning-hub/infra@0.1.0 test
> vitest run --coverage


 RUN  v3.2.4 /Users/stephen/Documents/ai-learning-hub/infra
      Coverage enabled with v8

 ✓ test/app.test.ts (1 test) 2ms
 ✓ test/bin/app-structure.test.ts (21 tests) 3ms
 ✓ test/config/aws-env.test.ts (18 tests) 6ms
 ✓ test/config/environments.test.ts (17 tests) 6ms
 ✓ test/secrets-scan.test.ts (143 tests) 7ms
 ✓ test/stacks/core/buckets.stack.test.ts (7 tests) 5ms
 ✓ test/stacks/core/tables.stack.test.ts (20 tests) 8ms
 ✓ test/stacks/observability/observability.stack.test.ts (6 tests) 78ms

 Test Files  8 passed (8)
      Tests  233 passed (233)
   Start at  15:41:05
   Duration  663ms (transform 176ms, setup 0ms, collect 1.10s, tests 115ms, environment 1ms, prepare 482ms)

 % Coverage report from v8
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |                   
 config            |     100 |      100 |     100 |     100 |                   
  aws-env.ts       |     100 |      100 |     100 |     100 |                   
  environments.ts  |     100 |      100 |     100 |     100 |                   
 lib/stacks/core   |     100 |      100 |     100 |     100 |                   
  buckets.stack.ts |     100 |      100 |     100 |     100 |                   
  tables.stack.ts  |     100 |      100 |     100 |     100 |                   
 .../observability |     100 |      100 |     100 |     100 |                   
  ...lity.stack.ts |     100 |      100 |     100 |     100 |                   
-------------------|---------|----------|---------|---------|-------------------

> @ai-learning-hub/frontend@0.1.0 test
> vitest run --coverage


 RUN  v3.2.4 /Users/stephen/Documents/ai-learning-hub/frontend
      Coverage enabled with v8

 ✓ test/App.test.tsx (1 test) 13ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  15:41:06
   Duration  511ms (transform 19ms, setup 29ms, collect 63ms, tests 13ms, environment 192ms, prepare 39ms)

 % Coverage report from v8
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |     100 |      100 |     100 |     100 |                   
 App.tsx  |     100 |      100 |     100 |     100 |                   
----------|---------|----------|---------|---------|-------------------

> @ai-learning-hub/backend@0.1.0 test
> vitest run --coverage


 RUN  v3.2.4 /Users/stephen/Documents/ai-learning-hub/backend
      Coverage enabled with v8

 ✓ test/placeholder.test.ts (1 test) 1ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  15:41:07
   Duration  218ms (transform 13ms, setup 0ms, collect 10ms, tests 1ms, environment 0ms, prepare 36ms)

 % Coverage report from v8
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |       0 |        0 |       0 |       0 |                   
----------|---------|----------|---------|---------|-------------------

> @ai-learning-hub/types@0.1.0 test
> vitest run --coverage


 RUN  v3.2.4 /Users/stephen/Documents/ai-learning-hub/backend/shared/types
      Coverage enabled with v8

 ✓ test/api.test.ts (8 tests) 2ms
 ✓ test/index.test.ts (2 tests) 2ms
 ✓ test/entities.test.ts (10 tests) 3ms
 ✓ test/errors.test.ts (8 tests) 4ms

 Test Files  4 passed (4)
      Tests  28 passed (28)
   Start at  15:41:07
   Duration  237ms (transform 72ms, setup 0ms, collect 102ms, tests 12ms, environment 0ms, prepare 184ms)

 % Coverage report from v8
-------------|---------|----------|---------|---------|-------------------
File         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------|---------|----------|---------|---------|-------------------
All files    |     100 |      100 |     100 |     100 |                   
 api.ts      |       0 |        0 |       0 |       0 |                   
 entities.ts |     100 |      100 |     100 |     100 |                   
 errors.ts   |     100 |      100 |     100 |     100 |                   
 index.ts    |     100 |      100 |     100 |     100 |                   
-------------|---------|----------|---------|---------|-------------------

> @ai-learning-hub/logging@0.1.0 test
> vitest run --coverage


 RUN  v3.2.4 /Users/stephen/Documents/ai-learning-hub/backend/shared/logging
      Coverage enabled with v8

 ✓ test/logger.test.ts (24 tests) 7ms

 Test Files  1 passed (1)
      Tests  24 passed (24)
   Start at  15:41:08
   Duration  237ms (transform 22ms, setup 0ms, collect 24ms, tests 7ms, environment 0ms, prepare 43ms)

 % Coverage report from v8
-----------|---------|----------|---------|---------|-------------------
File       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------|---------|----------|---------|---------|-------------------
All files  |    96.5 |    86.53 |   92.85 |    96.5 |                   
 index.ts  |       0 |        0 |       0 |       0 | 1                 
 logger.ts |   97.18 |    88.23 |     100 |   97.18 | 69-70,77-78       
-----------|---------|----------|---------|---------|-------------------

> @ai-learning-hub/validation@0.1.0 test
> vitest run --coverage


 RUN  v3.2.4 /Users/stephen/Documents/ai-learning-hub/backend/shared/validation
      Coverage enabled with v8

 ✓ test/schemas.test.ts (37 tests) 6ms
 ✓ test/validator.test.ts (17 tests) 5ms

 Test Files  2 passed (2)
      Tests  54 passed (54)
   Start at  15:41:08
   Duration  262ms (transform 52ms, setup 0ms, collect 80ms, tests 11ms, environment 0ms, prepare 87ms)

 % Coverage report from v8
--------------|---------|----------|---------|---------|-------------------
File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------|---------|----------|---------|---------|-------------------
All files     |   99.37 |    90.47 |   85.71 |   99.37 |                   
 index.ts     |       0 |        0 |       0 |       0 | 1                 
 schemas.ts   |     100 |      100 |     100 |     100 |                   
 validator.ts |     100 |    94.11 |     100 |     100 | 21                
--------------|---------|----------|---------|---------|-------------------

> @ai-learning-hub/db@0.1.0 test
> vitest run --coverage


 RUN  v3.2.4 /Users/stephen/Documents/ai-learning-hub/backend/shared/db
      Coverage enabled with v8

 ✓ test/client.test.ts (8 tests) 7ms
 ✓ test/helpers.test.ts (16 tests) 9ms

 Test Files  2 passed (2)
      Tests  24 passed (24)
   Start at  15:41:09
   Duration  310ms (transform 47ms, setup 0ms, collect 167ms, tests 16ms, environment 0ms, prepare 85ms)

 % Coverage report from v8
------------|---------|----------|---------|---------|-------------------------
File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s       
------------|---------|----------|---------|---------|-------------------------
All files   |   96.74 |    82.92 |    90.9 |   96.74 |                         
 client.ts  |     100 |      100 |     100 |     100 |                         
 helpers.ts |   96.75 |    81.81 |     100 |   96.75 | 186-187,189-190,193-194 
 index.ts   |       0 |        0 |       0 |       0 | 1                       
------------|---------|----------|---------|---------|-------------------------

> @ai-learning-hub/middleware@0.1.0 test
> vitest run --coverage


 RUN  v3.2.4 /Users/stephen/Documents/ai-learning-hub/backend/shared/middleware
      Coverage enabled with v8

 ✓ test/auth.test.ts (17 tests) 5ms
 ✓ test/error-handler.test.ts (13 tests) 7ms
 ✓ test/wrapper.test.ts (13 tests) 7ms

 Test Files  3 passed (3)
      Tests  43 passed (43)
   Start at  15:41:09
   Duration  255ms (transform 86ms, setup 0ms, collect 145ms, tests 19ms, environment 0ms, prepare 128ms)

 % Coverage report from v8
------------------|---------|----------|---------|---------|-------------------
File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------------|---------|----------|---------|---------|-------------------
All files         |   98.17 |     92.3 |   92.85 |   98.17 |                   
 auth.ts          |     100 |      100 |     100 |     100 |                   
 error-handler.ts |     100 |     92.3 |     100 |     100 | 63                
 index.ts         |       0 |        0 |       0 |       0 | 1                 
 wrapper.ts       |   96.55 |    88.88 |     100 |   96.55 | 59,69-70          
------------------|---------|----------|---------|---------|-------------------
- [x] 
> lint
> eslint .


/Users/stephen/Documents/ai-learning-hub/backend/shared/logging/src/logger.ts
   94:9  warning  Generic Object Injection Sink  security/detect-object-injection
   96:9  warning  Generic Object Injection Sink  security/detect-object-injection
  164:9  warning  Generic Object Injection Sink  security/detect-object-injection

/Users/stephen/Documents/ai-learning-hub/backend/shared/types/src/errors.ts
  50:23  warning  Generic Object Injection Sink  security/detect-object-injection

/Users/stephen/Documents/ai-learning-hub/infra/test/bin/app-structure.test.ts
  7:21  warning  Found readFileSync from package "fs" with non literal argument at index 0  security/detect-non-literal-fs-filename

/Users/stephen/Documents/ai-learning-hub/infra/test/secrets-scan.test.ts
   33:23  warning  Found readFileSync from package "fs" with non literal argument at index 0  security/detect-non-literal-fs-filename
  152:18  warning  Found readFileSync from package "fs" with non literal argument at index 0  security/detect-non-literal-fs-filename

/Users/stephen/Documents/ai-learning-hub/scripts/validate-templates.mjs
  43:19  warning  Found readFileSync from package "fs" with non literal argument at index 0  security/detect-non-literal-fs-filename
  65:8   warning  Found existsSync from package "fs" with non literal argument at index 0    security/detect-non-literal-fs-filename
  66:19  warning  Found readFileSync from package "fs" with non literal argument at index 0  security/detect-non-literal-fs-filename

/Users/stephen/Documents/ai-learning-hub/test/ci-workflow.test.ts
   43:21  warning  Found readFileSync from package "fs" with non literal argument at index 0  security/detect-non-literal-fs-filename
   50:21  warning  Found readFileSync from package "fs" with non literal argument at index 0  security/detect-non-literal-fs-filename
   59:21  warning  Found readFileSync from package "fs" with non literal argument at index 0  security/detect-non-literal-fs-filename
   78:21  warning  Found readFileSync from package "fs" with non literal argument at index 0  security/detect-non-literal-fs-filename
  100:21  warning  Found readFileSync from package "fs" with non literal argument at index 0  security/detect-non-literal-fs-filename
  107:21  warning  Found readFileSync from package "fs" with non literal argument at index 0  security/detect-non-literal-fs-filename
  124:21  warning  Found readFileSync from package "fs" with non literal argument at index 0  security/detect-non-literal-fs-filename
  139:21  warning  Found readFileSync from package "fs" with non literal argument at index 0  security/detect-non-literal-fs-filename
  154:21  warning  Found readFileSync from package "fs" with non literal argument at index 0  security/detect-non-literal-fs-filename
  164:21  warning  Found readFileSync from package "fs" with non literal argument at index 0  security/detect-non-literal-fs-filename
  175:21  warning  Found readFileSync from package "fs" with non literal argument at index 0  security/detect-non-literal-fs-filename
  188:21  warning  Found readFileSync from package "fs" with non literal argument at index 0  security/detect-non-literal-fs-filename
  197:21  warning  Found readFileSync from package "fs" with non literal argument at index 0  security/detect-non-literal-fs-filename

✖ 23 problems (0 errors, 23 warnings) (warnings only)
- [x] 
> build
> npm run build --workspaces --if-present


> @ai-learning-hub/infra@0.1.0 build
> tsc


> @ai-learning-hub/frontend@0.1.0 build
> tsc -b && vite build

vite v5.4.21 building for production...
transforming...
✓ 31 modules transformed.
rendering chunks...
computing gzip size...
dist/registerSW.js                0.13 kB
dist/manifest.webmanifest         0.17 kB
dist/index.html                   0.58 kB │ gzip:  0.35 kB
dist/assets/index-NlCsEm_O.css    5.17 kB │ gzip:  1.56 kB
dist/assets/index-Cyyt-a_g.js   142.89 kB │ gzip: 45.91 kB
✓ built in 395ms

PWA v0.17.5
mode      generateSW
precache  5 entries (145.29 KiB)
files generated
  dist/sw.js
  dist/workbox-7fc22fbe.js

> @ai-learning-hub/backend@0.1.0 build
> tsc


> @ai-learning-hub/types@0.1.0 build
> tsc


> @ai-learning-hub/logging@0.1.0 build
> tsc


> @ai-learning-hub/validation@0.1.0 build
> tsc


> @ai-learning-hub/db@0.1.0 build
> tsc


> @ai-learning-hub/middleware@0.1.0 build
> tsc

Closes #105

Made with [Cursor](https://cursor.com)