### PR TITLE
feat: API Key CRUD endpoints (Story 2.6)

### DIFF
--- a/backend/functions/api-keys/handler.test.ts
+++ b/backend/functions/api-keys/handler.test.ts
@@ -1,0 +1,491 @@
+/**
+ * API Keys Endpoint handler tests
+ *
+ * Tests the POST/GET/DELETE /users/api-keys endpoints per Story 2.6.
+ * Covers all acceptance criteria: AC1-AC6.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { APIGatewayProxyEvent, Context } from "aws-lambda";
+import { AppError, ErrorCode } from "@ai-learning-hub/types";
+
+// Mock @ai-learning-hub/db
+const mockCreateApiKey = vi.fn();
+const mockListApiKeys = vi.fn();
+const mockRevokeApiKey = vi.fn();
+const mockGetDefaultClient = vi.fn(() => ({}));
+
+vi.mock("@ai-learning-hub/db", () => ({
+  getDefaultClient: () => mockGetDefaultClient(),
+  createApiKey: (...args: unknown[]) => mockCreateApiKey(...args),
+  listApiKeys: (...args: unknown[]) => mockListApiKeys(...args),
+  revokeApiKey: (...args: unknown[]) => mockRevokeApiKey(...args),
+}));
+
+// Mock @ai-learning-hub/logging
+vi.mock("@ai-learning-hub/logging", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    timed: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+    setRequestContext: vi.fn(),
+  }),
+}));
+
+// Mock @ai-learning-hub/middleware
+vi.mock("@ai-learning-hub/middleware", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  wrapHandler: (handler: Function, options: Record<string, unknown>) => {
+    return async (event: APIGatewayProxyEvent, context: Context) => {
+      // Simulate auth requirement
+      if (options.requireAuth) {
+        const authorizer = event.requestContext?.authorizer;
+        if (!authorizer?.userId) {
+          return {
+            statusCode: 401,
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              error: {
+                code: "UNAUTHORIZED",
+                message: "Authentication required",
+                requestId: "test-req-id",
+              },
+            }),
+          };
+        }
+      }
+
+      const auth = event.requestContext?.authorizer
+        ? {
+            userId: event.requestContext.authorizer.userId as string,
+            roles: [(event.requestContext.authorizer.role as string) || "user"],
+            isApiKey: event.requestContext.authorizer.authMethod === "api-key",
+          }
+        : null;
+
+      try {
+        const result = await handler({
+          event,
+          context,
+          auth,
+          requestId: "test-req-id",
+          logger: {
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+            debug: vi.fn(),
+            timed: vi.fn(),
+            child: vi.fn().mockReturnThis(),
+            setRequestContext: vi.fn(),
+          },
+          startTime: Date.now(),
+        });
+
+        // If result is already an API Gateway response, return as-is
+        if (
+          typeof result === "object" &&
+          result !== null &&
+          "statusCode" in result
+        ) {
+          return result;
+        }
+
+        // Auto-wrap success
+        return {
+          statusCode: 200,
+          headers: {
+            "Content-Type": "application/json",
+            "X-Request-Id": "test-req-id",
+          },
+          body: JSON.stringify({ data: result }),
+        };
+      } catch (error: unknown) {
+        const err = error as {
+          code?: string;
+          statusCode?: number;
+          message?: string;
+        };
+        const code = err.code ?? "INTERNAL_ERROR";
+        const statusCode = err.statusCode ?? 500;
+        const message = err.message ?? "An unexpected error occurred";
+        return {
+          statusCode,
+          headers: {
+            "Content-Type": "application/json",
+            "X-Request-Id": "test-req-id",
+          },
+          body: JSON.stringify({
+            error: { code, message, requestId: "test-req-id" },
+          }),
+        };
+      }
+    };
+  },
+  extractAuthContext: vi.fn(),
+  requireAuth: vi.fn(),
+  createSuccessResponse: (
+    data: unknown,
+    requestId: string,
+    statusCode = 200
+  ) => ({
+    statusCode,
+    headers: {
+      "Content-Type": "application/json",
+      "X-Request-Id": requestId,
+    },
+    body: JSON.stringify({ data }),
+  }),
+  createNoContentResponse: (requestId: string) => ({
+    statusCode: 204,
+    headers: {
+      "X-Request-Id": requestId,
+    },
+    body: "",
+  }),
+  handleError: vi.fn(),
+}));
+
+// Note: @ai-learning-hub/validation is NOT mocked — uses real implementation
+
+import { handler } from "./handler.js";
+
+function createEvent(
+  method: "POST" | "GET" | "DELETE",
+  body?: Record<string, unknown>,
+  userId?: string,
+  pathParameters?: Record<string, string>
+): APIGatewayProxyEvent {
+  return {
+    httpMethod: method,
+    path: "/users/api-keys",
+    body: body ? JSON.stringify(body) : null,
+    headers: { "Content-Type": "application/json" },
+    multiValueHeaders: {},
+    isBase64Encoded: false,
+    pathParameters: pathParameters ?? null,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: "/users/api-keys",
+    requestContext: {
+      accountId: "123456789",
+      apiId: "api-id",
+      authorizer: userId
+        ? { userId, role: "user", authMethod: "jwt" }
+        : undefined,
+      protocol: "HTTP/1.1",
+      httpMethod: method,
+      identity: {
+        sourceIp: "127.0.0.1",
+        accessKey: null,
+        accountId: null,
+        apiKey: null,
+        apiKeyId: null,
+        caller: null,
+        clientCert: null,
+        cognitoAuthenticationProvider: null,
+        cognitoAuthenticationType: null,
+        cognitoIdentityId: null,
+        cognitoIdentityPoolId: null,
+        principalOrgId: null,
+        user: null,
+        userAgent: null,
+        userArn: null,
+      },
+      path: "/users/api-keys",
+      stage: "dev",
+      requestId: "test-request-id",
+      requestTimeEpoch: Date.now(),
+      resourceId: "resource-id",
+      resourcePath: "/users/api-keys",
+    },
+  };
+}
+
+const mockContext = {} as Context;
+
+describe("API Keys Handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("AC1: POST /users/api-keys — create key", () => {
+    it("creates an API key with name and scopes", async () => {
+      const mockResult = {
+        id: "key_01HXYZ123",
+        name: "My App Key",
+        key: "base64url-encoded-key-value",
+        scopes: ["*"],
+        createdAt: "2026-02-16T12:00:00Z",
+      };
+      mockCreateApiKey.mockResolvedValueOnce(mockResult);
+
+      const event = createEvent(
+        "POST",
+        { name: "My App Key", scopes: ["*"] },
+        "user_123"
+      );
+      const result = await handler(event, mockContext);
+      const body = JSON.parse(result.body);
+
+      expect(result.statusCode).toBe(201);
+      expect(body.data.id).toBe("key_01HXYZ123");
+      expect(body.data.name).toBe("My App Key");
+      expect(body.data.key).toBe("base64url-encoded-key-value");
+      expect(body.data.scopes).toEqual(["*"]);
+      expect(body.data.createdAt).toBeDefined();
+    });
+
+    it("calls createApiKey with correct arguments", async () => {
+      mockCreateApiKey.mockResolvedValueOnce({
+        id: "key_01",
+        name: "Test",
+        key: "test-key",
+        scopes: ["*"],
+        createdAt: "2026-02-16T12:00:00Z",
+      });
+
+      const event = createEvent(
+        "POST",
+        { name: "Test", scopes: ["*"] },
+        "user_abc"
+      );
+      await handler(event, mockContext);
+
+      expect(mockCreateApiKey).toHaveBeenCalledWith(
+        expect.anything(),
+        "user_abc",
+        "Test",
+        ["*"]
+      );
+    });
+  });
+
+  describe("AC2: GET /users/api-keys — list keys", () => {
+    it("returns list of keys without key values", async () => {
+      const mockResult = {
+        items: [
+          {
+            id: "key_01",
+            name: "App Key",
+            scopes: ["*"],
+            createdAt: "2026-02-16T12:00:00Z",
+            lastUsedAt: "2026-02-16T14:00:00Z",
+          },
+          {
+            id: "key_02",
+            name: "Capture Key",
+            scopes: ["saves:write"],
+            createdAt: "2026-02-16T13:00:00Z",
+            lastUsedAt: null,
+          },
+        ],
+        hasMore: false,
+      };
+      mockListApiKeys.mockResolvedValueOnce(mockResult);
+
+      const event = createEvent("GET", undefined, "user_123");
+      const result = await handler(event, mockContext);
+      const body = JSON.parse(result.body);
+
+      expect(result.statusCode).toBe(200);
+      expect(body.data.items).toHaveLength(2);
+      expect(body.data.items[0].id).toBe("key_01");
+      expect(body.data.items[0].name).toBe("App Key");
+      // Key value must NOT be present
+      expect(body.data.items[0].key).toBeUndefined();
+      expect(body.data.items[0].keyHash).toBeUndefined();
+    });
+
+    it("calls listApiKeys with correct userId", async () => {
+      mockListApiKeys.mockResolvedValueOnce({ items: [], hasMore: false });
+
+      const event = createEvent("GET", undefined, "user_xyz");
+      await handler(event, mockContext);
+
+      expect(mockListApiKeys).toHaveBeenCalledWith(
+        expect.anything(),
+        "user_xyz",
+        expect.any(Number),
+        undefined
+      );
+    });
+  });
+
+  describe("AC3: DELETE /users/api-keys/:id — revoke key", () => {
+    it("revokes an API key", async () => {
+      mockRevokeApiKey.mockResolvedValueOnce(undefined);
+
+      const event = createEvent("DELETE", undefined, "user_123", {
+        id: "key_01",
+      });
+      const result = await handler(event, mockContext);
+
+      expect(result.statusCode).toBe(204);
+      expect(result.body).toBe("");
+      expect(mockRevokeApiKey).toHaveBeenCalledWith(
+        expect.anything(),
+        "user_123",
+        "key_01"
+      );
+    });
+
+    it("returns 404 when key does not exist", async () => {
+      mockRevokeApiKey.mockRejectedValueOnce(
+        new AppError(ErrorCode.NOT_FOUND, "API key not found")
+      );
+
+      const event = createEvent("DELETE", undefined, "user_123", {
+        id: "nonexistent_key",
+      });
+      const result = await handler(event, mockContext);
+
+      expect(result.statusCode).toBe(404);
+      const body = JSON.parse(result.body);
+      expect(body.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 400 when no key ID provided", async () => {
+      const event = createEvent("DELETE", undefined, "user_123");
+      // No pathParameters
+      const result = await handler(event, mockContext);
+
+      expect(result.statusCode).toBe(400);
+    });
+  });
+
+  describe("AC4: POST with capture-only scopes", () => {
+    it("creates a capture-only key with saves:write scope", async () => {
+      const mockResult = {
+        id: "key_03",
+        name: "Capture Key",
+        key: "capture-key-value",
+        scopes: ["saves:write"],
+        createdAt: "2026-02-16T12:00:00Z",
+      };
+      mockCreateApiKey.mockResolvedValueOnce(mockResult);
+
+      const event = createEvent(
+        "POST",
+        { name: "Capture Key", scopes: ["saves:write"] },
+        "user_123"
+      );
+      const result = await handler(event, mockContext);
+      const body = JSON.parse(result.body);
+
+      expect(result.statusCode).toBe(201);
+      expect(body.data.scopes).toEqual(["saves:write"]);
+    });
+  });
+
+  describe("AC6: Invalid scopes return 400", () => {
+    it("returns 400 for invalid scope value", async () => {
+      const event = createEvent(
+        "POST",
+        { name: "Bad Key", scopes: ["admin:superpower"] },
+        "user_123"
+      );
+      const result = await handler(event, mockContext);
+
+      expect(result.statusCode).toBe(400);
+      const body = JSON.parse(result.body);
+      expect(body.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 400 for empty scopes array", async () => {
+      const event = createEvent(
+        "POST",
+        { name: "Bad Key", scopes: [] },
+        "user_123"
+      );
+      const result = await handler(event, mockContext);
+
+      expect(result.statusCode).toBe(400);
+    });
+
+    it("returns 400 for missing scopes", async () => {
+      const event = createEvent("POST", { name: "Bad Key" }, "user_123");
+      const result = await handler(event, mockContext);
+
+      expect(result.statusCode).toBe(400);
+    });
+
+    it("returns 400 for missing name", async () => {
+      const event = createEvent("POST", { scopes: ["*"] }, "user_123");
+      const result = await handler(event, mockContext);
+
+      expect(result.statusCode).toBe(400);
+    });
+
+    it("returns 400 for missing request body", async () => {
+      const event = createEvent("POST", undefined, "user_123");
+      const result = await handler(event, mockContext);
+
+      expect(result.statusCode).toBe(400);
+    });
+  });
+
+  describe("Auth enforcement via middleware", () => {
+    it("returns 401 when no auth context (POST)", async () => {
+      const event = createEvent("POST", {
+        name: "Key",
+        scopes: ["*"],
+      });
+      const result = await handler(event, mockContext);
+
+      expect(result.statusCode).toBe(401);
+    });
+
+    it("returns 401 when no auth context (GET)", async () => {
+      const event = createEvent("GET");
+      const result = await handler(event, mockContext);
+
+      expect(result.statusCode).toBe(401);
+    });
+
+    it("returns 401 when no auth context (DELETE)", async () => {
+      const event = createEvent("DELETE", undefined, undefined, {
+        id: "key_01",
+      });
+      const result = await handler(event, mockContext);
+
+      expect(result.statusCode).toBe(401);
+    });
+  });
+
+  describe("Method routing", () => {
+    it("returns 405 for unsupported HTTP method", async () => {
+      const event = createEvent("GET", undefined, "user_123");
+      event.httpMethod = "PUT";
+      const result = await handler(event, mockContext);
+      const body = JSON.parse(result.body);
+
+      expect(result.statusCode).toBe(405);
+      expect(body.error.code).toBe("METHOD_NOT_ALLOWED");
+    });
+  });
+
+  describe("Rate limiting (AC5)", () => {
+    it("returns 429 when rate limit exceeded", async () => {
+      mockCreateApiKey.mockRejectedValueOnce(
+        new AppError(
+          ErrorCode.RATE_LIMITED,
+          "Rate limit exceeded: 10 key generations per hour"
+        )
+      );
+
+      const event = createEvent(
+        "POST",
+        { name: "Key", scopes: ["*"] },
+        "user_123"
+      );
+      const result = await handler(event, mockContext);
+
+      expect(result.statusCode).toBe(429);
+      const body = JSON.parse(result.body);
+      expect(body.error.code).toBe("RATE_LIMITED");
+    });
+  });
+});

--- a/backend/functions/api-keys/handler.ts
+++ b/backend/functions/api-keys/handler.ts
@@ -1,0 +1,130 @@
+/**
+ * API Keys Endpoint — POST/GET/DELETE /users/api-keys
+ *
+ * Creates, lists, and revokes API keys.
+ *
+ * Per Story 2.6: API Key CRUD (Epic 2).
+ */
+import {
+  getDefaultClient,
+  createApiKey,
+  listApiKeys,
+  revokeApiKey,
+} from "@ai-learning-hub/db";
+import {
+  wrapHandler,
+  createSuccessResponse,
+  createNoContentResponse,
+  type HandlerContext,
+} from "@ai-learning-hub/middleware";
+import {
+  validateJsonBody,
+  validateQueryParams,
+  validatePathParams,
+  paginationQuerySchema,
+  z,
+} from "@ai-learning-hub/validation";
+import { createApiKeyBodySchema } from "./schemas.js";
+
+/** Path parameter schema for DELETE /users/api-keys/:id. */
+const deletePathSchema = z.object({
+  id: z.string().min(1, "API key ID is required").max(128),
+});
+
+/**
+ * POST /users/api-keys — Create a new API key (AC1, AC4, AC5).
+ *
+ * TODO(Story 2.7): Rate limiting (10 key generations per user per hour, AC5)
+ * will be enforced when Story 2.7 adds the rate-limit middleware. The handler
+ * correctly propagates RATE_LIMITED errors thrown by that middleware layer.
+ */
+async function handlePost(ctx: HandlerContext) {
+  const { event, auth, logger, requestId } = ctx;
+  const userId = auth!.userId;
+
+  const { name, scopes } = validateJsonBody(createApiKeyBodySchema, event.body);
+
+  const client = getDefaultClient();
+  const result = await createApiKey(client, userId, name, scopes);
+
+  logger.info("API key created", { userId, keyId: result.id });
+  return createSuccessResponse(result, requestId, 201);
+}
+
+/**
+ * GET /users/api-keys — List user's API keys (AC2).
+ */
+async function handleGet(ctx: HandlerContext) {
+  const { event, auth, logger } = ctx;
+  const userId = auth!.userId;
+
+  const { limit, cursor } = validateQueryParams(
+    paginationQuerySchema,
+    event.queryStringParameters
+  );
+
+  const client = getDefaultClient();
+  const result = await listApiKeys(client, userId, limit, cursor);
+
+  logger.info("API keys listed", { userId, count: result.items.length });
+  return result;
+}
+
+/**
+ * DELETE /users/api-keys/:id — Revoke an API key (AC3).
+ *
+ * Returns 204 No Content on success. If the key does not exist or is
+ * already revoked, the DB layer throws NOT_FOUND (DynamoDB condition
+ * check fails). This is intentional idempotent-revocation semantics:
+ * re-revoking a key is treated the same as revoking a nonexistent key.
+ */
+async function handleDelete(ctx: HandlerContext) {
+  const { event, auth, logger, requestId } = ctx;
+  const userId = auth!.userId;
+
+  const { id: keyId } = validatePathParams(
+    deletePathSchema,
+    event.pathParameters
+  );
+
+  const client = getDefaultClient();
+  await revokeApiKey(client, userId, keyId);
+
+  logger.info("API key revoked", { userId, keyId });
+  return createNoContentResponse(requestId);
+}
+
+/**
+ * Route POST, GET, DELETE requests.
+ */
+async function apiKeysHandler(ctx: HandlerContext) {
+  const method = ctx.event.httpMethod.toUpperCase();
+
+  switch (method) {
+    case "POST":
+      return handlePost(ctx);
+    case "GET":
+      return handleGet(ctx);
+    case "DELETE":
+      return handleDelete(ctx);
+    default:
+      return {
+        statusCode: 405,
+        headers: {
+          "Content-Type": "application/json",
+          Allow: "POST, GET, DELETE",
+        },
+        body: JSON.stringify({
+          error: {
+            code: "METHOD_NOT_ALLOWED",
+            message: `Method ${method} not allowed`,
+            requestId: ctx.requestId,
+          },
+        }),
+      };
+  }
+}
+
+export const handler = wrapHandler(apiKeysHandler, {
+  requireAuth: true,
+});

--- a/backend/functions/api-keys/schemas.ts
+++ b/backend/functions/api-keys/schemas.ts
@@ -1,0 +1,20 @@
+/**
+ * Validation schemas for API Keys endpoints (Story 2.6).
+ */
+import { apiKeyScopesSchema, z } from "@ai-learning-hub/validation";
+
+/**
+ * Create API key request body (POST /users/api-keys).
+ *
+ * AC1: name + scopes required.
+ * AC4: scopes: ['saves:write'] creates capture-only key.
+ * AC6: Invalid scopes return 400.
+ */
+export const createApiKeyBodySchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "API key name is required")
+    .max(255, "API key name too long"),
+  scopes: apiKeyScopesSchema,
+});

--- a/backend/shared/db/package.json
+++ b/backend/shared/db/package.json
@@ -20,7 +20,8 @@
     "@ai-learning-hub/logging": "*",
     "@ai-learning-hub/types": "*",
     "@aws-sdk/client-dynamodb": "^3.490.0",
-    "@aws-sdk/lib-dynamodb": "^3.490.0"
+    "@aws-sdk/lib-dynamodb": "^3.490.0",
+    "ulidx": "^2.4.1"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^3.2.4",

--- a/backend/shared/db/src/index.ts
+++ b/backend/shared/db/src/index.ts
@@ -31,11 +31,16 @@ export {
   updateProfile,
   getApiKeyByHash,
   updateApiKeyLastUsed,
+  createApiKey,
+  listApiKeys,
+  revokeApiKey,
   USERS_TABLE_CONFIG,
   type UserProfile,
   type PublicMetadata,
   type ApiKeyItem,
   type UpdateProfileFields,
+  type CreateApiKeyResult,
+  type PublicApiKeyItem,
 } from "./users.js";
 
 // Invite code operations

--- a/backend/shared/validation/src/schemas.ts
+++ b/backend/shared/validation/src/schemas.ts
@@ -146,11 +146,12 @@ export const userIdSchema = z
 export const apiKeyScopeSchema = z.enum(["*", "saves:write", "saves:read"]);
 
 /**
- * API Key scopes array
+ * API Key scopes array (duplicates are automatically removed)
  */
 export const apiKeyScopesSchema = z
   .array(apiKeyScopeSchema)
   .min(1)
+  .transform((scopes) => Array.from(new Set(scopes)))
   .describe("API key permission scopes");
 
 /**

--- a/docs/progress/epic-2-auto-run.md
+++ b/docs/progress/epic-2-auto-run.md
@@ -1,28 +1,32 @@
 ---
 epic_id: Epic-2
 status: in-progress
-scope: ["2.1", "2.2", "2.3", "2.4", "2.5"]
+scope: ["2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7"]
 started: 2026-02-14T12:00:00Z
-last_updated: 2026-02-15T11:00:00Z
+last_updated: 2026-02-16T11:00:00Z
 stories:
   "2.1": { status: done, issue: 122, pr: 123, review_rounds: 1 }
   "2.2": { status: done, pr: 126, review_rounds: 2 }
   "2.3": { status: done, pr: 128, review_rounds: 1 }
-  "2.4": { status: pending }
-  "2.5": { status: pending }
+  "2.4": { status: done, pr: 132, review_rounds: 1 }
+  "2.5": { status: done, pr: 134, review_rounds: 1 }
+  "2.6": { status: in-progress, issue: 135 }
+  "2.7": { status: pending }
 ---
 
 <!-- Human-readable display below (generated from frontmatter) -->
 
 # Epic 2 Auto-Run Progress
 
-| Story | Status      | PR   | Coverage | Review Rounds | Duration |
-| ----- | ----------- | ---- | -------- | ------------- | -------- |
-| 2.1   | ✅ Complete | #123 | >80%     | 1             | ~4h      |
-| 2.2   | ✅ Complete | #126 | -        | 2             | -        |
-| 2.3   | ✅ Complete | #128 | -        | 1             | -        |
-| 2.4   | ⏳ Pending  | -    | -        | -             | -        |
-| 2.5   | ⏳ Pending  | -    | -        | -             | -        |
+| Story | Status         | PR   | Coverage | Review Rounds | Duration |
+| ----- | -------------- | ---- | -------- | ------------- | -------- |
+| 2.1   | ✅ Complete    | #123 | >80%     | 1             | ~4h      |
+| 2.2   | ✅ Complete    | #126 | -        | 2             | -        |
+| 2.3   | ✅ Complete    | #128 | -        | 1             | -        |
+| 2.4   | ✅ Complete    | #132 | -        | 1             | -        |
+| 2.5   | ✅ Complete    | #134 | -        | 1             | -        |
+| 2.6   | 🔄 In Progress | -    | -        | -             | -        |
+| 2.7   | ⏳ Pending     | -    | -        | -             | -        |
 
 ## Activity Log
 
@@ -43,3 +47,10 @@ stories:
 - [10:xx] Story 2.3: PR #128 created and merged to main
 - [10:xx] Story 2.3: DONE
 - [11:00] Epic 2 resumed for Stories 2.4, 2.5
+- [xx:xx] Story 2.4: PR #132 merged to main
+- [xx:xx] Story 2.4: DONE
+- [xx:xx] Story 2.5: PR #134 merged to main
+- [xx:xx] Story 2.5: DONE
+- [11:00] Epic 2 resumed for Stories 2.6, 2.7
+- [11:00] Story 2.6: Issue #135 created, branch story-2-6-api-key-crud created
+- [11:00] Story 2.6: Implementation started

--- a/infra/test/stacks/auth/auth.stack.test.ts
+++ b/infra/test/stacks/auth/auth.stack.test.ts
@@ -39,8 +39,8 @@ describe("AuthStack", () => {
   });
 
   describe("JWT Authorizer Lambda", () => {
-    it("creates all four Lambda functions (JWT, API Key, Users Me, Validate Invite)", () => {
-      template.resourceCountIs("AWS::Lambda::Function", 4);
+    it("creates all five Lambda functions (JWT, API Key, Users Me, Validate Invite, API Keys)", () => {
+      template.resourceCountIs("AWS::Lambda::Function", 5);
     });
 
     it("uses the latest Node.js runtime", () => {
@@ -111,13 +111,13 @@ describe("AuthStack", () => {
   });
 
   describe("API Key Authorizer Lambda", () => {
-    it("creates a Lambda with USERS_TABLE_NAME but without CLERK_SECRET_KEY_PARAM (API Key authorizer)", () => {
+    it("creates Lambdas with USERS_TABLE_NAME but without CLERK_SECRET_KEY_PARAM (API Key authorizer, Users Me, API Keys)", () => {
       const lambdas = template.findResources("AWS::Lambda::Function");
       const nonJwtLambdas = Object.entries(lambdas).filter(([, resource]) => {
         const envVars = resource.Properties?.Environment?.Variables ?? {};
         return envVars.USERS_TABLE_NAME && !envVars.CLERK_SECRET_KEY_PARAM;
       });
-      expect(nonJwtLambdas).toHaveLength(2);
+      expect(nonJwtLambdas).toHaveLength(3);
     });
 
     it("creates Lambdas with both USERS_TABLE_NAME and CLERK_SECRET_KEY_PARAM (JWT authorizer + validate-invite)", () => {
@@ -170,6 +170,16 @@ describe("AuthStack", () => {
     it("exports the validate invite function name", () => {
       const outputs = template.findOutputs("*");
       expect(outputs.ValidateInviteFunctionName).toBeDefined();
+    });
+
+    it("exports the API keys function ARN", () => {
+      const outputs = template.findOutputs("*");
+      expect(outputs.ApiKeysFunctionArn).toBeDefined();
+    });
+
+    it("exports the API keys function name", () => {
+      const outputs = template.findOutputs("*");
+      expect(outputs.ApiKeysFunctionName).toBeDefined();
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,8 @@
         "@ai-learning-hub/logging": "*",
         "@ai-learning-hub/types": "*",
         "@aws-sdk/client-dynamodb": "^3.490.0",
-        "@aws-sdk/lib-dynamodb": "^3.490.0"
+        "@aws-sdk/lib-dynamodb": "^3.490.0",
+        "ulidx": "^2.4.1"
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^3.2.4",
@@ -8927,6 +8928,12 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/layerr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/layerr/-/layerr-3.0.0.tgz",
+      "integrity": "sha512-tv754Ki2dXpPVApOrjTyRo4/QegVb9eVFq4mjqp4+NM5NaX7syQvN5BBNfV/ZpAHCEHV24XdUVrBAoka4jt3pA==",
+      "license": "MIT"
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -11329,6 +11336,18 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/ulidx": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/ulidx/-/ulidx-2.4.1.tgz",
+      "integrity": "sha512-xY7c8LPyzvhvew0Fn+Ek3wBC9STZAuDI/Y5andCKi9AX6/jvfaX45PhsDX8oxgPL0YFp0Jhr8qWMbS/p9375Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "layerr": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/unbox-primitive": {


### PR DESCRIPTION
## Summary

Implements Story 2.6: API Key CRUD — POST/GET/DELETE /users/api-keys for creating, listing, and revoking API keys.

Closes #135

## Changes

- **New Lambda handler** (`backend/functions/api-keys/handler.ts`): Routes POST (201 Created), GET (200), DELETE (204 No Content) with auth enforcement via `wrapHandler`
- **DB operations** (`backend/shared/db/src/users.ts`): `createApiKey` (256-bit random key, SHA-256 hash, ULID keyId, conditional write), `listApiKeys` (strips internal fields, pagination), `revokeApiKey` (soft delete via revokedAt)
- **Validation** (`backend/functions/api-keys/schemas.ts`): Name + scopes schema using shared `apiKeyScopesSchema`; scope deduplication via `.transform()`; reuses shared `paginationQuerySchema`; path param validation on DELETE
- **CDK infrastructure** (`infra/lib/stacks/auth/auth.stack.ts`): New `apiKeysFunction` Lambda with least-privilege IAM (PutItem, Query, UpdateItem on users table)
- **Tests**: 18 handler tests + DB-level tests covering AC1-AC6

## Acceptance Criteria

- [x] AC1: POST creates 256-bit key, stores SHA-256 hash, returns key once
- [x] AC2: GET returns list without key values
- [x] AC3: DELETE sets revokedAt (soft delete)
- [x] AC4: scopes: ['saves:write'] creates capture-only key
- [x] AC5: Rate limit error propagation tested (enforcement deferred to Story 2.7)
- [x] AC6: Invalid scopes return 400

## Test plan

- [x] All 614 tests pass (`npm run validate`)
- [x] Handler tests cover all HTTP methods, auth enforcement, validation errors
- [x] DB tests verify key generation, hash storage, list stripping, revocation
- [x] CDK tests verify Lambda count, IAM permissions, outputs
- [x] Secrets scan clean — no sensitive data in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)