### PR TITLE
feat: scope/role deserialization in auth middleware (Story 2.3)

### DIFF
--- a/backend/functions/api-key-authorizer/handler.ts
+++ b/backend/functions/api-key-authorizer/handler.ts
@@ -46,7 +46,7 @@ export async function handler(
   const headerKey = Object.keys(event.headers || {}).find(
     (k) => k.toLowerCase() === "x-api-key"
   );
-  const apiKey = headerKey ? event.headers![headerKey] : undefined;
+  const apiKey = headerKey ? event.headers?.[headerKey] : undefined;
 
   if (!apiKey) {
     logger.warn("Missing x-api-key header");


### PR DESCRIPTION
## Summary
- Fixes `extractAuthContext` to properly deserialize JSON-serialized scopes and roles from API Gateway authorizer context (which only supports string values)
- Fixes critical `role`/`roles` field name mismatch: authorizers set `role` (singular) but middleware read `roles` (plural), causing all users to silently default to `["user"]` regardless of actual role
- Adds 9 new tests: JSON scope deserialization (3), integration AC1-AC4 (4), role mapping (2)
- Fixes TS build errors in handler.test.ts and authorizer-policy.test.ts
- Replaces non-null assertion with optional chaining in API key authorizer

## Changes
- `backend/shared/middleware/src/auth.ts` — Core fix: parse JSON scopes/roles, handle `role` (singular) from authorizers
- `backend/shared/middleware/test/auth.test.ts` — 9 new tests covering all edge cases
- `backend/functions/api-key-authorizer/handler.ts` — `event.headers!` → `event.headers?.` for null safety
- `backend/functions/api-key-authorizer/handler.test.ts` — TS fix: add missing `authorizer` and `path` properties
- `backend/shared/middleware/test/authorizer-policy.test.ts` — TS fix: proper type cast

## Test plan
- [x] All 530+ tests pass across all workspaces
- [x] Build clean (no TS errors)
- [x] Lint clean
- [x] Secrets scan clean (gitleaks pre-commit)
- [x] Code review completed (1 critical finding fixed: role/roles mismatch)
- [ ] CI pipeline passes

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)