### PR TITLE
feat: add rate limiting and throttling (Story 2.7) #137

### DIFF
--- a/backend/shared/db/src/index.ts
+++ b/backend/shared/db/src/index.ts
@@ -51,5 +51,15 @@ export {
   type InviteCodeItem,
 } from "./invite-codes.js";
 
+// Rate limiting operations
+export {
+  incrementAndCheckRateLimit,
+  enforceRateLimit,
+  getWindowKey,
+  getCounterTTL,
+  type RateLimitConfig,
+  type RateLimitResult,
+} from "./rate-limiter.js";
+
 // Re-export DynamoDB types for convenience
 export type { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";

--- a/backend/shared/db/src/rate-limiter.ts
+++ b/backend/shared/db/src/rate-limiter.ts
@@ -1,0 +1,183 @@
+/**
+ * Rate limiting with DynamoDB counters (Story 2.7).
+ *
+ * Uses hourly-partitioned counter items with TTL for automatic cleanup.
+ * Counter items: PK=RATELIMIT#<scope>#<identifier>, SK=<windowKey>
+ *
+ * Design: Fixed-window counters with 1-hour granularity. Each counter
+ * item has a TTL set to 2 hours after the window start, ensuring
+ * DynamoDB automatically deletes expired counters.
+ */
+import type { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { AppError, ErrorCode } from "@ai-learning-hub/types";
+import { createLogger, type Logger } from "@ai-learning-hub/logging";
+
+/**
+ * Rate limit configuration for a specific operation.
+ */
+export interface RateLimitConfig {
+  /** Operation identifier (e.g., "apikey-create", "invite-validate") */
+  operation: string;
+  /** Unique identifier for the subject (userId, IP address, etc.) */
+  identifier: string;
+  /** Maximum allowed requests in the time window */
+  limit: number;
+  /** Window size in seconds (e.g., 3600 for 1 hour) */
+  windowSeconds: number;
+}
+
+/**
+ * Result of a rate limit check.
+ */
+export interface RateLimitResult {
+  allowed: boolean;
+  current: number;
+  limit: number;
+  retryAfterSeconds?: number;
+}
+
+/**
+ * Get the window key for the current time period.
+ * Uses fixed windows aligned to hour boundaries.
+ */
+export function getWindowKey(windowSeconds: number, now?: Date): string {
+  const timestamp = now ?? new Date();
+  const epochSeconds = Math.floor(timestamp.getTime() / 1000);
+  const windowStart = epochSeconds - (epochSeconds % windowSeconds);
+  return String(windowStart);
+}
+
+/**
+ * Calculate TTL for a rate limit counter item.
+ * Set to 2x the window size to ensure cleanup after expiry.
+ */
+export function getCounterTTL(windowSeconds: number, now?: Date): number {
+  const timestamp = now ?? new Date();
+  const epochSeconds = Math.floor(timestamp.getTime() / 1000);
+  const windowStart = epochSeconds - (epochSeconds % windowSeconds);
+  return windowStart + windowSeconds * 2;
+}
+
+/**
+ * Increment and check a rate limit counter using DynamoDB atomic update.
+ *
+ * Uses UpdateItem with ADD to atomically increment the counter.
+ * Returns the new count so the caller can check against the limit.
+ *
+ * The counter item has:
+ * - PK: RATELIMIT#<operation>#<identifier>
+ * - SK: <windowKey>
+ * - count: atomic counter
+ * - ttl: epoch seconds for DynamoDB TTL
+ */
+// NOTE: The counter is incremented unconditionally before checking the limit.
+// This means the counter may exceed the configured limit (e.g., showing 15 when
+// the limit is 10) because rejected requests still increment it. This is by
+// design for simplicity — the limit check still works correctly, and the counter
+// resets naturally when the window expires. The inflated count may appear in logs
+// and error responses but does not affect correctness.
+export async function incrementAndCheckRateLimit(
+  client: DynamoDBDocumentClient,
+  tableName: string,
+  config: RateLimitConfig,
+  logger?: Logger
+): Promise<RateLimitResult> {
+  const log = logger ?? createLogger();
+  const now = new Date();
+  const windowKey = getWindowKey(config.windowSeconds, now);
+  const ttl = getCounterTTL(config.windowSeconds, now);
+
+  const pk = `RATELIMIT#${config.operation}#${config.identifier}`;
+
+  try {
+    const result = await client.send(
+      new UpdateCommand({
+        TableName: tableName,
+        Key: { PK: pk, SK: windowKey },
+        UpdateExpression:
+          "ADD #count :inc SET #ttl = if_not_exists(#ttl, :ttl)",
+        ExpressionAttributeNames: {
+          "#count": "count",
+          "#ttl": "ttl",
+        },
+        ExpressionAttributeValues: {
+          ":inc": 1,
+          ":ttl": ttl,
+        },
+        ReturnValues: "ALL_NEW",
+      })
+    );
+
+    const current = (result.Attributes?.count as number) ?? 1;
+    const allowed = current <= config.limit;
+
+    if (!allowed) {
+      // Calculate seconds remaining in this window for Retry-After
+      const epochSeconds = Math.floor(now.getTime() / 1000);
+      const windowStart = epochSeconds - (epochSeconds % config.windowSeconds);
+      const retryAfterSeconds =
+        windowStart + config.windowSeconds - epochSeconds;
+
+      log.warn("Rate limit exceeded", {
+        operation: config.operation,
+        identifier: config.identifier,
+        current,
+        limit: config.limit,
+        retryAfterSeconds,
+      });
+
+      return {
+        allowed: false,
+        current,
+        limit: config.limit,
+        retryAfterSeconds,
+      };
+    }
+
+    log.debug("Rate limit check passed", {
+      operation: config.operation,
+      current,
+      limit: config.limit,
+    });
+
+    return { allowed: true, current, limit: config.limit };
+  } catch (error) {
+    // On DynamoDB errors, fail open — don't block requests due to rate limit infra issues
+    log.error("Rate limit check failed, allowing request", error as Error, {
+      operation: config.operation,
+      identifier: config.identifier,
+    });
+    return { allowed: true, current: 0, limit: config.limit };
+  }
+}
+
+/**
+ * Check rate limit and throw RATE_LIMITED error if exceeded.
+ * Convenience wrapper around incrementAndCheckRateLimit.
+ */
+export async function enforceRateLimit(
+  client: DynamoDBDocumentClient,
+  tableName: string,
+  config: RateLimitConfig,
+  logger?: Logger
+): Promise<void> {
+  const result = await incrementAndCheckRateLimit(
+    client,
+    tableName,
+    config,
+    logger
+  );
+
+  if (!result.allowed) {
+    throw new AppError(
+      ErrorCode.RATE_LIMITED,
+      `Rate limit exceeded: ${config.limit} ${config.operation} per ${config.windowSeconds / 3600} hour(s)`,
+      {
+        retryAfter: result.retryAfterSeconds,
+        limit: result.limit,
+        current: result.current,
+      }
+    );
+  }
+}

--- a/backend/shared/db/test/rate-limiter.test.ts
+++ b/backend/shared/db/test/rate-limiter.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for rate limiting DynamoDB operations (Story 2.7)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  getWindowKey,
+  getCounterTTL,
+  incrementAndCheckRateLimit,
+  enforceRateLimit,
+  type RateLimitConfig,
+} from "../src/rate-limiter.js";
+
+// Mock the DynamoDB DocumentClient
+const mockSend = vi.fn();
+const mockClient = {
+  send: mockSend,
+} as unknown as import("@aws-sdk/lib-dynamodb").DynamoDBDocumentClient;
+
+// Mock logging
+vi.mock("@ai-learning-hub/logging", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    timed: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+    setRequestContext: vi.fn(),
+  }),
+}));
+
+const TABLE_NAME = "ai-learning-hub-users";
+
+describe("getWindowKey", () => {
+  it("returns a string representing the window start epoch", () => {
+    // 2026-02-16 14:30:00 UTC = epoch 1771339800
+    const now = new Date("2026-02-16T14:30:00Z");
+    const key = getWindowKey(3600, now);
+    // Window start should be aligned to hour: 14:00:00 UTC = 1771338000
+    expect(key).toBe(
+      String(
+        Math.floor(now.getTime() / 1000) -
+          (Math.floor(now.getTime() / 1000) % 3600)
+      )
+    );
+  });
+
+  it("produces same key for times within the same window", () => {
+    const now1 = new Date("2026-02-16T14:00:01Z");
+    const now2 = new Date("2026-02-16T14:59:59Z");
+    expect(getWindowKey(3600, now1)).toBe(getWindowKey(3600, now2));
+  });
+
+  it("produces different keys for times in different windows", () => {
+    const now1 = new Date("2026-02-16T13:59:59Z");
+    const now2 = new Date("2026-02-16T14:00:01Z");
+    expect(getWindowKey(3600, now1)).not.toBe(getWindowKey(3600, now2));
+  });
+});
+
+describe("getCounterTTL", () => {
+  it("returns TTL set to 2x the window after window start", () => {
+    const now = new Date("2026-02-16T14:30:00Z");
+    const ttl = getCounterTTL(3600, now);
+    const epochSeconds = Math.floor(now.getTime() / 1000);
+    const windowStart = epochSeconds - (epochSeconds % 3600);
+    // TTL should be windowStart + 2 * 3600
+    expect(ttl).toBe(windowStart + 7200);
+  });
+});
+
+describe("incrementAndCheckRateLimit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const config: RateLimitConfig = {
+    operation: "apikey-create",
+    identifier: "user_123",
+    limit: 10,
+    windowSeconds: 3600,
+  };
+
+  it("returns allowed=true when under the limit", async () => {
+    mockSend.mockResolvedValueOnce({
+      Attributes: { count: 5 },
+    });
+
+    const result = await incrementAndCheckRateLimit(
+      mockClient,
+      TABLE_NAME,
+      config
+    );
+
+    expect(result.allowed).toBe(true);
+    expect(result.current).toBe(5);
+    expect(result.limit).toBe(10);
+    expect(result.retryAfterSeconds).toBeUndefined();
+  });
+
+  it("returns allowed=true when exactly at the limit", async () => {
+    mockSend.mockResolvedValueOnce({
+      Attributes: { count: 10 },
+    });
+
+    const result = await incrementAndCheckRateLimit(
+      mockClient,
+      TABLE_NAME,
+      config
+    );
+
+    expect(result.allowed).toBe(true);
+    expect(result.current).toBe(10);
+  });
+
+  it("returns allowed=false when over the limit", async () => {
+    mockSend.mockResolvedValueOnce({
+      Attributes: { count: 11 },
+    });
+
+    const result = await incrementAndCheckRateLimit(
+      mockClient,
+      TABLE_NAME,
+      config
+    );
+
+    expect(result.allowed).toBe(false);
+    expect(result.current).toBe(11);
+    expect(result.limit).toBe(10);
+    expect(result.retryAfterSeconds).toBeDefined();
+    expect(result.retryAfterSeconds).toBeGreaterThan(0);
+    expect(result.retryAfterSeconds).toBeLessThanOrEqual(3600);
+  });
+
+  it("sends correct DynamoDB UpdateCommand", async () => {
+    mockSend.mockResolvedValueOnce({
+      Attributes: { count: 1 },
+    });
+
+    await incrementAndCheckRateLimit(mockClient, TABLE_NAME, config);
+
+    expect(mockSend).toHaveBeenCalledOnce();
+    const command = mockSend.mock.calls[0][0];
+    expect(command.input.TableName).toBe(TABLE_NAME);
+    expect(command.input.Key.PK).toBe("RATELIMIT#apikey-create#user_123");
+    expect(command.input.Key.SK).toBeDefined();
+    expect(command.input.UpdateExpression).toContain("ADD #count :inc");
+    expect(command.input.ExpressionAttributeValues[":inc"]).toBe(1);
+    expect(command.input.ExpressionAttributeValues[":ttl"]).toBeDefined();
+    expect(command.input.ReturnValues).toBe("ALL_NEW");
+  });
+
+  it("fails open on DynamoDB errors (does not block requests)", async () => {
+    mockSend.mockRejectedValueOnce(new Error("DynamoDB throttled"));
+
+    const result = await incrementAndCheckRateLimit(
+      mockClient,
+      TABLE_NAME,
+      config
+    );
+
+    expect(result.allowed).toBe(true);
+    expect(result.current).toBe(0);
+  });
+
+  it("uses correct PK format for IP-based rate limiting", async () => {
+    mockSend.mockResolvedValueOnce({
+      Attributes: { count: 1 },
+    });
+
+    const ipConfig: RateLimitConfig = {
+      operation: "invite-validate",
+      identifier: "192.168.1.1",
+      limit: 5,
+      windowSeconds: 3600,
+    };
+
+    await incrementAndCheckRateLimit(mockClient, TABLE_NAME, ipConfig);
+
+    const command = mockSend.mock.calls[0][0];
+    expect(command.input.Key.PK).toBe("RATELIMIT#invite-validate#192.168.1.1");
+  });
+});
+
+describe("enforceRateLimit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const config: RateLimitConfig = {
+    operation: "apikey-create",
+    identifier: "user_123",
+    limit: 10,
+    windowSeconds: 3600,
+  };
+
+  it("does not throw when under the limit", async () => {
+    mockSend.mockResolvedValueOnce({
+      Attributes: { count: 5 },
+    });
+
+    await expect(
+      enforceRateLimit(mockClient, TABLE_NAME, config)
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws RATE_LIMITED when over the limit (AC3)", async () => {
+    expect.assertions(5);
+
+    mockSend.mockResolvedValueOnce({
+      Attributes: { count: 11 },
+    });
+
+    await expect(
+      enforceRateLimit(mockClient, TABLE_NAME, config)
+    ).rejects.toThrow("Rate limit exceeded");
+
+    try {
+      mockSend.mockResolvedValueOnce({ Attributes: { count: 12 } });
+      await enforceRateLimit(mockClient, TABLE_NAME, config);
+    } catch (error) {
+      const { AppError, ErrorCode } = await import("@ai-learning-hub/types");
+      expect(error).toBeInstanceOf(AppError);
+      expect((error as InstanceType<typeof AppError>).code).toBe(
+        ErrorCode.RATE_LIMITED
+      );
+      expect((error as InstanceType<typeof AppError>).statusCode).toBe(429);
+      expect((error as InstanceType<typeof AppError>).details).toHaveProperty(
+        "retryAfter"
+      );
+    }
+  });
+
+  it("includes retryAfter in error details (AC3)", async () => {
+    expect.assertions(4);
+
+    mockSend.mockResolvedValueOnce({
+      Attributes: { count: 11 },
+    });
+
+    try {
+      await enforceRateLimit(mockClient, TABLE_NAME, config);
+    } catch (error) {
+      const err = error as { details?: Record<string, unknown> };
+      expect(err.details?.retryAfter).toBeDefined();
+      expect(typeof err.details?.retryAfter).toBe("number");
+      expect(err.details?.limit).toBe(10);
+      expect(err.details?.current).toBe(11);
+    }
+  });
+});

--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -7,6 +7,7 @@ import { TablesStack } from "../lib/stacks/core/tables.stack";
 import { BucketsStack } from "../lib/stacks/core/buckets.stack";
 import { ObservabilityStack } from "../lib/stacks/observability/observability.stack";
 import { AuthStack } from "../lib/stacks/auth/auth.stack";
+import { RateLimitingStack } from "../lib/stacks/api/rate-limiting.stack";
 
 const app = new cdk.App();
 
@@ -47,8 +48,25 @@ const observabilityStack = new ObservabilityStack(
   }
 );
 
+// Rate Limiting Stack - WAF + API Gateway throttling config (Story 2.7, AC1)
+const rateLimitingStack = new RateLimitingStack(
+  app,
+  "AiLearningHubRateLimiting",
+  {
+    env: awsEnv,
+    description:
+      "Rate limiting for ai-learning-hub (WAF rate-based rules, API Gateway throttling config)",
+  }
+);
+
 // Export stack instances for future cross-stack references (avoids unused variable lint errors)
-export { tablesStack, bucketsStack, authStack, observabilityStack };
+export {
+  tablesStack,
+  bucketsStack,
+  authStack,
+  observabilityStack,
+  rateLimitingStack,
+};
 
 cdk.Tags.of(app).add("Project", "ai-learning-hub");
 cdk.Tags.of(app).add("ManagedBy", "CDK");

--- a/infra/lib/stacks/api/rate-limiting.stack.ts
+++ b/infra/lib/stacks/api/rate-limiting.stack.ts
@@ -1,0 +1,88 @@
+/**
+ * Rate Limiting Stack (Story 2.7, AC1)
+ *
+ * Layer 1: Infrastructure-level rate limiting.
+ * - WAF WebACL with rate-based rule: 500 requests per 5 minutes per IP
+ * - API Gateway throttling settings: 100 requests/second (default stage)
+ *
+ * The WebACL is created as a standalone resource. It will be associated
+ * with the API Gateway REST API when the API stack is created (future epic).
+ * The throttle settings are exported as outputs for the API stack to consume.
+ */
+import * as cdk from "aws-cdk-lib";
+import * as wafv2 from "aws-cdk-lib/aws-wafv2";
+import { NagSuppressions } from "cdk-nag";
+import { Construct } from "constructs";
+
+export class RateLimitingStack extends cdk.Stack {
+  public readonly webAcl: wafv2.CfnWebACL;
+
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // WAF WebACL with rate-based rule (AC1: 500 req/5min per IP)
+    this.webAcl = new wafv2.CfnWebACL(this, "ApiRateLimitWebAcl", {
+      name: "ai-learning-hub-api-rate-limit",
+      scope: "REGIONAL",
+      defaultAction: { allow: {} },
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: true,
+        metricName: "AiLearningHubApiRateLimit",
+        sampledRequestsEnabled: true,
+      },
+      rules: [
+        {
+          name: "RateBasedRule",
+          priority: 1,
+          action: { block: {} },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: "AiLearningHubRateBasedRule",
+            sampledRequestsEnabled: true,
+          },
+          statement: {
+            rateBasedStatement: {
+              // 500 requests per 5 minutes per IP (AC1)
+              // WAF evaluates over a rolling 5-minute window
+              limit: 500,
+              aggregateKeyType: "IP",
+            },
+          },
+        },
+      ],
+    });
+
+    NagSuppressions.addResourceSuppressions(
+      this.webAcl,
+      [
+        {
+          id: "AwsSolutions-WAF1",
+          reason:
+            "WAF logging will be configured when API Gateway stack is created. Rate limiting stack is preparatory.",
+        },
+      ],
+      true
+    );
+
+    // Outputs for API Gateway stack to consume
+    new cdk.CfnOutput(this, "WebAclArn", {
+      value: this.webAcl.attrArn,
+      description: "WAF WebACL ARN for API Gateway association",
+      exportName: "AiLearningHub-RateLimitWebAclArn",
+    });
+
+    // Export recommended throttling settings for API Gateway stage (AC1: 100 req/s)
+    new cdk.CfnOutput(this, "RecommendedThrottleRate", {
+      value: "100",
+      description:
+        "Recommended API Gateway throttle rate (requests/second) per AC1",
+      exportName: "AiLearningHub-ApiThrottleRate",
+    });
+
+    new cdk.CfnOutput(this, "RecommendedThrottleBurst", {
+      value: "200",
+      description: "Recommended API Gateway throttle burst capacity",
+      exportName: "AiLearningHub-ApiThrottleBurst",
+    });
+  }
+}

--- a/infra/lib/stacks/auth/auth.stack.ts
+++ b/infra/lib/stacks/auth/auth.stack.ts
@@ -315,8 +315,13 @@ export class AuthStack extends cdk.Stack {
     // Grant read/write to invite-codes table (GetItem for lookup, UpdateItem for redemption)
     inviteCodesTable.grantReadWriteData(this.validateInviteFunction);
 
-    // Grant read to users table (for profile checks)
-    usersTable.grantReadData(this.validateInviteFunction);
+    // Grant least-privilege: only UpdateItem needed for rate limit counter increments (Story 2.7)
+    this.validateInviteFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["dynamodb:UpdateItem"],
+        resources: [usersTable.tableArn],
+      })
+    );
 
     // Grant read access to Clerk secret key in SSM Parameter Store
     this.validateInviteFunction.addToRolePolicy(

--- a/infra/lib/stacks/core/tables.stack.ts
+++ b/infra/lib/stacks/core/tables.stack.ts
@@ -29,6 +29,7 @@ export class TablesStack extends cdk.Stack {
       pointInTimeRecoverySpecification: {
         pointInTimeRecoveryEnabled: true,
       },
+      timeToLiveAttribute: "ttl",
       removalPolicy: cdk.RemovalPolicy.RETAIN,
     });
 

--- a/infra/test/stacks/api/rate-limiting.stack.test.ts
+++ b/infra/test/stacks/api/rate-limiting.stack.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Rate Limiting Stack tests (Story 2.7, AC1)
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { RateLimitingStack } from "../../../lib/stacks/api/rate-limiting.stack";
+import { getAwsEnv } from "../../../config/aws-env";
+
+describe("RateLimitingStack", () => {
+  let template: Template;
+
+  beforeAll(() => {
+    const app = new cdk.App();
+    const awsEnv = getAwsEnv();
+    const stack = new RateLimitingStack(app, "TestRateLimiting", {
+      env: awsEnv,
+    });
+    template = Template.fromStack(stack);
+  });
+
+  describe("WAF WebACL (AC1)", () => {
+    it("creates a WAF WebACL", () => {
+      template.resourceCountIs("AWS::WAFv2::WebACL", 1);
+    });
+
+    it("uses REGIONAL scope for API Gateway", () => {
+      template.hasResourceProperties("AWS::WAFv2::WebACL", {
+        Scope: "REGIONAL",
+      });
+    });
+
+    it("has a rate-based rule with 500 req/5min limit", () => {
+      template.hasResourceProperties("AWS::WAFv2::WebACL", {
+        Rules: [
+          {
+            Name: "RateBasedRule",
+            Action: { Block: {} },
+            Statement: {
+              RateBasedStatement: {
+                Limit: 500,
+                AggregateKeyType: "IP",
+              },
+            },
+          },
+        ],
+      });
+    });
+
+    it("enables CloudWatch metrics", () => {
+      template.hasResourceProperties("AWS::WAFv2::WebACL", {
+        VisibilityConfig: {
+          CloudWatchMetricsEnabled: true,
+          SampledRequestsEnabled: true,
+        },
+      });
+    });
+
+    it("has default allow action", () => {
+      template.hasResourceProperties("AWS::WAFv2::WebACL", {
+        DefaultAction: { Allow: {} },
+      });
+    });
+  });
+
+  describe("Outputs", () => {
+    it("exports the WebACL ARN", () => {
+      const outputs = template.findOutputs("*");
+      expect(outputs.WebAclArn).toBeDefined();
+    });
+
+    it("exports the recommended throttle rate", () => {
+      const outputs = template.findOutputs("*");
+      expect(outputs.RecommendedThrottleRate).toBeDefined();
+    });
+
+    it("exports the recommended throttle burst", () => {
+      const outputs = template.findOutputs("*");
+      expect(outputs.RecommendedThrottleBurst).toBeDefined();
+    });
+  });
+});

--- a/infra/test/stacks/core/tables.stack.test.ts
+++ b/infra/test/stacks/core/tables.stack.test.ts
@@ -152,6 +152,16 @@ describe("TablesStack", () => {
       });
     });
 
+    it("should enable TTL on users table for rate limit counter cleanup", () => {
+      template.hasResourceProperties("AWS::DynamoDB::Table", {
+        TableName: "ai-learning-hub-users",
+        TimeToLiveSpecification: {
+          AttributeName: "ttl",
+          Enabled: true,
+        },
+      });
+    });
+
     it("should use on-demand billing mode", () => {
       const tables = template.findResources("AWS::DynamoDB::Table");
       Object.values(tables).forEach((table) => {


### PR DESCRIPTION
## Summary
- Add DynamoDB-backed rate limiting with fixed-window counters and TTL auto-cleanup
- Add WAF WebACL with rate-based rule (500 req/5min per IP) as CDK stack
- Wire per-endpoint rate limits: POST /users/api-keys (10/hr/user), POST /auth/validate-invite (5/hr/IP)
- Add Retry-After HTTP header on 429 responses
- Enable DynamoDB TTL on users table for counter cleanup

## Changes

### New Files
- `backend/shared/db/src/rate-limiter.ts` — DynamoDB counter operations with atomic increment
- `backend/shared/db/test/rate-limiter.test.ts` — 13 unit tests for rate limiter
- `infra/lib/stacks/api/rate-limiting.stack.ts` — CDK WAF WebACL stack
- `infra/test/stacks/api/rate-limiting.stack.test.ts` — CDK tests for WAF stack

### Modified Files
- `backend/functions/api-keys/handler.ts` — Wired enforceRateLimit (10/hr/user)
- `backend/functions/validate-invite/handler.ts` — Wired enforceRateLimit (5/hr/IP)
- `backend/shared/middleware/src/error-handler.ts` — Retry-After header for 429s
- `infra/lib/stacks/core/tables.stack.ts` — TTL enabled on users table
- `infra/lib/stacks/auth/auth.stack.ts` — Scoped IAM for rate limit counters
- `infra/bin/app.ts` — RateLimitingStack instantiation

## Acceptance Criteria
- [x] AC1: WAF WebACL rate-based rule (500 req/5min/IP), API Gateway throttle settings exported
- [x] AC3: DynamoDB fixed-window counters with TTL auto-cleanup
- [x] AC4: Per-endpoint rate limits wired into handlers
- [x] AC5: 429 response with Retry-After HTTP header
- [x] AC6: Rate limit counters in existing users table (no new table)

## Test plan
- [ ] 665 tests pass (npm run validate)
- [ ] Rate limiter unit tests cover: under/at/over limit, fail-open, DynamoDB command format
- [ ] Middleware tests verify Retry-After header on 429 responses
- [ ] CDK tests verify WAF WebACL, TTL, and stack outputs
- [ ] Secrets scan clean on all changed files

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)