### PR TITLE
docs: add story artifacts for 3-1c (Events package) and 3-2 (List & Get Saves API)

### DIFF
--- a/_bmad-output/implementation-artifacts/3-1b-create-save-api.md
+++ b/_bmad-output/implementation-artifacts/3-1b-create-save-api.md
@@ -1,0 +1,475 @@
+---
+id: "3.1b"
+title: "Create Save API"
+status: ready-for-dev
+depends_on:
+  - 3-1a-save-validation-modules
+  - 3-1c-events-shared-package
+touches:
+  - backend/functions/saves
+  - backend/shared/db
+  - infra/lib/stacks
+  - infra/config/route-registry.ts
+risk: medium-high
+---
+
+# Story 3.1b: Create Save API
+
+Status: ready-for-dev
+
+## Story
+
+As a user (web, Shortcut, or API),
+I want to save a URL with optional metadata,
+so that the URL is stored in my library and available for organization, enrichment, and recall.
+
+## Acceptance Criteria
+
+| #   | Given                                                    | When                                                                       | Then                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --- | -------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC1 | User authenticated (JWT or API key)                      | `POST /saves` with body `{ url, title?, userNotes?, contentType?, tags? }` | URL normalized using `normalizeUrl()` from `@ai-learning-hub/validation`. `urlHash` = SHA-256 of `normalizedUrl`. Input validated using `createSaveSchema` from `@ai-learning-hub/validation`.                                                                                                                                                                                                          |
+| AC2 | Normalized URL has not been saved by this user           | Save creation                                                              | New item written to `saves` table: `PK=USER#<userId>`, `SK=SAVE#<ULID>` with all attributes + `linkedProjectCount: 0`, `isTutorial: false`; `tutorialStatus` attribute is **omitted entirely** (not set to null) to avoid polluting the `userId-tutorialStatus-index` GSI; returns 201 with save object |
+| AC3 | Normalized URL already saved by this user (same urlHash) | Save creation                                                              | Returns 409 with body `{ error: { code: 'DUPLICATE_SAVE', message: 'URL already saved', requestId: '<correlation-id>' }, existingSave: {...} }` — `existingSave` is a sibling of `error` (not nested inside it) to keep the `error` object compliant with ADR-008's standard shape                                                                                                                      |
+| AC4 | Save created successfully                                | After DynamoDB write                                                       | EventBridge event emitted: `source: 'ai-learning-hub.saves'`, `detailType: 'SaveCreated'`, detail includes `{ userId, saveId, url, normalizedUrl, urlHash, contentType }`                                                                                                                                                                                                                               |
+| AC5 | URL provided without contentType                         | Save creation                                                              | System calls `detectContentType()` from `@ai-learning-hub/validation`. User-provided `contentType` always takes precedence.                                                                                                                                                                                                                                                                             |
+| AC6 | Any warm invocation                                      | POST /saves                                                                | Response time < 1 second (NFR-P2). Cold start may exceed per ADR-016. EventBridge `PutEvents` is **fire-and-forget** (`void` — not awaited) so it is off the critical path; the response is returned before the event emission completes. |
+| AC7 | Any request                                              | Handler executes                                                           | Lambda uses `@ai-learning-hub/logging`, `@ai-learning-hub/middleware`, `@ai-learning-hub/db`, `@ai-learning-hub/validation`. Rate limiting inherited from Epic 2 middleware (Story 2.7): POST /saves is a write operation.                                                                                                                                                                              |
+| AC8 | Duplicate check                                          | Before DynamoDB write                                                      | **Layer 1:** Query GSI `urlHash-index` with `urlHash = <hash>`, FilterExpression `PK = USER#<userId> AND attribute_not_exists(deletedAt)`. **Layer 2:** TransactWriteItems atomically writes save item + uniqueness marker `PK=USER#<userId>, SK=URL#<urlHash>` with ConditionExpression `attribute_not_exists(SK)` on marker. If condition fails → 409. Two-layer guard mitigates TOCTOU race.          |
+| AC9 | URL was previously saved then soft-deleted               | `POST /saves` with same URL                                                | Layer 1 passes (deleted save filtered out), Layer 2 condition fails (marker still exists). Handler re-queries for the soft-deleted save via GSI (see Dev Notes), clears `deletedAt` using `ConditionExpression: attribute_exists(deletedAt)` (so only one concurrent restore wins), emits `SaveRestored` event (`source: 'ai-learning-hub.saves'`, `detailType: 'SaveRestored'`, detail includes `{ userId, saveId, url, normalizedUrl, urlHash, contentType }`), returns 200 with restored save. iOS Shortcut treats both 201 and 200 as success. If no soft-deleted save is found (orphaned marker), log anomaly and return 500 INTERNAL_ERROR. |
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Add `transactWriteItems` helper to `@ai-learning-hub/db` (AC: #8)
+  - [ ] 1.1 Create `backend/shared/db/src/transact.ts` with `transactWriteItems(client, transactItems, logger?)` function using `TransactWriteCommand` from `@aws-sdk/lib-dynamodb`
+  - [ ] 1.2 Map `TransactionCanceledException` to a typed result (return reason codes: `ConditionalCheckFailed` per item index) so callers can distinguish which item caused failure
+  - [ ] 1.3 Export `transactWriteItems` and `TransactionCancelledError` from `backend/shared/db/src/index.ts`
+  - [ ] 1.4 Add unit tests in `backend/shared/db/test/transact.test.ts`
+
+- [ ] Task 2: Create the saves-create Lambda handler (AC: all)
+  - [ ] 2.1 Create `backend/functions/saves/handler.ts` (route: POST /saves)
+  - [ ] 2.2 Implement `SAVES_TABLE_CONFIG` using `process.env.SAVES_TABLE_NAME ?? 'ai-learning-hub-saves'`
+  - [ ] 2.3 Implement Layer 1 duplicate check: Query `urlHash-index` GSI with `urlHash = :hash`, FilterExpression `PK = :pk AND attribute_not_exists(deletedAt)`
+  - [ ] 2.4 Build save item: generate `saveId` with `ulid()`, `PK=USER#<userId>`, `SK=SAVE#<saveId>`, all fields from story notes (see Full Save Item Shape)
+  - [ ] 2.5 Implement Layer 2: `transactWriteItems` writing save item + marker item `SK=URL#<urlHash>` with `ConditionExpression: attribute_not_exists(SK)` on marker
+  - [ ] 2.6 Implement Layer 2 failure handling (three sub-paths):
+    - Re-query `urlHash-index` GSI (same as Layer 1) for active save → return 409 with `existingSave`
+    - Query `urlHash-index` GSI without `attribute_not_exists(deletedAt)` filter to find soft-deleted save → `updateItem` with `UpdateExpression: 'REMOVE deletedAt SET updatedAt = :now'` and **`ConditionExpression: attribute_exists(deletedAt)`** (prevents double-restore in concurrent requests) → emit `SaveRestored` event (fire-and-forget) → return 200 with restored save
+    - If neither active nor soft-deleted save found (orphaned marker — data anomaly): log error with `requestId` for investigation and return 500 `INTERNAL_ERROR` with message `'Save state inconsistency detected'`
+  - [ ] 2.7 Emit events using `emitEvent` from `@ai-learning-hub/events` as **fire-and-forget** (`void emitEvent(...)` — do NOT await); `emitEvent` catches and logs its own errors internally; calling code returns the API response immediately without waiting for event delivery. See Dev Notes — EventBridge for the exact call site.
+  - [ ] 2.8 Export `handler = wrapHandler(savesCreateHandler, { requireAuth: true })`
+
+- [ ] Task 3: Create EventBridge CDK stack (AC: #4)
+  - [ ] 3.1 Create `infra/lib/stacks/core/events.stack.ts` with a custom `EventBus` named `ai-learning-hub-events`
+  - [ ] 3.2 Export `eventBus` as a public property; output `EventBusName` and `EventBusArn` as CloudFormation exports
+  - [ ] 3.3 Pass `EVENT_BUS_NAME` env var to saves-create Lambda (set to `eventBus.eventBusName`)
+
+- [ ] Task 4: Wire saves-create Lambda in CDK (AC: #7)
+  - [ ] 4.1 Create `infra/lib/stacks/api/saves-routes.stack.ts` containing the saves-create Lambda (`NodejsFunction`)
+  - [ ] 4.2 Lambda config: `memorySize: 256`, `timeout: 10s`, `tracing: ACTIVE`, env vars `SAVES_TABLE_NAME` + `EVENT_BUS_NAME`
+  - [ ] 4.3 Grant IAM permissions: `savesTable.grantReadWriteData(savesCreateFunction)` (saves CRUD) + `usersTable.grantReadWriteData(savesCreateFunction)` (**required** — `enforceRateLimit` writes counter items to the users table) + `events:PutEvents` on the event bus ARN via an `iam.PolicyStatement`
+  - [ ] 4.4 Register route in `infra/config/route-registry.ts`: `{ path: '/saves', methods: ['POST'], authType: 'jwt-or-apikey', handlerRef: 'savesCreateFunction', epic: 'Epic-3' }`
+  - [ ] 4.5 Extend `HandlerRef` union type to include `'savesCreateFunction'`
+  - [ ] 4.6 Wire the route in `infra/lib/stacks/api/saves-routes.stack.ts` following the auth-routes pattern (add API Gateway resource + method pointing at the Lambda)
+  - [ ] 4.7 Update `infra/bin/app.ts` to instantiate `EventsStack` and `SavesRoutesStack`; pass `savesTable` **and** `usersTable` from `TablesStack` as props to `SavesRoutesStack` so Task 4.3 grants are possible
+
+- [ ] Task 5: Write comprehensive tests (AC: all)
+  - [ ] 5.1 Unit tests: create handler — 201 on fresh URL, 409 on active duplicate (both Layer 1 fast-path and Layer 2 transaction failure paths), 200 auto-restore on re-save-after-delete, 400 invalid URL, 400 embedded credentials URL, tags trimmed+deduplicated on create
+  - [ ] 5.2 Integration test: EventBridge event emitted includes `normalizedUrl`, `urlHash`, `contentType` — mock `@ai-learning-hub/events` and verify `emitEvent` was called with correct `source`, `detailType`, and `detail` fields
+  - [ ] 5.3 Test: concurrent duplicate guard — two simultaneous POST requests for same URL; verify Layer 2 TransactWriteItems ConditionExpression blocks the second write
+  - [ ] 5.4 Test: EventBridge failure does NOT fail the API response — mock `PutEvents` throwing; verify 201 still returned. Then call `await flushPromises()` (defined as `new Promise(resolve => setTimeout(resolve, 0))`) before asserting `logger.warn` was called with the EventBridge error. The async work runs in a detached IIFE; the event loop must advance before side effects are visible. Do NOT use `vi.runAllMicrotasksAsync()` — it does not exist in Vitest 3.x.
+  - [ ] 5.5 Test: `SAVES_TABLE_CONFIG` reads from `process.env.SAVES_TABLE_NAME`
+  - [ ] 5.6 Architecture enforcement tests (T1–T4 in `infra/test/stacks/api/route-registry.test.ts`) must continue to pass after adding new route entry
+
+- [ ] Task 6: Verify build and quality gates
+  - [ ] 6.1 `npm test` — all tests pass (including existing 1,243 tests from 3.1a + new tests)
+  - [ ] 6.2 `npm run lint` — no errors
+  - [ ] 6.3 `npm run build` — clean TypeScript compilation
+  - [ ] 6.4 `npm run type-check` — no type errors
+  - [ ] 6.5 Verify `npm run format` has been run on all changed files
+
+## Dev Notes
+
+### Critical: Modules From Story 3.1a (DO NOT Reinvent)
+
+Story 3.1a is done (PR #156). Import everything directly from `@ai-learning-hub/validation`:
+
+```typescript
+import {
+  normalizeUrl,
+  detectContentType,
+  createSaveSchema,
+  validateJsonBody,
+  NormalizeError,
+} from '@ai-learning-hub/validation';
+```
+
+`normalizeUrl(rawUrl)` returns `{ normalizedUrl: string, urlHash: string }` or throws `NormalizeError` (which maps to `VALIDATION_ERROR`).
+
+`detectContentType(url, userProvidedContentType?)` returns the `ContentType` — user-provided value always wins.
+
+`createSaveSchema` validates the request body: `{ url, title?, userNotes?, contentType?, tags? }`.
+
+### Full Save Item Shape
+
+```typescript
+const saveItem = {
+  PK: `USER#${userId}`,
+  SK: `SAVE#${saveId}`,           // ULID — sort-friendly, chronological
+  userId,
+  saveId,
+  url,                             // original URL as submitted
+  normalizedUrl,                   // from normalizeUrl()
+  urlHash,                         // SHA-256 of normalizedUrl, from normalizeUrl()
+  ...(body.title !== undefined && { title: body.title }),
+  ...(body.userNotes !== undefined && { userNotes: body.userNotes }),
+  contentType,                     // from detectContentType() or user-provided
+  tags: body.tags ?? [],
+  isTutorial: false,
+  // tutorialStatus is intentionally OMITTED (not set to null) so this item is not
+  // projected into the userId-tutorialStatus-index GSI, keeping the GSI clean.
+  linkedProjectCount: 0,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+```
+
+### Uniqueness Marker Item
+
+```typescript
+const markerItem = {
+  PK: `USER#${userId}`,
+  SK: `URL#${urlHash}`,           // NOT SAVE# — different SK prefix prevents collision with save item
+};
+```
+
+The marker is NEVER removed (not on soft-delete, not on restore). It permanently occupies the URL slot for this user. This ensures Layer 2 always blocks a second concurrent create for the same URL.
+
+### ULID Usage
+
+```typescript
+import { ulid } from 'ulid';
+const saveId = ulid();
+```
+
+`ulid` is already in the workspace (check `package.json` at root; it was added for Epic 1 or 2). If missing: `npm install ulid`.
+
+### DynamoDB Table Config Pattern
+
+Follow the existing pattern from `@ai-learning-hub/db`:
+
+```typescript
+import { type TableConfig } from '@ai-learning-hub/db';
+
+const SAVES_TABLE_CONFIG: TableConfig = {
+  tableName: process.env.SAVES_TABLE_NAME ?? 'ai-learning-hub-saves',
+  partitionKey: 'PK',
+  sortKey: 'SK',
+};
+```
+
+The saves table is `ai-learning-hub-saves` (confirmed in `infra/lib/stacks/core/tables.stack.ts` line 46).
+
+### TransactWriteItems — New Helper Required
+
+The `@ai-learning-hub/db` package does NOT currently export `transactWriteItems`. You MUST add it (Task 1) before using it in the handler. Do NOT use the DynamoDB SDK directly in the handler — that violates the import-guard rule.
+
+The helper signature should be:
+
+```typescript
+export async function transactWriteItems(
+  client: DynamoDBDocumentClient,
+  transactItems: TransactWriteCommandInput['TransactItems'],
+  logger?: Logger
+): Promise<void>
+```
+
+Import `TransactWriteCommand`, `TransactWriteCommandInput` from `@aws-sdk/lib-dynamodb`. Handle `TransactionCanceledException` from `@aws-sdk/client-dynamodb` — the `CancellationReasons` array tells you which item failed (index 0 = save item, index 1 = marker item).
+
+### Two-Layer Duplicate Detection Flow
+
+```
+POST /saves
+    │
+    ▼
+[Validate body with createSaveSchema]
+    │
+    ▼
+[normalizeUrl(url)] → NormalizeError → 400 VALIDATION_ERROR
+    │
+    ▼
+[detectContentType(url, body.contentType)]
+    │
+    ▼
+[Layer 1: Query urlHash-index GSI (active saves only)]
+  ├── active save found → return 409 with existingSave
+  └── no active save found → continue to Layer 2
+    │
+    ▼
+[Layer 2: TransactWriteItems (save + marker)]
+  ├── success → void emitSaveCreatedEvent(...) → return 201
+  └── TransactionCanceledException (marker exists)
+        │
+        ▼
+      [Re-query urlHash-index GSI for active save]
+        ├── active save found → return 409 with existingSave
+        └── no active save found (was soft-deleted or anomaly)
+              │
+              ▼
+            [Re-query urlHash-index GSI WITHOUT deletedAt filter]
+              ├── soft-deleted save found
+              │     → UpdateItem REMOVE deletedAt (ConditionExpression: attribute_exists(deletedAt))
+              │     → void emitSaveRestoredEvent(...)
+              │     → return 200 with restored save
+              └── no save found at all (orphaned marker — data anomaly)
+                    → log error with requestId
+                    → return 500 INTERNAL_ERROR
+```
+
+### Layer 1: GSI Query
+
+```typescript
+// Layer 1 — active saves only (filter by userId + no deletedAt)
+const layer1Result = await queryItems<SaveItem>(client, SAVES_TABLE_CONFIG, {
+  keyConditionExpression: 'urlHash = :urlHash',
+  expressionAttributeValues: {
+    ':urlHash': urlHash,
+    ':pk': `USER#${userId}`,  // REQUIRED — FilterExpression references :pk
+  },
+  filterExpression: 'PK = :pk AND attribute_not_exists(deletedAt)',
+  expressionAttributeNames: undefined,
+  indexName: 'urlHash-index',
+});
+
+// Re-query for soft-deleted save (same GSI, without the deletedAt filter)
+const softDeletedResult = await queryItems<SaveItem>(client, SAVES_TABLE_CONFIG, {
+  keyConditionExpression: 'urlHash = :urlHash',
+  expressionAttributeValues: {
+    ':urlHash': urlHash,
+    ':pk': `USER#${userId}`,
+  },
+  filterExpression: 'PK = :pk AND attribute_exists(deletedAt)',
+  expressionAttributeNames: undefined,
+  indexName: 'urlHash-index',
+});
+```
+
+Note: The GSI has ALL projection so `deletedAt` and `PK` are projected. `attribute_not_exists(deletedAt)` / `attribute_exists(deletedAt)` work correctly in FilterExpression against GSI items. **Known limitation:** For globally popular URLs saved by thousands of users, the GSI page (up to ~1MB) may not contain this user's row on the first DynamoDB page. In that case Layer 1 returns empty and the request falls through to Layer 2 — correctness is preserved (Layer 2 TransactWriteItems blocks the duplicate via the marker), but the fast-path 409 with `existingSave` body becomes a slower-path 409 without `existingSave`. This is an accepted trade-off at boutique scale (< 100 users). If this becomes an issue at scale, replace with a targeted main-table GetItem using `PK=USER#<userId>, SK=URL#<urlHash>` to detect the marker, then fetch the save separately.
+
+### Layer 2: TransactWriteItems
+
+```typescript
+await transactWriteItems(client, [
+  {
+    Put: {
+      TableName: SAVES_TABLE_CONFIG.tableName,
+      Item: saveItem,
+    },
+  },
+  {
+    Put: {
+      TableName: SAVES_TABLE_CONFIG.tableName,
+      Item: markerItem,
+      ConditionExpression: 'attribute_not_exists(SK)',
+    },
+  },
+], logger);
+```
+
+Only the MARKER item needs the ConditionExpression — the save item write is unconditional (ULID guarantees uniqueness of `SK=SAVE#<ulid>`).
+
+### Auto-Restore: UpdateItem with ConditionExpression
+
+Use a conditional update to prevent concurrent requests both emitting `SaveRestored`:
+
+```typescript
+// Only the first concurrent restore wins; others get ConditionalCheckFailed (ignored)
+await updateItem(client, SAVES_TABLE_CONFIG, {
+  key: { PK: `USER#${userId}`, SK: softDeleted.SK },
+  updateExpression: 'REMOVE deletedAt SET updatedAt = :now',
+  expressionAttributeValues: { ':now': new Date().toISOString() },
+  conditionExpression: 'attribute_exists(deletedAt)',  // guard against double-restore
+  returnValues: 'ALL_NEW',
+}, logger);
+```
+
+The `ConditionExpression: attribute_exists(deletedAt)` ensures that only one concurrent POST wins the restore. If a second concurrent request also tries to restore, `updateItem` throws (which the existing `updateItem` helper maps to `NOT_FOUND` via `ConditionalCheckFailedException`) — catch it and treat as success (the URL is now active in the library, which is the user's intent).
+
+### EventBridge — Using @ai-learning-hub/events
+
+No EventBridge CDK stack exists yet. You need to create one (Task 3). The event bus name should be `ai-learning-hub-events` (default custom bus).
+
+**Lambda-side PutEvents** — import `emitEvent` and `getDefaultClient` from `@ai-learning-hub/events` (created in Story 3.1c, which this story depends on). `emitEvent` returns `void` — **do not prefix with `void` and do not `await` it**; the fire-and-forget contract is enforced by the return type.
+
+```typescript
+import {
+  emitEvent,
+  getDefaultClient,
+  SAVES_EVENT_SOURCE,
+  type SavesEventDetailType,
+  type SavesEventDetail,
+} from '@ai-learning-hub/events';
+
+// Fail loudly at Lambda cold-start if env var is missing — per architecture-guard rule
+// (hardcoding real resource names in application code is prohibited).
+const EVENT_BUS_NAME = process.env.EVENT_BUS_NAME;
+if (!EVENT_BUS_NAME) throw new Error('EVENT_BUS_NAME env var is not set');
+
+// Module-level singleton — reused across warm invocations
+const ebClient = getDefaultClient();
+
+// Synchronous call — returns void immediately; async work is detached
+emitEvent<SavesEventDetailType, SavesEventDetail>(ebClient, EVENT_BUS_NAME, {
+  source: SAVES_EVENT_SOURCE,              // const — no magic string drift
+  detailType: 'SaveCreated',               // compile error if not in SavesEventDetailType
+  detail: { userId, saveId, url, normalizedUrl, urlHash, contentType },
+}, logger);
+return createSuccessResponse(toPublicSave(saved), requestId, 201);
+```
+
+`emitEvent` catches and logs its own errors internally — callers never need a try/catch. The `@aws-sdk/client-eventbridge` package is an `externalModule` in CDK bundling (available in the Lambda runtime); no local install needed.
+
+### SaveRestored Event Shape
+
+`SaveRestored` uses the same `emitEvent` call with `detailType: 'SaveRestored'` and an identical detail shape:
+
+```typescript
+emitEvent<SavesEventDetailType, SavesEventDetail>(ebClient, EVENT_BUS_NAME, {
+  source: SAVES_EVENT_SOURCE,
+  detailType: 'SaveRestored',
+  detail: {
+    userId, saveId: softDeleted.saveId, url: softDeleted.url,
+    normalizedUrl: softDeleted.normalizedUrl, urlHash: softDeleted.urlHash,
+    contentType: softDeleted.contentType,
+  },
+}, logger);
+```
+
+Downstream consumers (Epic 9 enrichment pipeline, Epic 7 search index sync) should treat `SaveRestored` identically to `SaveCreated` — re-enqueue the URL for enrichment and re-add to search index.
+
+### 409 Response Shape (ADR-008 compliant)
+
+Define `toPublicSave` inline in `backend/functions/saves/handler.ts` — it does NOT exist in any shared package yet:
+
+```typescript
+/** Strip internal DynamoDB keys before returning a save to the API caller. */
+function toPublicSave(item: SaveItem) {
+  const { PK, SK, ...rest } = item;  // omit DynamoDB keys
+  return rest;
+}
+
+// 409 response — existingSave is a SIBLING of error, not nested inside it
+return {
+  statusCode: 409,
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    error: {
+      code: 'DUPLICATE_SAVE',
+      message: 'URL already saved',
+      requestId,
+    },
+    existingSave: toPublicSave(existingSave),
+  }),
+};
+```
+
+The `error` object must be ADR-008-compliant (`{ code, message, requestId }`). `existingSave` lives alongside `error` at the top level — NOT nested inside it.
+
+### Rate Limiting (Inherited from Epic 2)
+
+The `wrapHandler` middleware from `@ai-learning-hub/middleware` does NOT automatically enforce rate limiting. Rate limiting must be called explicitly using `enforceRateLimit` from `@ai-learning-hub/db`:
+
+```typescript
+import { enforceRateLimit, USERS_TABLE_CONFIG } from '@ai-learning-hub/db';
+
+// Inside handler, after auth:
+await enforceRateLimit(client, USERS_TABLE_CONFIG.tableName, {
+  operation: 'saves-create',
+  identifier: userId,
+  limit: 200,         // 200 saves per hour — saves is a core daily action (vs 10/hr for api-key creation)
+  windowSeconds: 3600,
+}, logger);
+```
+
+**Rate limit value rationale:** No story file exists for Story 2.7 to cross-reference. Based on the existing implemented limits — `api-key-create` uses 10/hour (sensitive, infrequent) and `invite-code-generate` uses 5/day (very infrequent) — `saves-create` is a core high-frequency action; 200/hour is a reasonable V1 limit that prevents abuse while not blocking power users. If the Story 2.7 implementation established a different value (e.g. via a rate-limits config file), use that value instead. **Consider creating `backend/shared/db/src/rate-limits.ts`** to define all rate limit constants in one place rather than scattering magic numbers across handlers.
+
+### Route Registry Update
+
+Add to `infra/config/route-registry.ts`:
+
+1. Extend the `HandlerRef` type:
+```typescript
+export type HandlerRef =
+  | "validateInviteFunction"
+  | "usersMeFunction"
+  | "apiKeysFunction"
+  | "generateInviteFunction"
+  | "savesCreateFunction";   // ADD THIS
+```
+
+2. Add to `ROUTE_REGISTRY`:
+```typescript
+{
+  path: '/saves',
+  methods: ['POST'],
+  authType: 'jwt-or-apikey',
+  handlerRef: 'savesCreateFunction',
+  epic: 'Epic-3',
+},
+```
+
+The architecture enforcement tests in `infra/test/stacks/api/route-registry.test.ts` (from Story 2.1-D5) validate the registry against CDK resources. They will fail until the CDK stack also exposes a `savesCreateFunction` property that matches.
+
+### Architecture Compliance
+
+| ADR | How This Story Complies |
+|-----|-------------------------|
+| ADR-001 (DynamoDB) | `PK=USER#<userId>`, `SK=SAVE#<ULID>`, marker `SK=URL#<urlHash>` all follow documented key patterns |
+| ADR-003 (EventBridge) | `SaveCreated` emitted after successful write; `SaveRestored` emitted on auto-restore; non-throwing emission |
+| ADR-005 (No L2L) | No Lambda invocations; EventBridge for async |
+| ADR-008 (Error Handling) | All errors use `{ error: { code, message, requestId } }`; 409 adds `existingSave` as sibling field |
+| ADR-014 (API-First) | `POST /saves` returns 201 with save object; pagination deferred to 3.2 |
+| ADR-016 (Cold Starts) | NFR-P2 claim qualified as "warm invocation" |
+
+### Testing Standards
+
+- **Framework:** Vitest (used by all backend packages — check `backend/functions/api-keys/handler.test.ts` for the pattern)
+- **Coverage:** 80% minimum (CI-enforced)
+- **Mock pattern:** Use the shared `wrapHandler` mock utility added in Story 2.1-D3: `backend/shared/middleware/test/mock-wrapper.ts`. Check `backend/functions/api-keys/handler.test.ts` for the import and usage pattern.
+- **EventBridge mock:** Mock `@ai-learning-hub/events` using `vi.mock('@ai-learning-hub/events')` and assert `emitEvent` was called with the correct `source`, `detailType`, and `detail` shape. Do NOT mock `@aws-sdk/client-eventbridge` directly — that is tested in the `@ai-learning-hub/events` package itself.
+- **TransactWriteItems mock:** Mock the new `transactWriteItems` helper from `@ai-learning-hub/db` — test both success and `TransactionCanceledException` paths
+- **DynamoDB mock:** Use `vi.mock('@ai-learning-hub/db')` to mock `queryItems`, `transactWriteItems`, `updateItem`
+
+### Project Structure Notes
+
+- New Lambda handler: `backend/functions/saves/handler.ts` (directory already exists with `.gitkeep`)
+- New db helper: `backend/shared/db/src/transact.ts` (add to existing package)
+- New CDK stack: `infra/lib/stacks/core/events.stack.ts`
+- New CDK stack: `infra/lib/stacks/api/saves-routes.stack.ts`
+- Modified: `infra/config/route-registry.ts` (add route + extend HandlerRef)
+- Modified: `infra/bin/app.ts` (instantiate new stacks)
+- Modified: `backend/shared/db/src/index.ts` (export new transact helpers)
+- Do NOT create a `saves/` subdirectory under `backend/functions/saves/` — flat file, single handler handles POST /saves; separate handlers for list/get/update/delete will be added in Stories 3.2 and 3.3
+
+### References
+
+- [Source: docs/progress/epic-3-stories-and-plan.md#Story-3.1b] — Story definition, ACs, two-layer dedup technical notes
+- [Source: _bmad-output/implementation-artifacts/3-1a-save-validation-modules.md] — Previous story outputs: `normalizeUrl`, `detectContentType`, `createSaveSchema` all exported from `@ai-learning-hub/validation`
+- [Source: infra/lib/stacks/core/tables.stack.ts#SavesTable] — `ai-learning-hub-saves` table, `urlHash-index` GSI (ALL projection, `urlHash` PK)
+- [Source: infra/config/route-registry.ts] — Route registry pattern and `HandlerRef` type
+- [Source: backend/functions/api-keys/handler.ts] — `wrapHandler` + `enforceRateLimit` usage pattern
+- [Source: backend/shared/db/src/helpers.ts] — Existing `queryItems`, `updateItem` helpers + `TableConfig` type
+- [Source: backend/shared/db/src/users.ts] — `USERS_TABLE_CONFIG` pattern (env var fallback)
+- [Source: backend/shared/middleware/src/index.ts] — Available middleware exports
+- [Source: _bmad-output/planning-artifacts/architecture.md] — ADR-001 key patterns, ADR-003 EventBridge, ADR-008 error codes (DUPLICATE_SAVE → 409)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+{{agent_model_name_version}}
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/3-1c-events-shared-package.md
+++ b/_bmad-output/implementation-artifacts/3-1c-events-shared-package.md
@@ -1,0 +1,502 @@
+---
+id: "3.1c"
+title: "EventBridge Shared Package (@ai-learning-hub/events)"
+status: ready-for-dev
+depends_on: []
+touches:
+  - backend/shared/events
+  - package.json (root workspace)
+  - tsconfig.base.json (project references)
+risk: low
+---
+
+# Story 3.1c: EventBridge Shared Package (@ai-learning-hub/events)
+
+Status: ready-for-dev
+
+## Story
+
+As a developer building Lambda handlers that emit EventBridge events,
+I want a shared `@ai-learning-hub/events` package with a typed, non-throwing event emitter,
+so that all Lambdas emit events consistently without copy-pasting `EventBridgeClient` boilerplate.
+
+## Acceptance Criteria
+
+| #   | Given                                                      | When                                                                   | Then                                                                                                                                                                                                                                                                        |
+| --- | ---------------------------------------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC1 | A Lambda calls `emitEvent(client, busName, entry, logger)` | The EventBridge `PutEvents` call succeeds                              | The event is published; the function returns synchronously (return type is `void`, not `Promise<void>`)                                                                                                                                                                     |
+| AC2 | A Lambda calls `emitEvent(...)` and PutEvents throws       | EventBridge call fails for any reason                                  | The error is caught internally, logged at `warn` level with `{ detailType, err }`, and the function still returns `void` — it never throws. Callers cannot accidentally block on it.                                                                                        |
+| AC3 | Any Lambda initialises the module                          | Module loads                                                           | `getDefaultClient()` returns a singleton `EventBridgeClient` configured from `AWS_REGION` env var (fallback `us-east-1`). `createEventBridgeClient()` always constructs a new instance (for testing or custom config). `resetDefaultClient()` clears the singleton for test teardown. |
+| AC4 | `emitEvent` is called                                      | Inspecting the `PutEventsCommand` payload                              | Entry shape: `{ Source, DetailType, Detail: JSON.stringify(detail), EventBusName: busName }`. Only one entry per call.                                                                                                                                                       |
+| AC5 | Event catalog types are imported                           | TypeScript compilation                                                 | `SavesEventDetail` and `SavesEventDetailType` are exported. `emitEvent` is generic over `<TDetailType extends string, TDetail extends object>`: passing a `detailType` not assignable to `TDetailType` is a **compile error**. The `detail` shape is also enforced at compile time. |
+| AC6 | `emitEvent` is called from a Lambda handler                | TypeScript compilation                                                 | `emitEvent` returns `void`. TypeScript itself does not error on `await voidFn()` — awaiting a `void` value is syntactically valid. The `@typescript-eslint/await-thenable` rule would flag it, but **that rule requires type-aware linting (`recommendedTypeChecked`) which this project has explicitly deferred** (see `eslint.config.js`). The practical enforcement is semantic: the `void` return type signals intent clearly, and a missing `await` has no compile consequence because there is nothing to await. This is a known limitation documented here so future developers understand the guarantee boundary. |
+| AC7 | PutEvents returns `FailedEntryCount > 0`                   | Partial EventBridge failure                                            | Logged at `warn` level including `detailType`, `failedCount`, `errorCode`, and `errorMessage` from `result.Entries?.[0]` — the fields needed for production debugging.                                                                                                      |
+| AC8 | Package is built                                           | `npm run build` in `backend/shared/events`                             | Clean TypeScript compilation with `.d.ts` declarations; package exports resolve correctly from `@ai-learning-hub/events`.                                                                                                                                                   |
+| AC9 | Tests run                                                  | `npm test` in `backend/shared/events`                                  | All tests pass, ≥ 80% coverage enforced by `vitest.config.ts` thresholds (not just by CI flag).                                                                                                                                                                             |
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Scaffold the package (AC: #3, #8)
+  - [ ] 1.1 Create `backend/shared/events/` directory with `src/`, `src/events/`, and `test/` subdirectories
+  - [ ] 1.2 Create `backend/shared/events/package.json` — name `@ai-learning-hub/events`; follow the exact structure of `@ai-learning-hub/db` (`"type": "module"`, `main`/`types`/`exports` pointing at `dist/index.js`, `build`/`test`/`lint` scripts, `@ai-learning-hub/logging` as dependency, `@aws-sdk/client-eventbridge` as dependency). See Dev Notes — package.json Template.
+  - [ ] 1.3 Create `backend/shared/events/tsconfig.json` — extend `../../../tsconfig.base.json`, `outDir: dist`, `rootDir: src`, `composite: true`, `declaration: true`, `declarationMap: true`. `exclude: ["node_modules", "dist", "test"]`. References: `../logging` only (no `../types` — intentional; see Dev Notes — ContentType). See Dev Notes — tsconfig.json Template.
+  - [ ] 1.4 Create `backend/shared/events/vitest.config.ts` — copy coverage threshold pattern from `@ai-learning-hub/db`; alias `@ai-learning-hub/logging` to its `src/index.ts`. See Dev Notes — vitest.config.ts Template.
+  - [ ] 1.5 Add `"backend/shared/events"` to the `workspaces` array in root `package.json` (after `backend/shared/middleware`)
+  - [ ] 1.6 Run `npm install` at workspace root to link the new package
+
+- [ ] Task 2: Implement the EventBridge client module (AC: #3)
+  - [ ] 2.1 Create `backend/shared/events/src/client.ts`
+  - [ ] 2.2 Implement `createEventBridgeClient(options?: { region?: string }): EventBridgeClient` — always constructs and returns a new `EventBridgeClient`; mirrors `createDynamoDBClient` in `@ai-learning-hub/db`
+  - [ ] 2.3 Implement `getDefaultClient(): EventBridgeClient` — module-level singleton; constructs on first call via `createEventBridgeClient()`, returns same instance on subsequent calls
+  - [ ] 2.4 Implement `/** @internal — for test teardown only */ resetDefaultClient(): void` — sets singleton to `null`. Add the `@internal` JSDoc annotation so tooling and reviewers know this must not be called in production code.
+  - [ ] 2.5 Add X-Ray tracing comment matching the pattern in `@ai-learning-hub/db/src/client.ts` — note that EventBridge subsegment capture is deferred, same as DynamoDB. See Dev Notes — X-Ray.
+
+- [ ] Task 3: Implement the event emitter (AC: #1, #2, #4, #6, #7)
+  - [ ] 3.1 Create `backend/shared/events/src/emitter.ts`
+  - [ ] 3.2 Define `EventEntry<TDetailType extends string, TDetail extends object>` interface: `{ source: string; detailType: TDetailType; detail: TDetail }` — two generics so both `detailType` and `detail` are type-constrained at the call site
+  - [ ] 3.3 Implement `emitEvent<TDetailType extends string, TDetail extends object>(client, busName, entry, logger): void` — **return type is `void`**, not `Promise<void>`; the async work runs inside a fire-and-forget IIFE. See Dev Notes — Emitter Module for the exact pattern.
+  - [ ] 3.4 Inside the IIFE: send `PutEventsCommand` with `{ Source, DetailType, Detail: JSON.stringify(entry.detail), EventBusName: busName }`
+  - [ ] 3.5 After a successful send: check `result.FailedEntryCount > 0`; if true, log `warn` including `detailType`, `failedCount`, `errorCode: result.Entries?.[0]?.ErrorCode`, `errorMessage: result.Entries?.[0]?.ErrorMessage`
+  - [ ] 3.6 In the `catch` block: wrap the `logger.warn(...)` call in its own inner try/catch with an empty catch body (`catch {}`). If `logger.warn` itself throws (logging library bug, serialization error), the outer IIFE's promise would become an unhandled rejection — which terminates the Node 20 Lambda process. The inner try/catch prevents this. Never rethrow from either catch.
+  - [ ] 3.7 Add a dev note (inline comment) in `emitter.ts` about `JSON.stringify` constraints — see Dev Notes — JSON.stringify Constraints
+
+- [ ] Task 4: Define typed event catalog for the Saves domain (AC: #5)
+  - [ ] 4.1 Create `backend/shared/events/src/events/saves.ts`
+  - [ ] 4.2 Define `SavesEventDetailType` as `'SaveCreated' | 'SaveRestored'` — **only these two** because they are the only Saves events emitted in Epic 3 stories 3.1b and 3.3 (restore path). `SaveUpdated` and `SaveDeleted` are deferred to Story 3.3 where their distinct detail shapes will be defined.
+  - [ ] 4.3 Define `SavesEventDetail` interface matching the architecture spec (see Dev Notes — Event Catalog). Note: `contentType` is typed as `string`, not the `ContentType` enum — see Dev Notes — ContentType.
+  - [ ] 4.4 Export `SAVES_EVENT_SOURCE = 'ai-learning-hub.saves' as const` — callers import this constant instead of repeating the magic string. Prevents source typos that cause EventBridge rules to silently receive events no rule matches.
+  - [ ] 4.5 Export `SavesEventDetailType`, `SavesEventDetail`, and `SAVES_EVENT_SOURCE` from `backend/shared/events/src/events/saves.ts`
+  - [ ] 4.6 Re-export all three from `backend/shared/events/src/index.ts`
+
+- [ ] Task 5: Wire the index exports (AC: #3, #5, #8)
+  - [ ] 5.1 Create `backend/shared/events/src/index.ts` that exports all public symbols (see Dev Notes — Public Exports)
+
+- [ ] Task 6: Write tests (AC: #9)
+  - [ ] 6.1 Create `backend/shared/events/test/emitter.test.ts`
+  - [ ] 6.2 Test: `emitEvent` calls `PutEventsCommand` with correct `Source`, `DetailType`, `Detail` (JSON-serialised), `EventBusName`
+  - [ ] 6.3 Test: `emitEvent` returns `void` synchronously and does NOT return a Promise — `const r = emitEvent(...); assert(r === undefined)`
+  - [ ] 6.4 Test: when PutEvents throws, `emitEvent` does NOT throw at the call site AND `logger.warn` is called with the error — **call `await flushPromises()` after `emitEvent(...)` and before asserting** (the async work runs in a detached IIFE; assertions need the microtask queue to drain). Use the `flushPromises` helper defined in Dev Notes — Test Timing. Do NOT use `vi.runAllMicrotasksAsync()` — this function does not exist in Vitest 3.x.
+  - [ ] 6.5 Test: when `FailedEntryCount > 0`, `emitEvent` does NOT throw AND `logger.warn` is called with `errorCode` and `errorMessage` from the SDK response — same `flushPromises()` drain technique as 6.4
+  - [ ] 6.6 Test: when `FailedEntryCount === 0` (success), `logger.warn` is NOT called — **also requires `await flushPromises()` before asserting**; without it the test is a false positive (the IIFE hasn't completed, so warn simply hasn't run yet rather than genuinely not having been called)
+  - [ ] 6.7 Create `backend/shared/events/test/client.test.ts` — test singleton lifecycle: first call to `getDefaultClient()` creates client, second call returns same instance, `resetDefaultClient()` clears it so next call creates a new instance
+  - [ ] 6.8 Mock `EventBridgeClient` via `vi.mock('@aws-sdk/client-eventbridge')` in all tests
+
+- [ ] Task 7: Quality gates
+  - [ ] 7.1 `npm run build` from workspace root — clean compilation including the new package
+  - [ ] 7.2 `npm test` from workspace root — all tests pass (new + existing ≥ 1,243); `vitest.config.ts` thresholds enforce 80% coverage
+  - [ ] 7.3 `npm run lint` — no errors
+  - [ ] 7.4 `npm run type-check` — no type errors
+  - [ ] 7.5 `npm run format` — run Prettier on all new files
+
+## Dev Notes
+
+### Why This Story Exists Before 3.1b
+
+Story 3.1b (Create Save API) is the first Lambda to emit EventBridge events. Without this package, 3.1b would inline its own `EventBridgeClient` + `emitSavesEvent` function (as noted in 3.1b's dev notes). Stories 3.3, 3.5, Epic 9, and others all emit events too. Creating the shared package first means 3.1b (and every downstream story) imports a consistent, tested abstraction instead of accumulating copy-paste boilerplate that would require a cleanup story to fix.
+
+**3.1b will use this package** — its dev notes have already been updated to import from `@ai-learning-hub/events`. The CDK EventBridge stack (`events.stack.ts`) stays in 3.1b — that is infrastructure setup, not the shared library.
+
+### Package Structure
+
+```
+backend/shared/events/
+├── src/
+│   ├── client.ts          # EventBridgeClient singleton
+│   ├── emitter.ts         # emitEvent() helper
+│   ├── events/
+│   │   └── saves.ts       # Saves domain event types
+│   └── index.ts           # Public exports
+├── test/
+│   ├── client.test.ts
+│   └── emitter.test.ts
+├── package.json
+├── tsconfig.json
+└── vitest.config.ts
+```
+
+### Client Module Pattern
+
+Mirror `@ai-learning-hub/db`'s `client.ts`. Key distinction: `createEventBridgeClient()` always returns a **new** instance; `getDefaultClient()` is the singleton. AC3 reflects this correctly — do not conflate the two functions.
+
+```typescript
+/**
+ * EventBridge client for Lambda.
+ *
+ * X-Ray: Lambda injects _X_AMZN_TRACE_ID; trace ID is available via env for
+ * logging/correlation. EventBridge subsegment capture (aws-xray-sdk) is deferred
+ * to a later story; use the Lambda trace for request-level tracing until then.
+ */
+import { EventBridgeClient } from '@aws-sdk/client-eventbridge';
+
+let defaultClient: EventBridgeClient | null = null;
+
+export function createEventBridgeClient(options: { region?: string } = {}): EventBridgeClient {
+  return new EventBridgeClient({
+    region: options.region ?? process.env.AWS_REGION ?? 'us-east-1',
+  });
+}
+
+export function getDefaultClient(): EventBridgeClient {
+  if (!defaultClient) {
+    defaultClient = createEventBridgeClient();
+  }
+  return defaultClient;
+}
+
+/**
+ * @internal — for test teardown only. Do not call in production code.
+ */
+export function resetDefaultClient(): void {
+  defaultClient = null;
+}
+```
+
+### Emitter Module
+
+`emitEvent` returns **`void`** (not `Promise<void>`). The async work runs inside a detached IIFE. This means:
+- Callers naturally fire-and-forget: `emitEvent(client, bus, entry, logger);`
+- TypeScript itself does NOT error on `await emitEvent(...)` — awaiting a `void` value is syntactically valid. The `@typescript-eslint/await-thenable` rule would catch it, but requires type-aware linting which this project has deferred (see AC6 for the full explanation).
+- The `void` return type is a strong semantic signal, not a hard compiler barrier. Code review should reject any `await emitEvent(...)` call site.
+- The `void` prefix (`void emitEvent(...)`) is redundant and should be omitted — the return type is already `void`.
+
+```typescript
+import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
+import type { Logger } from '@ai-learning-hub/logging';
+
+export interface EventEntry<TDetailType extends string, TDetail extends object> {
+  source: string;
+  detailType: TDetailType;
+  detail: TDetail;
+}
+
+export function emitEvent<TDetailType extends string, TDetail extends object>(
+  client: EventBridgeClient,
+  busName: string,
+  entry: EventEntry<TDetailType, TDetail>,
+  logger: Logger,
+): void {
+  // Fire-and-forget: async work runs in a detached IIFE. Return type is void so
+  // callers cannot accidentally await this function and block the response path.
+  void (async () => {
+    try {
+      const result = await client.send(
+        new PutEventsCommand({
+          Entries: [{
+            Source: entry.source,
+            DetailType: entry.detailType,
+            // JSON.stringify constraints: undefined fields are silently omitted,
+            // Date objects serialize to ISO strings, circular references throw (caught
+            // below). Callers must pass plain serializable objects — no class instances.
+            Detail: JSON.stringify(entry.detail),
+            EventBusName: busName,
+          }],
+        }),
+      );
+      if (result.FailedEntryCount && result.FailedEntryCount > 0) {
+        logger.warn('EventBridge PutEvents partial failure (non-fatal)', undefined, {
+          detailType: entry.detailType,
+          failedCount: result.FailedEntryCount,
+          errorCode: result.Entries?.[0]?.ErrorCode,
+          errorMessage: result.Entries?.[0]?.ErrorMessage,
+        });
+      }
+    } catch (err) {
+      // Inner try/catch around logger.warn is REQUIRED: if logger.warn throws
+      // (logging library bug, serialization error), the exception would propagate
+      // out of this catch block into the detached IIFE's promise. In Node 20,
+      // unhandled promise rejections terminate the process — crashing the Lambda.
+      try {
+        logger.warn('EventBridge PutEvents failed (non-fatal)', err as Error, {
+          detailType: entry.detailType,
+        });
+      } catch {
+        // logger itself failed — nothing safe to do here
+      }
+    }
+  })();
+}
+```
+
+### JSON.stringify Constraints
+
+Add this as an inline comment in `emitter.ts` (shown above) and be aware when writing tests:
+
+- **`undefined` fields are silently dropped** — `{ foo: undefined }` serializes to `{}`. If a field is required by downstream consumers, make it non-optional in the detail type.
+- **`Date` objects serialize to ISO strings** — generally fine but not explicit in types.
+- **Circular references throw** — the throw lands in the `catch` block and is logged as a warn. The event is silently swallowed, not retried. Do not pass objects with circular references as `detail`.
+- **Plain objects only** — no class instances in `detail`. All exported detail interfaces use primitive types; callers construct them inline.
+
+### Event Catalog — Saves Domain
+
+Define in `src/events/saves.ts`. Only define what has a concrete detail shape today:
+
+```typescript
+/**
+ * EventBridge source for all Saves domain events.
+ * Import this constant — do not repeat the string literal at call sites.
+ */
+export const SAVES_EVENT_SOURCE = 'ai-learning-hub.saves' as const;
+
+/**
+ * Detail types for Saves domain events emitted in Epic 3.
+ * SaveUpdated and SaveDeleted will be added in Story 3.3 with their distinct detail shapes.
+ */
+export type SavesEventDetailType = 'SaveCreated' | 'SaveRestored';
+
+export interface SavesEventDetail {
+  userId: string;
+  saveId: string;
+  url: string;
+  normalizedUrl: string;
+  urlHash: string;
+  /** Typed as string, not the ContentType enum — see Dev Notes: ContentType */
+  contentType: string;
+}
+```
+
+`SaveCreated` and `SaveRestored` share the same detail shape in Story 3.1b. When Story 3.3 adds `SaveUpdated` (which needs `updatedFields`) and `SaveDeleted`, it will extend `SavesEventDetailType` and add the appropriate interfaces. Story 3.3 should also consider converting to a discriminated union at that point.
+
+### ContentType: string, not the Enum
+
+`SavesEventDetail.contentType` is typed as `string` rather than the `ContentType` enum from `@ai-learning-hub/types`. This is **intentional**:
+
+- Adding `@ai-learning-hub/types` as a dependency couples `@ai-learning-hub/events` to the types package. EventBridge events cross domain boundaries (Epic 9 enrichment, Epic 7 search, future external consumers) and their payloads should be loosely typed at the wire level.
+- Lambda handlers that call `emitEvent` already have `contentType` typed as `ContentType` from `@ai-learning-hub/types`. TypeScript will accept a `ContentType` enum value for a `string`-typed field without complaint (enums are assignable to their base type).
+- If strict type-checking at the call site is desired in the future, callers can cast: `contentType: save.contentType as string` — but this is unnecessary in practice.
+
+### How Story 3.1b Will Use This Package
+
+```typescript
+import {
+  emitEvent,
+  getDefaultClient,
+  SAVES_EVENT_SOURCE,
+  type SavesEventDetailType,
+  type SavesEventDetail,
+} from '@ai-learning-hub/events';
+
+const EVENT_BUS_NAME = process.env.EVENT_BUS_NAME;
+if (!EVENT_BUS_NAME) throw new Error('EVENT_BUS_NAME env var is not set');
+
+// Module-level singleton — reused across warm invocations
+const ebClient = getDefaultClient();
+
+// Inside handler — synchronous call, fire-and-forget by return type:
+emitEvent<SavesEventDetailType, SavesEventDetail>(ebClient, EVENT_BUS_NAME, {
+  source: SAVES_EVENT_SOURCE,              // const — no magic string drift
+  detailType: 'SaveCreated',               // compile error if not in SavesEventDetailType
+  detail: { userId, saveId, url, normalizedUrl, urlHash, contentType },  // compile error if shape wrong
+}, logger);
+return createSuccessResponse(toPublicSave(saved), requestId, 201);
+```
+
+### Test Timing — Fire-and-Forget Async
+
+Because `emitEvent` returns `void` and the async work runs in a detached IIFE, test assertions about `logger.warn` or `PutEventsCommand` call counts must wait for the microtask queue to drain **before asserting**. Without draining, assertions run before the IIFE has resolved — producing both false negatives (warn not called yet on failure paths) and false positives (warn not called yet on success paths).
+
+**Do NOT use `vi.runAllMicrotasksAsync()`** — this function does not exist in Vitest 3.x. The available fake-timer APIs (`vi.runAllTicks()`, `vi.runAllTimers()`) operate only when fake timers are active and are not relevant here.
+
+Define a `flushPromises` helper at the top of each test file and use it after every `emitEvent(...)` call that requires assertions:
+
+```typescript
+// Drains the microtask queue and any pending I/O callbacks.
+// Required after calling emitEvent() to allow the detached IIFE to complete
+// before asserting on logger.warn or PutEventsCommand call counts.
+const flushPromises = (): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, 0));
+
+it('logs warn when PutEvents throws', async () => {
+  mockSend.mockRejectedValueOnce(new Error('throttled'));
+
+  emitEvent(client, 'bus', entry, mockLogger);  // synchronous call
+
+  await flushPromises();  // drain the detached IIFE before asserting
+
+  expect(mockLogger.warn).toHaveBeenCalledWith(
+    'EventBridge PutEvents failed (non-fatal)',
+    expect.any(Error),
+    expect.objectContaining({ detailType: entry.detailType }),
+  );
+});
+
+it('does NOT call logger.warn on success', async () => {
+  mockSend.mockResolvedValueOnce({ FailedEntryCount: 0, Entries: [] });
+
+  emitEvent(client, 'bus', entry, mockLogger);
+
+  await flushPromises();  // required even on success path — false positive without it
+
+  expect(mockLogger.warn).not.toHaveBeenCalled();
+});
+```
+
+`setTimeout(resolve, 0)` runs after all pending microtasks and I/O callbacks in the current event loop turn, making it reliable for draining an async IIFE whose mocked `client.send` resolves synchronously.
+
+This also applies to the 3.1b tests (Task 5.4): call the handler, then `await flushPromises()` before asserting `logger.warn` was called with the EventBridge error. The 201 response assertion can run immediately — it precedes `emitEvent` in handler execution order.
+
+### Lambda Freeze / At-Most-Once Delivery
+
+**This is a known trade-off of the fire-and-forget design in Lambda specifically.**
+
+When the Lambda handler returns (after `return createSuccessResponse(...)`), AWS may freeze the execution environment before the detached IIFE's `PutEventsCommand` network call completes. If Lambda freezes mid-flight, the event is never delivered to EventBridge. On the next warm invocation the environment is thawed, but the in-flight request from the previous invocation is gone.
+
+This means event delivery is **best-effort / at-most-once**, not guaranteed:
+- If Lambda stays warm (typical on warm invocations with concurrent traffic), the IIFE completes in the background before the environment is frozen — events are delivered.
+- If Lambda freezes immediately after the handler returns (e.g., no concurrent traffic, end of burst), the in-flight request is dropped — events are silently lost.
+
+**At boutique scale (< 100 users) this is an accepted trade-off**: the NFR-P2 latency requirement (< 1s response) outweighs the risk of occasional event loss. Downstream pipelines (Epic 9 enrichment, Epic 7 search) are idempotent and will catch up via other triggers. Do not change this design without a confirmed scale requirement.
+
+If guaranteed delivery becomes a requirement: move event emission into a DynamoDB Stream trigger or use a transactional outbox pattern instead.
+
+### package.json Template
+
+```json
+{
+  "name": "@ai-learning-hub/events",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run --coverage",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@ai-learning-hub/logging": "*",
+    "@aws-sdk/client-eventbridge": "^3.490.0"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^3.2.4",
+    "typescript": "~5.3.0",
+    "vitest": "^3.2.4"
+  }
+}
+```
+
+**SDK version note:** `^3.490.0` matches the `@aws-sdk/*` versions in `@ai-learning-hub/db/package.json`. If `@ai-learning-hub/db` is upgraded to a newer SDK version in a future story, update this package in the same PR to keep them in sync. The monorepo does not currently enforce a shared AWS SDK version via root `resolutions` — keeping the versions consistent manually is the current convention.
+
+### tsconfig.json Template
+
+```json
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"],
+  "references": [
+    { "path": "../logging" }
+  ]
+}
+```
+
+Notes:
+- No `../types` reference — intentional; see Dev Notes — ContentType.
+- `exclude` uses `"test"` (not `"**/*.test.ts"`). Tests live in `test/`, not under `src/`. Since `rootDir` is `src`, TypeScript would never compile `test/**` anyway; the pattern `**/*.test.ts` was misleading and is not used here.
+
+### vitest.config.ts Template
+
+Copy from `@ai-learning-hub/db/vitest.config.ts`, but alias only `@ai-learning-hub/logging` (no types alias needed):
+
+```typescript
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@ai-learning-hub/logging': path.join(__dirname, '..', 'logging', 'src', 'index.ts'),
+    },
+  },
+  test: {
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts', 'src/**/*.d.ts'],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
+    },
+  },
+});
+```
+
+This wires the 80% coverage threshold directly in the package so `npm test` fails locally (not just in CI) if coverage drops.
+
+### Public Exports (`src/index.ts`)
+
+```typescript
+// Client
+export { createEventBridgeClient, getDefaultClient, resetDefaultClient } from './client.js';
+
+// Emitter
+export { emitEvent, type EventEntry } from './emitter.js';
+
+// Event catalog — Saves domain
+export { SAVES_EVENT_SOURCE, type SavesEventDetailType, type SavesEventDetail } from './events/saves.js';
+```
+
+### Architecture Compliance
+
+| ADR | How This Story Complies |
+|-----|-------------------------|
+| ADR-003 (EventBridge) | Provides the standard emission pattern; `void` return type ensures event failures never block the API response path |
+| ADR-005 (No L2L) | Package emits to EventBridge only — no Lambda-to-Lambda calls |
+| ADR-008 (Error Handling) | `emitEvent` never throws; error is logged and swallowed so callers' response shapes are unaffected |
+
+### Testing Standards
+
+- **Framework:** Vitest (matches all other backend packages)
+- **Coverage:** 80% minimum — enforced by `vitest.config.ts` thresholds (fails locally, not just CI)
+- **Mock pattern:** `vi.mock('@aws-sdk/client-eventbridge')` — mock `EventBridgeClient.prototype.send` or use `vi.fn()` on the mock instance. Check `backend/shared/db/test/` for existing mock patterns.
+- **Logger mock:** Use `vi.fn()` on `logger.warn` to assert it is called (and only called) on failure paths
+- **Async timing:** All assertions about `logger.warn` and `PutEventsCommand` after calling `emitEvent` must follow `await flushPromises()` (see Dev Notes — Test Timing for the helper definition). This applies to both failure and success-path tests. Do NOT use `vi.runAllMicrotasksAsync()` — it does not exist in Vitest 3.x.
+
+### Project Structure Notes
+
+- New package: `backend/shared/events/` (create from scratch — no `.gitkeep` exists yet)
+- Modified: root `package.json` — add `"backend/shared/events"` to `workspaces`
+- No changes to `infra/` — the CDK EventBridge stack is created in Story 3.1b
+- No changes to other shared packages
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/architecture.md#ADR-003] — EventBridge + Step Functions async pattern; event catalog
+- [Source: backend/shared/db/src/client.ts] — Singleton client pattern (and X-Ray comment) to mirror
+- [Source: backend/shared/db/package.json] — package.json template to follow
+- [Source: backend/shared/db/tsconfig.json] — tsconfig template to follow
+- [Source: backend/shared/db/vitest.config.ts] — vitest.config.ts coverage threshold pattern to follow
+- [Source: _bmad-output/implementation-artifacts/3-1b-create-save-api.md#EventBridge] — Inline implementation this package replaces; fire-and-forget requirement; `EVENT_BUS_NAME` env var guard
+
+## Dev Agent Record
+
+### Agent Model Used
+
+{{agent_model_name_version}}
+
+### Debug Log References
+
+### Completion Notes List

--- a/_bmad-output/implementation-artifacts/3-2-list-get-saves-api.md
+++ b/_bmad-output/implementation-artifacts/3-2-list-get-saves-api.md
@@ -1,0 +1,694 @@
+---
+id: "3.2"
+title: "List & Get Saves API"
+status: ready-for-dev
+depends_on:
+  - 3-1b-create-save-api
+touches:
+  - backend/shared/types/src/entities.ts
+  - backend/shared/db/src/saves.ts (new)
+  - backend/shared/db/src/query-all.ts (new)
+  - backend/shared/db/src/helpers.ts
+  - backend/shared/db/src/index.ts
+  - backend/functions/saves-list/handler.ts (new)
+  - backend/functions/saves-get/handler.ts (new)
+  - infra/lib/stacks/api/saves-routes.stack.ts
+  - infra/config/route-registry.ts
+risk: medium
+---
+
+# Story 3.2: List & Get Saves API
+
+Status: ready-for-dev
+
+## Story
+
+As a user,
+I want to view all my saves in a list and see individual save details,
+so that I can browse my saved URLs and access their metadata.
+
+## Acceptance Criteria
+
+| #   | Given                              | When                                     | Then                                                                                                                                                                                                                                                             |
+| --- | ---------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC1 | User authenticated                 | `GET /saves`                             | Returns paginated list of user's active saves (where `deletedAt` is absent), sorted by `createdAt` descending (newest first)                                                                                                                                     |
+| AC2 | —                                  | `GET /saves?nextToken=<token>&limit=<n>` | In-memory pagination over active saves only: active saves fetched from DynamoDB (up to 1000-item ceiling applied to **active** saves), then paginated with ULID cursor. Default limit=25, max limit=100. Response: `{ items: PublicSave[], nextToken?: string, hasMore: boolean }` |
+| AC3 | User authenticated                 | `GET /saves/:saveId`                     | Returns single save with all public attributes; returns 404 if not found or if it belongs to another user                                                                                                                                                        |
+| AC4 | Save exists and is returned        | `GET /saves/:saveId`                     | `lastAccessedAt` updated via awaited-but-non-throwing `updateItem` call (errors logged with full correlation context, not propagated); response is returned whether or not the update succeeds                                                                    |
+| AC5 | Save has been soft-deleted         | `GET /saves/:saveId`                     | Returns 404 `{ error: { code: 'NOT_FOUND', message: 'Save not found', requestId } }`                                                                                                                                                                             |
+| AC6 | User has no saves                  | `GET /saves`                             | Returns `{ items: [], hasMore: false }` (empty list, not an error)                                                                                                                                                                                               |
+| AC7 | Save belongs to a different user   | `GET /saves/:saveId`                     | Returns 404 (not 403 — no information leakage). Key scoping (`PK=USER#<userId>`) makes this automatic: the item simply won't be found.                                                                                                                            |
+| AC8 | —                                  | Any main saves-table read                | All `GetItem` and `Query` calls on the saves table (main table, not GSI) use `ConsistentRead: true`. Scope: saves table only. Users table reads (Epic 2 handlers) are unchanged. GSI reads (other stories) remain eventually consistent by DynamoDB design.      |
+| AC9 | —                                  | `GET /saves` or `GET /saves/:saveId`     | Response time < 1 second on warm invocation (NFR-P2). Cold start may exceed per ADR-016.                                                                                                                                                                         |
+| AC10| `nextToken` is provided            | Token references a save no longer in result set | Returns 400 `{ error: { code: 'VALIDATION_ERROR', message: 'nextToken is invalid or has expired — restart pagination', requestId } }`. Client must reset to page 1. |
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Add `SaveItem` type to `@ai-learning-hub/types` (Minor #15)
+  - [ ] 1.1 In `backend/shared/types/src/entities.ts`, add `export type SaveItem = Save & { PK: string; SK: string };` below the `Save` interface
+  - [ ] 1.2 Add `export type PublicSave = Omit<SaveItem, 'PK' | 'SK' | 'deletedAt'>;` alongside it
+  - [ ] 1.3 Verify existing types exports in `backend/shared/types/src/index.ts` include these new types (add if missing)
+
+- [ ] Task 2: Add `SAVES_TABLE_CONFIG` and `toPublicSave` to `@ai-learning-hub/db` (Significant #9, #10)
+  - [ ] 2.1 Create `backend/shared/db/src/saves.ts` with `SAVES_TABLE_CONFIG` (reads `process.env.SAVES_TABLE_NAME`, fallback `'ai-learning-hub-saves'`) and `toPublicSave(item: SaveItem): PublicSave` (strips `PK`, `SK`, `deletedAt`)
+  - [ ] 2.2 Export `SAVES_TABLE_CONFIG`, `toPublicSave` from `backend/shared/db/src/index.ts`
+  - [ ] 2.3 Add unit tests in `backend/shared/db/test/saves.test.ts` — verify `toPublicSave` strips `PK`, `SK`, `deletedAt`; verify it preserves all other fields including optional ones; verify `SAVES_TABLE_CONFIG.tableName` reads from env var with fallback
+
+- [ ] Task 3: Add `queryAllItems` helper to `@ai-learning-hub/db` (Critical #1, #4)
+  - [ ] 3.1 Create `backend/shared/db/src/query-all.ts` — see Dev Notes for `QueryAllParams` interface and full implementation including the FilterExpression-aware Limit logic
+  - [ ] 3.2 The `Limit` optimization (`ceiling - allItems.length`) MUST be disabled when `filterExpression` is present (DynamoDB `Limit` applies before `FilterExpression`, so using it would starve accumulation on tables with many soft-deleted items). When `filterExpression` is present, use a fixed page size of 500.
+  - [ ] 3.3 Log `pages` counter alongside `totalItems` and `durationMs` for performance diagnosis (Minor #16)
+  - [ ] 3.4 Export `queryAllItems` and `QueryAllParams` from `backend/shared/db/src/index.ts`
+  - [ ] 3.5 Add unit tests in `backend/shared/db/test/query-all.test.ts` — see Dev Notes for required test cases
+
+- [ ] Task 4: Add `ConsistentRead` support to `getItem` and `queryItems` in `@ai-learning-hub/db` (AC: #8)
+  - [ ] 4.1 Add `consistentRead?: boolean` to `QueryParams` interface in `backend/shared/db/src/helpers.ts`; wire into `QueryCommandInput` via `...(params.consistentRead && { ConsistentRead: true })`
+  - [ ] 4.2 Add `consistentRead?: boolean` to `getItem` options param; wire into `GetCommandInput`; update all callers in `backend/shared/db/src/` that use `getItem` (add `options` arg as `{}` to preserve existing behaviour)
+
+- [ ] Task 5: Create `saves-list` Lambda handler — `GET /saves` (AC: #1, #2, #6, #8, #9, #10)
+  - [ ] 5.1 Create `backend/functions/saves-list/handler.ts` using the `WrappedHandler<T>` / `HandlerContext` pattern — see Dev Notes for the complete handler skeleton
+  - [ ] 5.2 Parse and validate query params with `validateQueryParams` from `@ai-learning-hub/validation`: `limit` (int, 1–100, default 25) and `nextToken` (optional string). Return `AppError(ErrorCode.VALIDATION_ERROR, ...)` for invalid `limit`.
+  - [ ] 5.3 Call `queryAllItems` with `filterExpression: 'attribute_not_exists(deletedAt)'` so the 1000-item ceiling applies to **active** saves only (Critical #1 fix). No in-memory filter step needed.
+  - [ ] 5.4 Apply ULID cursor pagination from the result. If `nextToken` resolves to a `saveId` not present in the result set, throw `AppError(ErrorCode.VALIDATION_ERROR, 'nextToken is invalid or has expired — restart pagination')` (AC10, Critical #2 fix).
+  - [ ] 5.5 Log a `warn` if `truncated: true`: `logger.warn('Save list truncated at ceiling', { userId, ceiling: 1000 })`. Do NOT expose `truncated` in the response body yet — Story 3.4 will add it. Add a `// TODO(story-3.4): expose truncated in response` comment (Moderate #14).
+  - [ ] 5.6 Return `{ items: page.map(toPublicSave), ...(nextToken && { nextToken }), hasMore }` — `wrapHandler` auto-wraps this as a 200 response
+  - [ ] 5.7 Export `handler = wrapHandler(savesListHandler, { requireAuth: true })`
+
+- [ ] Task 6: Create `saves-get` Lambda handler — `GET /saves/:saveId` (AC: #3, #4, #5, #7, #8, #9)
+  - [ ] 6.1 Create `backend/functions/saves-get/handler.ts` using the `HandlerContext` pattern
+  - [ ] 6.2 Validate `saveId` path param with `validatePathParams(saveIdPathSchema, ctx.event.pathParameters)` — schema: `z.object({ saveId: z.string().regex(/^[0-9A-Z]{26}$/, 'saveId must be a 26-character ULID') })` (Significant #8 fix)
+  - [ ] 6.3 Fetch save with `getItem<SaveItem>(client, SAVES_TABLE_CONFIG, { PK: \`USER#${userId}\`, SK: \`SAVE#${saveId}\` }, { consistentRead: true }, logger)` — pass logger (Significant #7 fix)
+  - [ ] 6.4 Return 404 via `AppError(ErrorCode.NOT_FOUND, 'Save not found')` if `item === null` OR `item.deletedAt` is set (AC5). Key scoping makes AC7 automatic.
+  - [ ] 6.5 Update `lastAccessedAt` — awaited, wrapped in try/catch, uses `ctx.logger` (NOT a freshly created logger) to preserve correlation context (Significant #6 fix); pass `logger` to `updateItem` (Significant #7 fix). See Dev Notes for the exact pattern.
+  - [ ] 6.6 Return `toPublicSave(item)` — `wrapHandler` auto-wraps as 200
+  - [ ] 6.7 Export `handler = wrapHandler(savesGetHandler, { requireAuth: true })`
+
+- [ ] Task 7: Extend `saves-routes.stack.ts` CDK stack
+  - [ ] 7.1 Add `savesListFunction` and `savesGetFunction` `NodejsFunction` constructs to `infra/lib/stacks/api/saves-routes.stack.ts` — config: `memorySize: 256`, `timeout: 10s`, `tracing: ACTIVE`, env var `SAVES_TABLE_NAME`
+  - [ ] 7.2 Grant IAM: `savesTable.grantReadData(savesListFunction)` and `savesTable.grantReadData(savesGetFunction)` — read-only, sufficient for these handlers
+  - [ ] 7.3 **Do NOT grant `usersTable` access to these functions** — GET endpoints are not explicitly rate-limited in V1 (see Dev Notes: Rate Limiting Decision), so `enforceRateLimit` is not called and the users table grant would be over-permissioned (Minor #17 fix)
+  - [ ] 7.4 Wire API Gateway routes on the `/saves` resource (created in Story 3.1b): `GET` → `savesListFunction`; add `{saveId}` child resource with `GET` → `savesGetFunction`. Add `corsOptions` preflight to the `{saveId}` resource.
+  - [ ] 7.5 Expose `savesListFunction` and `savesGetFunction` as public properties on `SavesRoutesStack` (for architecture enforcement tests T1–T4)
+
+- [ ] Task 8: Update route registry
+  - [ ] 8.1 Extend `HandlerRef` union to include `'savesListFunction'` and `'savesGetFunction'`
+  - [ ] 8.2 Add two entries to `ROUTE_REGISTRY`: `GET /saves` (savesListFunction) and `GET /saves/{saveId}` (savesGetFunction), both `authType: 'jwt-or-apikey'`, `epic: 'Epic-3'`
+  - [ ] 8.3 Architecture enforcement tests (T1–T4) must still pass — they fail until CDK stack exposes matching public properties
+
+- [ ] Task 9: Write comprehensive tests (AC: all)
+  - [ ] 9.1 Tests for `query-all.ts`: single-page result, two-page accumulation (mock `LastEvaluatedKey` on first call), ceiling truncation with `truncated: true` and correct items count, empty table → `{ items: [], truncated: false }`, `ConsistentRead: true` passed to DynamoDB, FilterExpression disables Limit optimization (verify DynamoDB receives no `Limit` when filterExpression is present), page counter included in log output
+  - [ ] 9.2 Tests for `saves-list` handler: 200 with items and pagination shape, empty list → `{ items: [], hasMore: false }`, cursor pagination (page 1 → nextToken → page 2 correctly skips), stale nextToken → 400, limit=100 (max), limit=101 → 400, malformed nextToken string → 400, `ConsistentRead: true` passed through, `toPublicSave` strips PK/SK/deletedAt from each item
+  - [ ] 9.3 Tests for `saves-get` handler: 200 with save, `lastAccessedAt` updated (verify `updateItem` called), `lastAccessedAt` update failure does NOT fail response (mock `updateItem` throw → verify 200 still returned, error logged on `ctx.logger`), not found → 404, soft-deleted → 404, invalid saveId format (e.g. too short) → 400, `ConsistentRead: true` passed through
+  - [ ] 9.4 Tests for `saves.ts` (db package): `toPublicSave` strips exactly `PK`, `SK`, `deletedAt`; preserves optional fields when present and absent; `SAVES_TABLE_CONFIG.tableName` reads env var with fallback
+  - [ ] 9.5 Architecture enforcement tests (T1–T4 in `infra/test/`) pass
+
+- [ ] Task 10: Verify build and quality gates
+  - [ ] 10.1 `npm test` — all tests pass (including existing 3.1a, 3.1b, and prior epics)
+  - [ ] 10.2 `npm run lint` — no errors
+  - [ ] 10.3 `npm run build` — clean TypeScript compilation
+  - [ ] 10.4 `npm run type-check` — no type errors
+  - [ ] 10.5 `npm run format` run on all changed files
+
+## Dev Notes
+
+### Critical: Story 3.1b Must Be Done First
+
+Story 3.1b (Create Save API) is a hard prerequisite. Before starting Story 3.2, confirm these exist:
+- `infra/lib/stacks/api/saves-routes.stack.ts` (3.1b creates it; 3.2 extends it)
+- `infra/lib/stacks/core/events.stack.ts` and `EventsStack` in `infra/bin/app.ts`
+- Route registry entry for `savesCreateFunction` / `POST /saves`
+- `backend/functions/saves/handler.ts` (POST handler from 3.1b)
+
+### Critical: Correct Handler Signature — `HandlerContext`, Not `APIGatewayProxyHandler`
+
+`wrapHandler` does NOT accept a `(event, context) => ...` function. It accepts a `WrappedHandler` that receives a single `HandlerContext` object. Every handler in this project follows this pattern. Using the wrong signature compiles but `wrapHandler` will pass a `HandlerContext` where the handler expects `APIGatewayProxyEvent` — a silent runtime failure.
+
+```typescript
+import {
+  wrapHandler,
+  createSuccessResponse,
+  type HandlerContext,
+} from '@ai-learning-hub/middleware';
+
+// CORRECT ✓
+async function savesListHandler(ctx: HandlerContext) {
+  const { event, auth, requestId, logger } = ctx;
+  const userId = auth!.userId;
+  // ...
+}
+export const handler = wrapHandler(savesListHandler, { requireAuth: true });
+
+// WRONG ✗
+const savesListHandler: APIGatewayProxyHandler = async (event, context) => { ... };
+```
+
+Reference: `backend/functions/api-keys/handler.ts` — canonical example of this pattern.
+
+### Shared Packages: What to Import From Where
+
+```typescript
+// From @ai-learning-hub/types (after Task 1):
+import type { Save, SaveItem, PublicSave } from '@ai-learning-hub/types';
+
+// From @ai-learning-hub/db (after Tasks 2–4):
+import {
+  getDefaultClient,
+  getItem,
+  updateItem,
+  queryAllItems,
+  SAVES_TABLE_CONFIG,
+  toPublicSave,
+  type QueryAllParams,
+} from '@ai-learning-hub/db';
+
+// From @ai-learning-hub/middleware:
+import { wrapHandler, type HandlerContext } from '@ai-learning-hub/middleware';
+
+// From @ai-learning-hub/validation:
+import {
+  validateQueryParams,
+  validatePathParams,
+  z,
+} from '@ai-learning-hub/validation';
+
+// From @ai-learning-hub/types (errors):
+import { AppError, ErrorCode } from '@ai-learning-hub/types';
+```
+
+### New DB Additions (Tasks 1–4)
+
+#### `backend/shared/types/src/entities.ts` — Add `SaveItem` and `PublicSave`
+
+```typescript
+// Add after the existing `Save` interface:
+
+/**
+ * DynamoDB item shape for the saves table.
+ * Extends Save with internal partition/sort keys.
+ */
+export type SaveItem = Save & { PK: string; SK: string };
+
+/**
+ * Public API shape for a save — DynamoDB keys and soft-delete marker stripped.
+ */
+export type PublicSave = Omit<SaveItem, 'PK' | 'SK' | 'deletedAt'>;
+```
+
+#### `backend/shared/db/src/saves.ts` — New File
+
+```typescript
+import type { TableConfig } from './helpers.js';
+import type { SaveItem, PublicSave } from '@ai-learning-hub/types';
+
+export const SAVES_TABLE_CONFIG: TableConfig = {
+  tableName: process.env.SAVES_TABLE_NAME ?? 'ai-learning-hub-saves',
+  partitionKey: 'PK',
+  sortKey: 'SK',
+};
+
+/**
+ * Strip internal DynamoDB keys and soft-delete marker before returning to API caller.
+ * Pattern mirrors toPublicInviteCode in invite-codes.ts.
+ */
+export function toPublicSave(item: SaveItem): PublicSave {
+  const { PK, SK, deletedAt, ...rest } = item;
+  return rest;
+}
+```
+
+This follows the same pattern as `toPublicInviteCode` in `backend/shared/db/src/invite-codes.ts`. By Story 3.3 there will be 5+ saves handlers — all importing from this single shared location rather than each defining their own copy.
+
+#### `backend/shared/db/src/query-all.ts` — New File
+
+```typescript
+import { QueryCommand } from '@aws-sdk/lib-dynamodb';
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { AppError, ErrorCode } from '@ai-learning-hub/types';
+import { createLogger, type Logger } from '@ai-learning-hub/logging';
+import type { TableConfig } from './helpers.js';
+
+// Page size used when filterExpression is present.
+// Cannot use ceiling-remainder optimization because DynamoDB's Limit
+// applies before FilterExpression — it would starve accumulation on
+// tables with many soft-deleted items.
+const FILTER_PAGE_SIZE = 500;
+
+export interface QueryAllParams {
+  keyConditionExpression: string;
+  expressionAttributeValues: Record<string, unknown>;
+  expressionAttributeNames?: Record<string, string>;
+  filterExpression?: string;   // If present, Limit optimization is disabled (see above)
+  scanIndexForward?: boolean;
+  consistentRead?: boolean;
+  ceiling?: number;            // Max items to accumulate (default: 1000)
+}
+
+export async function queryAllItems<T>(
+  client: DynamoDBDocumentClient,
+  config: TableConfig,
+  params: QueryAllParams,
+  logger?: Logger
+): Promise<{ items: T[]; truncated: boolean }> {
+  const log = logger ?? createLogger();
+  const ceiling = params.ceiling ?? 1000;
+  const allItems: T[] = [];
+  let lastKey: Record<string, unknown> | undefined;
+  let truncated = false;
+  let pages = 0;
+  const startTime = Date.now();
+
+  do {
+    // When filterExpression is present, skip the Limit optimization:
+    // DynamoDB Limit caps scanned items BEFORE filtering, so it would
+    // under-accumulate when many items are filtered out.
+    const limitValue = params.filterExpression
+      ? FILTER_PAGE_SIZE
+      : ceiling - allItems.length;
+
+    const input = {
+      TableName: config.tableName,
+      KeyConditionExpression: params.keyConditionExpression,
+      ExpressionAttributeValues: params.expressionAttributeValues,
+      ...(params.expressionAttributeNames && {
+        ExpressionAttributeNames: params.expressionAttributeNames,
+      }),
+      ...(params.filterExpression && { FilterExpression: params.filterExpression }),
+      ...(params.scanIndexForward !== undefined && {
+        ScanIndexForward: params.scanIndexForward,
+      }),
+      ...(params.consistentRead && { ConsistentRead: true }),
+      ...(lastKey && { ExclusiveStartKey: lastKey }),
+      Limit: limitValue,
+    };
+
+    const result = await client.send(new QueryCommand(input));
+    pages++;
+    const page = (result.Items ?? []) as T[];
+    allItems.push(...page);
+    lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+
+    if (allItems.length >= ceiling && lastKey) {
+      truncated = true;
+      // Trim to exactly ceiling — in the filter case we may have received
+      // slightly more items if the last page pushed us over.
+      allItems.splice(ceiling);
+      break;
+    }
+  } while (lastKey);
+
+  log.timed('DynamoDB QueryAll', startTime, {
+    table: config.tableName,
+    totalItems: allItems.length,
+    pages,
+    truncated,
+  });
+
+  return { items: allItems, truncated };
+}
+```
+
+**DynamoDB throttle note:** AWS SDK v3 retries throttled requests automatically with exponential backoff (default: 3 retries). If all retries are exhausted the helper throws, and `wrapHandler` catches it and returns a 500. Returning partial results on throttle is not implemented — at boutique scale, throttle on the saves table is extremely unlikely (on-demand capacity mode). (Moderate #13)
+
+### Handler: `saves-list` — Complete Implementation
+
+**File:** `backend/functions/saves-list/handler.ts`
+
+```typescript
+import { getDefaultClient, queryAllItems, SAVES_TABLE_CONFIG, toPublicSave } from '@ai-learning-hub/db';
+import { wrapHandler, type HandlerContext } from '@ai-learning-hub/middleware';
+import { validateQueryParams, z } from '@ai-learning-hub/validation';
+import { AppError, ErrorCode } from '@ai-learning-hub/types';
+import type { SaveItem } from '@ai-learning-hub/types';
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+const CEILING = 1000;
+
+const listQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),
+  nextToken: z.string().optional(),
+});
+
+function encodeNextToken(saveId: string): string {
+  return Buffer.from(saveId).toString('base64url');
+}
+
+function decodeNextToken(token: string): string | undefined {
+  try {
+    return Buffer.from(token, 'base64url').toString('utf-8');
+  } catch {
+    return undefined;
+  }
+}
+
+async function savesListHandler(ctx: HandlerContext) {
+  const { event, auth, requestId, logger } = ctx;
+  const userId = auth!.userId;
+  const client = getDefaultClient();
+
+  const { limit, nextToken: nextTokenParam } = validateQueryParams(
+    listQuerySchema,
+    event.queryStringParameters
+  );
+
+  // Fetch active saves up to ceiling. FilterExpression ensures the ceiling
+  // applies to ACTIVE items only — soft-deleted items do not count toward it.
+  const { items: activeSaves, truncated } = await queryAllItems<SaveItem>(
+    client,
+    SAVES_TABLE_CONFIG,
+    {
+      keyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+      expressionAttributeValues: {
+        ':pk': `USER#${userId}`,
+        ':prefix': 'SAVE#',   // REQUIRED: excludes URL#<urlHash> marker items (Story 3.1b)
+      },
+      filterExpression: 'attribute_not_exists(deletedAt)',
+      scanIndexForward: false,     // newest first
+      consistentRead: true,         // NFR-R7
+      ceiling: CEILING,
+    },
+    logger
+  );
+
+  // TODO(story-3.4): expose truncated in response so clients can surface
+  // "Showing your most recent 1000 saves" banner.
+  if (truncated) {
+    logger.warn('Save list truncated at ceiling', { userId, ceiling: CEILING });
+  }
+
+  // Apply ULID cursor pagination over the in-memory active result set.
+  let startIndex = 0;
+  if (nextTokenParam) {
+    const cursorSaveId = decodeNextToken(nextTokenParam);
+    if (!cursorSaveId) {
+      throw new AppError(
+        ErrorCode.VALIDATION_ERROR,
+        'nextToken is invalid or has expired — restart pagination'
+      );
+    }
+    const idx = activeSaves.findIndex((s) => s.saveId === cursorSaveId);
+    if (idx === -1) {
+      // Cursor item is no longer in the result set (e.g. was soft-deleted
+      // between requests). Client must restart pagination explicitly.
+      throw new AppError(
+        ErrorCode.VALIDATION_ERROR,
+        'nextToken is invalid or has expired — restart pagination'
+      );
+    }
+    startIndex = idx + 1;
+  }
+
+  const page = activeSaves.slice(startIndex, startIndex + limit);
+  const hasMore = startIndex + limit < activeSaves.length;
+  const nextToken =
+    hasMore ? encodeNextToken(page[page.length - 1].saveId) : undefined;
+
+  return {
+    items: page.map(toPublicSave),
+    ...(nextToken && { nextToken }),
+    hasMore,
+  };
+}
+
+export const handler = wrapHandler(savesListHandler, { requireAuth: true });
+```
+
+### Handler: `saves-get` — Complete Implementation
+
+**File:** `backend/functions/saves-get/handler.ts`
+
+```typescript
+import {
+  getDefaultClient,
+  getItem,
+  updateItem,
+  SAVES_TABLE_CONFIG,
+  toPublicSave,
+} from '@ai-learning-hub/db';
+import { wrapHandler, type HandlerContext } from '@ai-learning-hub/middleware';
+import { validatePathParams, z } from '@ai-learning-hub/validation';
+import { AppError, ErrorCode } from '@ai-learning-hub/types';
+import type { SaveItem } from '@ai-learning-hub/types';
+
+const saveIdPathSchema = z.object({
+  saveId: z
+    .string()
+    .regex(/^[0-9A-Z]{26}$/, 'saveId must be a 26-character ULID'),
+});
+
+async function savesGetHandler(ctx: HandlerContext) {
+  const { event, auth, requestId, logger } = ctx;
+  const userId = auth!.userId;
+  const client = getDefaultClient();
+
+  // Validate path param — rejects malformed inputs before touching DynamoDB (Significant #8)
+  const { saveId } = validatePathParams(saveIdPathSchema, event.pathParameters);
+
+  // Fetch save. PK scoping (USER#<userId>) enforces per-user isolation (AC7).
+  const item = await getItem<SaveItem>(
+    client,
+    SAVES_TABLE_CONFIG,
+    { PK: `USER#${userId}`, SK: `SAVE#${saveId}` },
+    { consistentRead: true },   // NFR-R7
+    logger                       // pass logger for structured DynamoDB error context
+  );
+
+  if (!item || item.deletedAt) {
+    throw new AppError(ErrorCode.NOT_FOUND, 'Save not found');
+  }
+
+  // Update lastAccessedAt — awaited but non-throwing (AC4).
+  // Use ctx.logger (NOT createLogger()) to preserve correlation context
+  // (requestId, traceId, userId already set on the wrapHandler-injected logger).
+  try {
+    await updateItem(
+      client,
+      SAVES_TABLE_CONFIG,
+      {
+        key: { PK: `USER#${userId}`, SK: `SAVE#${saveId}` },
+        updateExpression: 'SET lastAccessedAt = :now',
+        expressionAttributeValues: { ':now': new Date().toISOString() },
+      },
+      logger   // pass same logger — preserves correlation context
+    );
+  } catch (err) {
+    logger.error('Failed to update lastAccessedAt (non-fatal)', err as Error, {
+      saveId,
+    });
+    // Never propagate — response is returned regardless
+  }
+
+  return toPublicSave(item);
+}
+
+export const handler = wrapHandler(savesGetHandler, { requireAuth: true });
+```
+
+### In-Memory Pagination Design: Why ULID Cursor Is Stable Under Concurrent Inserts
+
+The reviewer raised a concern about cursor stability when new saves are created between paginated requests. This is handled correctly by the ULID properties:
+
+- Items are sorted by `SK` (SAVE#<ULID>) with `ScanIndexForward=false` — newest first
+- ULIDs encode creation time and sort lexicographically in the same order as `createdAt`
+- A new save created between page 1 and page 2 has a newer ULID (higher sort key)
+- With newest-first ordering, the new item appears **above** the cursor position
+- `startIndex = idx + 1` correctly skips past the cursor to items **older** than it ✓
+
+The only genuine stale cursor case is when the cursor item itself (the last item of the previous page) is **soft-deleted** between requests. With the `filterExpression: 'attribute_not_exists(deletedAt)'` fix, that item disappears from the next fetch → `idx === -1` → 400 INVALID_CURSOR (AC10).
+
+### Rate Limiting Decision — GET Endpoints Not Explicitly Rate-Limited (Significant #5)
+
+`GET /saves` and `GET /saves/:saveId` do NOT call `enforceRateLimit` in V1. Rationale:
+- All write endpoints (POST, PATCH, DELETE) are rate-limited — these protect data modification
+- Read endpoints rely on API Gateway's built-in throttle (500 RPS per endpoint by default)
+- At boutique scale (<100 users), read abuse is not a current risk
+
+**Consequence for CDK:** The `savesListFunction` and `savesGetFunction` Lambdas do **NOT** need `usersTable` access (the users table is only needed by `enforceRateLimit`). Grant `savesTable.grantReadData()` only — not `usersTable.grantReadWriteData()` (Minor #17 fix).
+
+If the policy changes, add `enforceRateLimit` call with a high threshold (e.g., 1000/hour) and add `usersTable.grantReadWriteData()` at that time.
+
+### CDK Extension: `saves-routes.stack.ts`
+
+Story 3.1b **creates** this file. Story 3.2 **extends** it. The `SavesRoutesStackProps` interface and `eventBus` prop already exist from 3.1b — do not add them again (Moderate #11).
+
+In the stack constructor, add after the existing `savesCreateFunction`:
+
+```typescript
+// saves-list — GET /saves
+const savesListFunction = new lambda.NodejsFunction(this, 'SavesListFunction', {
+  entry: path.join(__dirname, '../../../../backend/functions/saves-list/handler.ts'),
+  handler: 'handler',
+  memorySize: 256,
+  timeout: cdk.Duration.seconds(10),
+  tracing: lambda.Tracing.ACTIVE,
+  environment: { SAVES_TABLE_NAME: props.savesTable.tableName },
+});
+// Read-only: no usersTable grant needed (GET endpoints not rate-limited in V1)
+props.savesTable.grantReadData(savesListFunction);
+this.savesListFunction = savesListFunction;
+
+// saves-get — GET /saves/:saveId
+const savesGetFunction = new lambda.NodejsFunction(this, 'SavesGetFunction', {
+  entry: path.join(__dirname, '../../../../backend/functions/saves-get/handler.ts'),
+  handler: 'handler',
+  memorySize: 256,
+  timeout: cdk.Duration.seconds(10),
+  tracing: lambda.Tracing.ACTIVE,
+  environment: { SAVES_TABLE_NAME: props.savesTable.tableName },
+});
+// grantReadData is sufficient for getItem; grantReadWriteData is for updateItem.
+// updateItem is used for lastAccessedAt — update to grantReadWriteData if IAM errors occur.
+// Keeping minimal scope first; lastAccessedAt update is non-fatal if it fails.
+props.savesTable.grantReadWriteData(savesGetFunction);  // updateItem for lastAccessedAt
+this.savesGetFunction = savesGetFunction;
+```
+
+**Note:** `savesGetFunction` needs `grantReadWriteData` (not `grantReadData`) because `updateItem` requires `dynamodb:UpdateItem` permission — even though it's a non-fatal side-effect, the Lambda needs the permission or it will log a 403 error on every call.
+
+Wire routes on the `/saves` resource tree:
+```typescript
+// savesResource already exists from Story 3.1b (has POST method + CORS)
+savesResource.addMethod('GET',
+  new apigateway.LambdaIntegration(savesListFunction),
+  { authorizer: props.apiKeyAuthorizer, authorizationType: apigateway.AuthorizationType.CUSTOM }
+);
+
+const saveByIdResource = savesResource.addResource('{saveId}');
+saveByIdResource.addCorsPreflight(corsOptions);
+saveByIdResource.addMethod('GET',
+  new apigateway.LambdaIntegration(savesGetFunction),
+  { authorizer: props.apiKeyAuthorizer, authorizationType: apigateway.AuthorizationType.CUSTOM }
+);
+```
+
+Add public class properties:
+```typescript
+public readonly savesListFunction: lambda.NodejsFunction;
+public readonly savesGetFunction: lambda.NodejsFunction;
+```
+
+### Route Registry Update
+
+```typescript
+// Extend HandlerRef (after 'savesCreateFunction' from 3.1b):
+export type HandlerRef =
+  | "validateInviteFunction"
+  | "usersMeFunction"
+  | "apiKeysFunction"
+  | "generateInviteFunction"
+  | "savesCreateFunction"    // Story 3.1b
+  | "savesListFunction"      // Story 3.2
+  | "savesGetFunction";      // Story 3.2
+
+// Add to ROUTE_REGISTRY:
+{
+  path: '/saves',
+  methods: ['GET'],
+  authType: 'jwt-or-apikey',
+  handlerRef: 'savesListFunction',
+  epic: 'Epic-3',
+},
+{
+  path: '/saves/{saveId}',
+  methods: ['GET'],
+  authType: 'jwt-or-apikey',
+  handlerRef: 'savesGetFunction',
+  epic: 'Epic-3',
+},
+```
+
+Use `{saveId}` (curly braces) to match CDK's `addResource('{saveId}')` syntax — consistent with the existing `{id}` entry for `/users/api-keys/{id}`.
+
+### Public Save Response Shape
+
+`PublicSave` (from `@ai-learning-hub/types`) after stripping `PK`, `SK`, `deletedAt`:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `saveId` | `string` | ULID |
+| `url` | `string` | Original URL as submitted |
+| `normalizedUrl` | `string` | After normalization (Story 3.1a) |
+| `urlHash` | `string` | SHA-256 of normalizedUrl |
+| `contentType` | `ContentType` | Enum value |
+| `tags` | `string[]` | Max 20 tags |
+| `isTutorial` | `boolean` | Always `false` until Epic 8 |
+| `linkedProjectCount` | `number` | Always `0` until Epic 5 |
+| `createdAt` | `string` | ISO 8601 |
+| `updatedAt` | `string` | ISO 8601 |
+| `userId` | `string` | Included for API client convenience |
+| `title` | `string?` | Present if set |
+| `userNotes` | `string?` | Present if set |
+| `lastAccessedAt` | `string?` | Set after first `GET /saves/:saveId` |
+| `enrichedAt` | `string?` | Set by Epic 9 enrichment (absent until then) |
+
+Fields never present: `PK`, `SK`, `deletedAt`, `tutorialStatus` (intentionally omitted at creation per Story 3.1b — absent items don't appear in JSON).
+
+### Architecture Compliance
+
+| ADR / NFR | How This Story Complies |
+|-----------|------------------------|
+| ADR-001 (DynamoDB) | `PK=USER#<userId>`, `SK=SAVE#<saveId>`. `begins_with(SK, 'SAVE#')` excludes URL marker items (`SK=URL#<urlHash>`) from Story 3.1b. |
+| ADR-005 (No L2L) | Pure read handlers — no Lambda invocations, no EventBridge |
+| ADR-008 (Error Handling) | All errors via `AppError` caught by `wrapHandler`. 404 for missing/soft-deleted/wrong-user saves. 400 for stale cursor. |
+| ADR-014 (API-First) | List endpoint: `{ items, nextToken?, hasMore }`. `nextToken` is opaque base64url. |
+| ADR-016 (Cold Starts) | NFR-P2 qualified as warm invocation |
+| NFR-R7 | `ConsistentRead: true` on **saves table** main-table reads only. Epic 2 users-table reads are unchanged. |
+| NFR-S4 | Per-user isolation enforced by DynamoDB key scoping. `getItem` with wrong userId → returns null. `queryAllItems` with wrong userId → returns empty. |
+
+### Testing Standards
+
+- **Framework:** Vitest
+- **Coverage:** 80% minimum (CI-enforced)
+- **Mock pattern:** `vi.mock('@ai-learning-hub/db')` for DynamoDB helpers. Use shared `wrapHandler` mock from `backend/shared/middleware/test/mock-wrapper.ts` (Story 2.1-D3). See `backend/functions/api-keys/handler.test.ts` for the canonical import and usage pattern.
+- **HandlerContext mock:** Provide `{ event, auth: { userId }, requestId, logger: mockLogger, startTime }` to handler functions directly (bypassing `wrapHandler`), or use the mock-wrapper.
+- **ConsistentRead verification:** Assert that `queryAllItems`/`getItem` were called with `consistentRead: true`.
+- **FilterExpression verification:** Assert that `queryAllItems` was called with `filterExpression: 'attribute_not_exists(deletedAt)'` — this verifies the ceiling applies to active items.
+
+### Project Structure Notes
+
+| File | Action |
+|------|--------|
+| `backend/shared/types/src/entities.ts` | **Modify** — add `SaveItem`, `PublicSave` types |
+| `backend/shared/db/src/saves.ts` | **Create** — `SAVES_TABLE_CONFIG`, `toPublicSave` |
+| `backend/shared/db/src/query-all.ts` | **Create** — `queryAllItems` helper |
+| `backend/shared/db/src/helpers.ts` | **Modify** — add `consistentRead` to `QueryParams` and `getItem` |
+| `backend/shared/db/src/index.ts` | **Modify** — export new symbols |
+| `backend/functions/saves-list/handler.ts` | **Create** — `GET /saves` handler |
+| `backend/functions/saves-get/handler.ts` | **Create** — `GET /saves/:saveId` handler |
+| `infra/lib/stacks/api/saves-routes.stack.ts` | **Modify** — add two Lambda functions and routes |
+| `infra/config/route-registry.ts` | **Modify** — extend `HandlerRef`, add 2 routes |
+
+**Note on function directories:** `backend/functions/saves-list/` and `backend/functions/saves-get/` are separate Lambda directories (Lambda per concern per ADR-005). Each has a single `handler.ts`. The `saves/` directory (with `handler.ts` from Story 3.1b) handles `POST /saves` only — do not add files to it.
+
+### Story 3.4 Forward Compatibility
+
+Story 3.2 is deliberately designed for Story 3.4 to extend:
+- The `nextToken` cursor format (base64url of `saveId`) is stable — 3.4 adds filter params but keeps the same cursor semantics
+- Story 3.4 modifies `saves-list/handler.ts` to add filter/sort query params and the `truncated` response flag (the `truncated` variable already exists in the handler, just not exposed yet)
+- The `queryAllItems` helper already supports `filterExpression`, `scanIndexForward` — Story 3.4 composes with these
+
+### References
+
+- [Source: docs/progress/epic-3-stories-and-plan.md#Story-3.2] — ACs, pagination strategy, nextToken semantics
+- [Source: _bmad-output/implementation-artifacts/3-1b-create-save-api.md] — `SAVES_TABLE_CONFIG` pattern, `toPublicSave`, URL marker item (`SK=URL#<urlHash>`), CDK stack structure
+- [Source: backend/shared/middleware/src/wrapper.ts] — `wrapHandler`, `HandlerContext` — handler signature pattern
+- [Source: backend/functions/api-keys/handler.ts] — Canonical `HandlerContext` handler pattern, `validateQueryParams`, `validatePathParams` usage
+- [Source: backend/shared/db/src/helpers.ts] — `getItem`, `queryItems`, `updateItem` helpers
+- [Source: backend/shared/db/src/invite-codes.ts] — `toPublicInviteCode` pattern (model for `toPublicSave`)
+- [Source: backend/shared/db/src/users.ts] — `USERS_TABLE_CONFIG` pattern (model for `SAVES_TABLE_CONFIG`)
+- [Source: backend/shared/types/src/entities.ts] — `Save` type (base for `SaveItem`)
+- [Source: backend/shared/logging/src/logger.ts] — `Logger.timed()` confirmed to exist at line 230
+- [Source: infra/lib/stacks/api/auth-routes.stack.ts] — CDK route wiring pattern (corsOptions, addMethod, LambdaIntegration)
+- [Source: infra/config/route-registry.ts] — Route registry pattern
+
+## Dev Agent Record
+
+### Agent Model Used
+
+{{agent_model_name_version}}
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -82,8 +82,9 @@ development_status:
   # Epic 3: Save URLs - Core CRUD (11 stories)
   epic-3: in-progress
   3-1a-save-validation-modules: done  # PR #156 merged 2026-02-19
-  3-1b-create-save-api: backlog
-  3-2-list-get-saves-api: backlog
+  3-1c-events-shared-package: ready-for-dev
+  3-1b-create-save-api: ready-for-dev
+  3-2-list-get-saves-api: ready-for-dev
   3-3-update-delete-restore-api: backlog
   3-4-save-filtering-sorting: backlog
   3-5-ios-shortcut-capture: backlog


### PR DESCRIPTION
## Summary

- Tracks `3-1b-create-save-api.md` under version control (was untracked since creation)
- Adds `3-1c-events-shared-package.md` — new story extracting EventBridge fire-and-forget emitter into a reusable `@ai-learning-hub/events` shared package (dependency of 3-1b and all future event-emitting handlers)
- Adds `3-2-list-get-saves-api.md` — `GET /saves` + `GET /saves/:saveId`, including adversarial review with 17 findings resolved
- Updates `sprint-status.yaml`: 3-1b, 3-1c, 3-2 promoted to `ready-for-dev`

## Changes

| File | Action |
|------|--------|
| `3-1b-create-save-api.md` | Tracked for first time |
| `3-1c-events-shared-package.md` | New story artifact |
| `3-2-list-get-saves-api.md` | New story artifact (post adversarial review) |
| `sprint-status.yaml` | 3-1b/3-1c/3-2 → `ready-for-dev` |

## Key decisions in 3-2 (post adversarial review)

- **Soft-delete ceiling fix:** FilterExpression `attribute_not_exists(deletedAt)` passed to `queryAllItems` so the 1000-item ceiling applies to active saves only
- **Stale cursor → 400:** Explicit `VALIDATION_ERROR` when cursor item no longer exists; client must restart pagination (AC10 added)
- **`queryAllItems` FilterExpression + Limit semantic:** Limit optimization disabled when FilterExpression present; fixed page size of 500 used instead
- **Shared packages:** `SaveItem`/`PublicSave` types → `@ai-learning-hub/types`; `SAVES_TABLE_CONFIG`/`toPublicSave` → `@ai-learning-hub/db`
- **Handler signature:** Corrected to `HandlerContext` (not `APIGatewayProxyHandler`) per `wrapper.ts`
- **GET endpoints not rate-limited** in V1; no `usersTable` grant for read functions

## Testing

- No code changes — story artifacts only
- `npm test`, `npm run lint`, `npm run build` pass (no source changes)

## Checklist

- [x] Story artifacts reviewed and adversarially tested (3-2: 17 findings, all resolved)
- [x] `sprint-status.yaml` updated consistently
- [x] All files reference correct shared library patterns (`HandlerContext`, `@ai-learning-hub/*`)
- [x] Closes #160

Closes #160

Made with [Cursor](https://cursor.com)