### PR TITLE
chore: add PR merge guard hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,8 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/bash-guard.js\"",
-            "timeout": 5000
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/bash-guard.cjs\"",
+            "timeout": 17500
           }
         ]
       },


### PR DESCRIPTION
## Summary
- Renames `bash-guard.js` → `bash-guard.cjs` for ESM compatibility (root `package.json` has `"type": "module"`)
- Adds PR merge gate to the Claude Code hook that blocks `gh pr merge` when CI checks are failing or still running
- Escalates to human when CI status cannot be determined
- Updates `.claude/settings.json` to reference `.cjs` with increased timeout (17500ms) for the `gh pr checks` call

## Context
PR #123 was merged with failing CI checks because there was no guard. This hook prevents that from happening again.

## Test plan
- [ ] Verify hook blocks merge when CI checks are failing
- [ ] Verify hook blocks merge when CI checks are pending
- [ ] Verify hook escalates when `gh pr checks` errors
- [ ] Verify hook allows merge when all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)