### PR TITLE
fix: add validate script matching CI pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,json,md}\"",
     "type-check": "tsc --build",
+    "validate": "npm run lint && npm run type-check && npm test",
     "validate-templates": "node scripts/validate-templates.mjs",
     "prepare": "husky install || true"
   },


### PR DESCRIPTION
## Summary
- Adds `npm run validate` script that chains lint → type-check → test, exactly mirroring CI stages
- Updates epic orchestrator quality gate to use `npm run type-check` instead of `npm run build`
- Adds lessons learned from Epic 2 to orchestrator docs

## Root cause
CI runs `tsc --build` (project references mode) which is stricter than per-workspace `tsc`. Our local quality gate only ran `npm run build`, missing type errors that CI caught. Vitest strips types via esbuild, so tests pass even with TS errors.

## Changes
- `package.json` — Added `validate` script
- `.claude/skills/epic-orchestrator/SKILL.md` — Updated quality gate, added lessons learned section

## Test plan
- [x] `npm run validate` runs successfully end-to-end
- [x] Orchestrator quality gate docs updated with explanation

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)