### PR TITLE
docs: adversarial architecture review + D7 story artifacts

### DIFF
--- a/_bmad-output/implementation-artifacts/2.1-D7-adversarial-review-fixes.md
+++ b/_bmad-output/implementation-artifacts/2.1-D7-adversarial-review-fixes.md
@@ -1,0 +1,456 @@
+---
+id: "2.1-D7"
+title: "Adversarial Architecture Review Fixes"
+status: ready-for-dev
+depends_on: ["2.1-D5"]
+touches:
+  - infra/test/architecture-enforcement
+  - infra/test/helpers
+  - infra/lib/stacks/api
+  - infra/lib/stacks/auth
+  - backend/shared/types/src/errors.ts
+  - backend/shared/middleware/src/wrapper.ts
+  - backend/shared/middleware/package.json
+  - backend/shared/db/src/users.ts
+  - backend/shared/db/src/invite-codes.ts
+  - backend/shared/types/src/entities.ts
+  - backend/functions/api-keys
+  - backend/functions/invite-codes
+  - backend/functions/users-me
+  - frontend/src/api
+  - frontend/vite.config.ts
+risk: medium
+---
+
+# Story 2.1.D7: Adversarial Architecture Review Fixes
+
+## Story
+
+As a developer about to build Epic 3 saves endpoints and future frontend features,
+I want the 15 findings from the adversarial architecture review (2026-02-20) fixed — covering architecture enforcement test blind spots, ADR-008 contract gaps, request logging, configuration discipline, handler test coverage, type alignment, and frontend API foundations,
+so that the project's structural soundness moves from 7/10 to 9/10 and Epics 3+ build on a genuinely robust base rather than accumulating debt.
+
+## Context & Motivation
+
+An adversarial architecture review on 2026-02-20 (post D5/D6) identified 15 findings across 5 severity levels. The most critical: architecture enforcement tests (T1-T4) can detect _presence_ of handler wiring but not _correctness_ — a route pointing to the wrong Lambda would silently ship. Three handlers return 405 responses via hand-built JSON that bypasses ADR-008, the DB layer silently falls back to hardcoded table names, and the frontend has zero API integration infrastructure.
+
+These findings are cataloged in `docs/adversarial-architecture-review-2026-02-20.md` with file paths, line numbers, and proposed fixes. This story specifies the implementation plan for all 15 fixes.
+
+**Review findings addressed:** F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15
+
+## Acceptance Criteria
+
+### Group A: Architecture Enforcement Hardening (F1, F3, F5)
+
+1. **AC1** — Given the route registry maps `handlerRef` to a specific Lambda, when T2/T4 runs, then each route's `Integration.Uri` in the CDK template is validated against the _specific_ Lambda expected for that `handlerRef` — not just any Lambda. If `/users/me` is accidentally wired to `apiKeysFunction`, the test fails with a message identifying the mismatch.
+
+2. **AC2** — Given the T2-AC6 and T4-AC10 orphan detection tests, when they run, then orphan detection works by parsing each Method's `Integration.Uri` to extract the Lambda function ARN reference (via `Fn::GetAtt` or `Fn::Join`), building a `handlerRef → Lambda ARN` map from CDK template resources, and verifying every handler ref in the registry appears in at least one method's integration — replacing the current unreliable cardinality comparison.
+
+3. **AC3** — Given the T1-AC2 Gateway Response test, when it validates `UNAUTHORIZED`, `ACCESS_DENIED`, `THROTTLED`, `DEFAULT_5XX` responses, then it also verifies each `GatewayResponse` resource's `StatusCode` property matches the expected HTTP status for that response type (e.g., `THROTTLED` → `429`, `UNAUTHORIZED` → `401`).
+
+### Group B: ADR-008 Contract — METHOD_NOT_ALLOWED (F13)
+
+4. **AC4** — Given the `ErrorCode` enum in `backend/shared/types/src/errors.ts`, when the enum is inspected, then `METHOD_NOT_ALLOWED = "METHOD_NOT_ALLOWED"` exists as a member and `ErrorCodeToStatus` maps it to `405`.
+
+5. **AC5** — Given the handlers `api-keys/handler.ts`, `invite-codes/handler.ts`, `users-me/handler.ts`, when an unsupported HTTP method is received, then the handler throws `new AppError(ErrorCode.METHOD_NOT_ALLOWED, ...)` with an `Allow` header in the details, and `wrapHandler` returns the response through `createErrorResponse` — replacing the current hand-built 405 JSON.
+
+6. **AC6** — Given the updated 405 responses flow through `createErrorResponse`, when existing handler tests assert `METHOD_NOT_ALLOWED`, then `assertADR008Error(result, "METHOD_NOT_ALLOWED", 405)` passes and the `Allow` header is present in the response.
+
+### Group C: Request Logging (F4)
+
+7. **AC7** — Given `wrapHandler` in `backend/shared/middleware/src/wrapper.ts`, when a request is received, then the wrapper logs `"Request received"` with `{ method, path, queryParams }` immediately after logger creation and before auth extraction.
+
+8. **AC8** — Given the new request-entry log line, when all existing handler tests run, then they continue to pass without modification (the log line is informational, not behavioral).
+
+### Group D: Configuration Discipline (F14, F7, F12)
+
+9. **AC9** — Given `USERS_TABLE_CONFIG` in `backend/shared/db/src/users.ts` and `INVITE_CODES_TABLE_CONFIG` in `backend/shared/db/src/invite-codes.ts`, when the `*_TABLE_NAME` env var is missing at runtime, then the module throws a clear error (`"USERS_TABLE_NAME environment variable is required"`) instead of silently falling back to a hardcoded name. Test environments may set `NODE_ENV=test` to use fallbacks.
+
+10. **AC10** — Given `TablesStack` in `infra/lib/stacks/core/tables.stack.ts`, when it creates DynamoDB tables, then table names include an environment prefix (e.g., `dev-ai-learning-hub-users`). The prefix is passed as a stack prop from `bin/app.ts` and defaults to `"dev"`.
+
+11. **AC11** — Given `ApiGatewayStack` in `infra/lib/stacks/api/api-gateway.stack.ts`, when it creates the REST API deployment, then `stageName` is a configurable stack prop that defaults to `"dev"` — not a hardcoded string literal.
+
+### Group E: Handler Test Coverage (F8, F9)
+
+12. **AC12** — Given handlers that call `enforceRateLimit()` before business logic (api-keys POST, invite-codes POST, validate-invite POST), when handler tests run, then at least one test per handler verifies the call ordering: `enforceRateLimit` is called before the business operation (e.g., `createApiKey`, `createInviteCode`).
+
+13. **AC13** — Given handlers wrapped with `requiredScope` (api-keys POST/DELETE, invite-codes POST), when a handler test sends a request with `authMethod: "api-key"` and insufficient scopes, then the response is `403 SCOPE_INSUFFICIENT` via `assertADR008Error`.
+
+### Group F: Type Alignment & Cleanup (F15, F6)
+
+14. **AC14** — Given `InviteCode` in `backend/shared/types/src/entities.ts` and `InviteCodeItem` in `backend/shared/db/src/invite-codes.ts`, when field names are compared, then they use consistent terminology: the types package uses `generatedBy`/`redeemedBy` (matching the DB source of truth), not `createdBy`/`usedBy`.
+
+15. **AC15** — Given `backend/shared/middleware/package.json`, when its dependencies are inspected, then `@ai-learning-hub/validation` is NOT listed (it was unused).
+
+### Group G: IAM Least Privilege (F11)
+
+16. **AC16** — Given the JWT and API Key authorizer Lambdas in `infra/lib/stacks/auth/auth.stack.ts`, when their IAM permissions are inspected, then they use explicit action grants (`dynamodb:GetItem`, `dynamodb:PutItem`, `dynamodb:UpdateItem`, `dynamodb:Query`) instead of `grantReadWriteData` (which includes `Scan`, `BatchGetItem`, `BatchWriteItem`).
+
+### Group H: Frontend API Foundations (F2, F10)
+
+17. **AC17** — Given a file `frontend/src/api/client.ts`, when it is imported, then it exports a typed `ApiClient` class or function that: (a) takes a base URL from `VITE_API_URL`, (b) provides `get<T>()`, `post<T>()`, `patch<T>()`, `delete()` methods that unwrap the `{ data: T }` envelope and return `Promise<T>` (throwing typed `AppError`-shaped errors on non-2xx), (c) accepts an auth token injection function.
+
+18. **AC18** — Given a file `frontend/src/api/hooks.ts`, when `useApiClient()` is called inside a React component, then it returns an `ApiClient` instance configured with the current Clerk session token via `useAuth()`.
+
+19. **AC19** — Given `frontend/vite.config.ts`, when Vite resolves `@ai-learning-hub/types`, then it resolves to the shared types package source (via `resolve.alias` or workspace dependency), and TypeScript compilation succeeds.
+
+### Group I: Gate
+
+20. **AC20** — All existing tests pass (`npm test`), CDK synth passes, no lint errors, and no regressions in coverage thresholds.
+
+## Tasks / Subtasks
+
+- [ ] **Task 1: Harden T2/T4 handler identity and orphan detection** (AC: #1, #2)
+  - [ ] 1.1 In `infra/test/helpers/create-test-api-stacks.ts`, add an explicit `HANDLER_REF_TO_CONSTRUCT_ID` map (e.g., `{ validateInviteFunction: "ValidateInviteFunction", ... }`) and a helper `buildHandlerRefToLambdaArn(template)` that uses this map to find each handler's Lambda logical ID in the CDK template deterministically — do NOT use fuzzy substring matching on logical IDs
+  - [ ] 1.2 In `route-completeness.test.ts` (T2-AC5), enhance the test so that for each route, the Method's `Integration.Uri` references the Lambda corresponding to the route's `handlerRef` — not just any Lambda
+  - [ ] 1.3 In `route-completeness.test.ts` (T2-AC6), replace the cardinality comparison with a deterministic check: parse each Method's `Integration.Uri`, extract Lambda ARN references, and verify every `handlerRef` in the registry appears in at least one integration
+  - [ ] 1.4 In `lambda-route-wiring.test.ts` (T4-AC9), replace the weak `uriStr.includes("lambda")` check with validation that the URI references a real Lambda function ARN from the template
+  - [ ] 1.5 In `lambda-route-wiring.test.ts` (T4-AC10), apply the same deterministic orphan detection from 1.3
+  - [ ] 1.6 Write a dedicated test case that creates a mis-wired test fixture (swapping `usersMeFunction` and `apiKeysFunction` in the test helper's stack setup) and asserts the handler identity test fails — do NOT modify production stacks; the miswiring must be isolated to a test-only fixture
+
+- [ ] **Task 2: Add Gateway Response status code validation to T1** (AC: #3)
+  - [ ] 2.1 In `api-gateway-contract.test.ts`, add a sub-test under AC2 that extracts `StatusCode` from each `AWS::ApiGateway::GatewayResponse` resource
+  - [ ] 2.2 Assert each response type maps to the correct HTTP status: `UNAUTHORIZED` → `401`, `ACCESS_DENIED` → `403`, `THROTTLED` → `429`, `DEFAULT_5XX` → `500`
+
+- [ ] **Task 3: Add METHOD_NOT_ALLOWED to ErrorCode enum** (AC: #4)
+  - [ ] 3.1 Add `METHOD_NOT_ALLOWED = "METHOD_NOT_ALLOWED"` to the `ErrorCode` enum in `backend/shared/types/src/errors.ts`
+  - [ ] 3.2 Add `[ErrorCode.METHOD_NOT_ALLOWED]: 405` to `ErrorCodeToStatus`
+  - [ ] 3.3 Update `assertADR008Error` tests to cover the new error code
+
+- [ ] **Task 4: Migrate handlers to use AppError for 405 responses** (AC: #5, #6)
+  - [ ] 4.1 In `backend/functions/api-keys/handler.ts`, replace the hand-built 405 JSON (line ~130-138) with `throw new AppError(ErrorCode.METHOD_NOT_ALLOWED, "Method ${method} not allowed")` — handle the `Allow` header by adding it to `wrapHandler`'s response or via `error.details`
+  - [ ] 4.2 In `backend/functions/invite-codes/handler.ts`, apply the same replacement (line ~100-110)
+  - [ ] 4.3 In `backend/functions/users-me/handler.ts`, apply the same replacement (line ~85-95)
+  - [ ] 4.4 Add a reserved `responseHeaders` key to `AppError.details` (separate from the serialized `details` in the response body). In `createErrorResponse`, extract `error.details.responseHeaders`, merge into HTTP headers, and strip it from the body's `details` object before serialization — this prevents transport metadata from leaking into the API response body
+  - [ ] 4.5 Update handler tests to use `assertADR008Error(result, "METHOD_NOT_ALLOWED", 405)` and verify `Allow` header is present
+
+- [ ] **Task 5: Add request-entry logging to wrapHandler** (AC: #7, #8)
+  - [ ] 5.1 In `backend/shared/middleware/src/wrapper.ts`, add a `logger.info("Request received", { method: event.httpMethod, path: event.path, queryParams: Object.keys(event.queryStringParameters ?? {}) })` call after logger creation (line ~107) and before auth extraction (line ~111)
+  - [ ] 5.2 Run all handler tests to verify no regressions
+
+- [ ] **Task 6: Remove DB table name fallbacks — fail fast** (AC: #9)
+  - [ ] 6.1 In `backend/shared/db/src/users.ts`, replace `process.env.USERS_TABLE_NAME ?? "ai-learning-hub-users"` with a function that throws if the env var is missing (unless `NODE_ENV === "test"`)
+  - [ ] 6.2 In `backend/shared/db/src/invite-codes.ts`, apply the same pattern for `INVITE_CODES_TABLE_NAME`
+  - [ ] 6.3 Check all other DB files (rate-limiter, helpers) for similar fallback patterns and fix
+  - [ ] 6.4 Update DB unit tests to set `NODE_ENV=test` or set the env vars explicitly in `beforeAll` / `vi.stubEnv`
+  - [ ] 6.5 Update handler tests that depend on DB modules to ensure env vars are set
+
+- [ ] **Task 7: Add environment prefix to table names** (AC: #10)
+  - [ ] 7.1 In `infra/lib/stacks/core/tables.stack.ts`, accept an `environmentPrefix` prop (default `"dev"`)
+  - [ ] 7.2 Prepend the prefix to all table names (e.g., `${prefix}-ai-learning-hub-users`)
+  - [ ] 7.3 Update `bin/app.ts` to pass the prefix from context or environment
+  - [ ] 7.4 Update CDK tests that assert table names to account for the prefix
+  - [ ] 7.5 Update Lambda environment variable injection in CDK stacks to pass the prefixed table names
+
+- [ ] **Task 8: Parameterize API Gateway stage name** (AC: #11)
+  - [ ] 8.1 In `infra/lib/stacks/api/api-gateway.stack.ts`, add `stageName` to the stack props interface with default `"dev"`
+  - [ ] 8.2 Replace the hardcoded `"dev"` string with the prop value
+  - [ ] 8.3 Update `bin/app.ts` to pass the stage name from context
+  - [ ] 8.4 Update any CDK tests that reference the stage name
+
+- [ ] **Task 9: Add rate-limit ordering tests** (AC: #12)
+  - [ ] 9.1 In `backend/functions/api-keys/handler.test.ts`, add a test that verifies `enforceRateLimit` is called before `createApiKey` using call-order tracking
+  - [ ] 9.2 In `backend/functions/invite-codes/handler.test.ts`, add a test that verifies `enforceRateLimit` is called before `createInviteCode`
+  - [ ] 9.3 In `backend/functions/validate-invite/handler.test.ts`, add a test that verifies `enforceRateLimit` is called before `validateInviteCode`
+
+- [ ] **Task 10: Add scope enforcement tests** (AC: #13)
+  - [ ] 10.1 In `backend/functions/api-keys/handler.test.ts`, add a test: API key with `["saves:read"]` scope → POST /users/api-keys → `403 SCOPE_INSUFFICIENT`
+  - [ ] 10.2 In `backend/functions/invite-codes/handler.test.ts`, add a test: API key with insufficient scope → POST /users/invite-codes → `403 SCOPE_INSUFFICIENT`
+  - [ ] 10.3 Use `createMockEvent({ authMethod: "api-key", scopes: [...] })` and `assertADR008Error`
+
+- [ ] **Task 11: Align InviteCode type fields** (AC: #14)
+  - [ ] 11.1 In `backend/shared/types/src/entities.ts`, rename `InviteCode.createdBy` → `generatedBy` and `InviteCode.usedBy` → `redeemedBy`, `InviteCode.usedAt` → `redeemedAt`, `InviteCode.createdAt` → `generatedAt`
+  - [ ] 11.2 Search for all consumers of `InviteCode.createdBy` and `InviteCode.usedBy` across the codebase and update references
+  - [ ] 11.3 Verify TypeScript compilation succeeds across all workspaces
+
+- [ ] **Task 12: Remove unused validation dependency from middleware** (AC: #15)
+  - [ ] 12.1 Remove `"@ai-learning-hub/validation": "*"` from `backend/shared/middleware/package.json` dependencies
+  - [ ] 12.2 Run `npm install` to update lockfile (this is an expected lockfile change — include it in the commit with a note in the PR)
+  - [ ] 12.3 Verify middleware builds and tests pass
+
+- [ ] **Task 13: Narrow authorizer Lambda IAM** (AC: #16)
+  - [ ] 13.1 In `infra/lib/stacks/auth/auth.stack.ts`, replace `usersTable.grantReadWriteData(jwtAuthorizerFunction)` with explicit `addToRolePolicy` grants for `dynamodb:GetItem`, `dynamodb:PutItem`, `dynamodb:UpdateItem`, `dynamodb:Query`
+  - [ ] 13.2 Apply the same narrowing for `apiKeyAuthorizerFunction`
+  - [ ] 13.3 Include GSI ARN in the resource list for `dynamodb:Query` (needed for email/API key lookups)
+  - [ ] 13.4 Verify CDK synth passes and the auth stack template has the narrower permissions
+
+- [ ] **Task 14: Create frontend API client** (AC: #17, #18, #19)
+  - [ ] 14.1 Create `frontend/src/api/client.ts` with typed `ApiClient` — `get<T>()`, `post<T>()`, `patch<T>()`, `delete()` methods, `VITE_API_URL` base, token injection callback
+  - [ ] 14.2 Create `frontend/src/api/hooks.ts` with `useApiClient()` hook that uses Clerk's `useAuth()` to inject the session token
+  - [ ] 14.3 Create `frontend/src/api/index.ts` barrel export
+  - [ ] 14.4 In `frontend/vite.config.ts`, add `resolve.alias` for `@ai-learning-hub/types` pointing to `../backend/shared/types/src`
+  - [ ] 14.5 In `frontend/tsconfig.json`, add path alias for `@ai-learning-hub/types`
+  - [ ] 14.6 Create `frontend/.env.example` with `VITE_API_URL=http://localhost:3000/dev`
+  - [ ] 14.7 Add basic unit tests for `ApiClient` in `frontend/src/api/client.test.ts` (mock fetch)
+
+- [ ] **Task 15: Verify gate** (AC: #20)
+  - [ ] 15.1 Run `npm test` across all workspaces — all tests must pass
+  - [ ] 15.2 Run `npx tsc --noEmit` across all workspaces — no type errors
+  - [ ] 15.3 Run `npm run lint` — no lint errors
+  - [ ] 15.4 Run `cd infra && cdk synth` — must complete without errors
+  - [ ] 15.5 Verify coverage thresholds still met (80%+ across all packages)
+
+## Dev Notes
+
+### Task Ordering Recommendation
+
+The 15 tasks can be grouped into independent work tracks:
+
+**Track 1 (backend core — do first):**
+Tasks 3 → 4 → 5 → 6 (ErrorCode → handlers → wrapper → DB config)
+These have sequential dependencies: Task 4 depends on Task 3, etc.
+
+**Track 2 (infra):**
+Tasks 1, 2, 7, 8, 13 (test hardening + CDK changes)
+These are independent of Track 1 but must be done before Task 15.
+
+**Track 3 (test coverage):**
+Tasks 9, 10 (handler test additions)
+Depends on Task 4 being done (405 changes) but otherwise independent.
+
+**Track 4 (cleanup):**
+Tasks 11, 12 (type alignment, dep removal)
+Independent; can be done anytime.
+
+**Track 5 (frontend):**
+Task 14 (API client foundations)
+Independent of all backend changes.
+
+### Architecture Patterns to Follow
+
+**Adding a custom header to AppError responses (Task 4):**
+
+Use a reserved `responseHeaders` key in `error.details` — extracted by `createErrorResponse` into HTTP headers and stripped before body serialization:
+```typescript
+// In error-handler.ts:
+export function createErrorResponse(error: AppError, requestId: string): APIGatewayProxyResult {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-Request-Id": requestId,
+  };
+
+  // Extract transport-only headers from details (strip before body serialization)
+  const { responseHeaders, ...bodyDetails } = error.details ?? {};
+  if (responseHeaders && typeof responseHeaders === "object") {
+    Object.assign(headers, responseHeaders);
+  }
+
+  // ... existing Retry-After logic ...
+
+  // Use bodyDetails (without responseHeaders) for the serialized body
+  const body = error.toApiError(requestId);
+  if (body.error.details) {
+    const { responseHeaders: _, ...clean } = body.error.details;
+    body.error.details = Object.keys(clean).length > 0 ? clean : undefined;
+  }
+
+  return { statusCode: error.statusCode, headers, body: JSON.stringify(body) };
+}
+
+// In handler — clean, no transport metadata leaks into body:
+throw new AppError(ErrorCode.METHOD_NOT_ALLOWED, `Method ${method} not allowed`, {
+  responseHeaders: { Allow: "GET, PATCH" },
+});
+```
+
+**Fail-fast table config pattern (Task 6):**
+```typescript
+function requireEnv(name: string, testFallback?: string): string {
+  const value = process.env[name];
+  if (value) return value;
+  if (process.env.NODE_ENV === "test" && testFallback) return testFallback;
+  throw new Error(`${name} environment variable is required`);
+}
+
+export const USERS_TABLE_CONFIG: TableConfig = {
+  tableName: requireEnv("USERS_TABLE_NAME", "ai-learning-hub-users"),
+  partitionKey: "PK",
+  sortKey: "SK",
+};
+```
+
+**Handler identity verification pattern (Task 1):**
+```typescript
+// Explicit mapping — DO NOT use fuzzy substring matching on CDK logical IDs.
+// CDK appends hash suffixes to logical IDs and may change them across versions.
+// This map is the single source of truth for which construct ID corresponds to
+// which handlerRef in the route registry.
+const HANDLER_REF_TO_CONSTRUCT_ID: Record<string, string> = {
+  validateInviteFunction: "ValidateInviteFunction",
+  usersMeFunction: "UsersMeFunction",
+  apiKeysFunction: "ApiKeysFunction",
+  generateInviteFunction: "GenerateInviteFunction",
+};
+
+function buildHandlerRefToLambdaArn(
+  template: Template
+): Map<string, string> {
+  const functions = template.findResources("AWS::Lambda::Function");
+  const map = new Map<string, string>();
+
+  for (const [handlerRef, constructId] of Object.entries(HANDLER_REF_TO_CONSTRUCT_ID)) {
+    // Find the logical ID that starts with the construct ID (CDK appends a hash)
+    const logicalId = Object.keys(functions).find((id) =>
+      id.startsWith(constructId)
+    );
+    if (!logicalId) {
+      throw new Error(`No Lambda found for handlerRef "${handlerRef}" (expected construct ID prefix "${constructId}")`);
+    }
+    map.set(handlerRef, logicalId);
+  }
+
+  return map;
+}
+```
+
+**Rate-limit ordering test pattern (Task 9):**
+```typescript
+it("enforces rate limit before creating API key", async () => {
+  const callOrder: string[] = [];
+  mockEnforceRateLimit.mockImplementation(async () => {
+    callOrder.push("rateLimit");
+  });
+  mockCreateApiKey.mockImplementation(async () => {
+    callOrder.push("createApiKey");
+    return mockApiKeyResult;
+  });
+
+  const event = createMockEvent({ method: "POST", path: "/users/api-keys", ... });
+  await handler(event, mockContext);
+
+  expect(callOrder).toEqual(["rateLimit", "createApiKey"]);
+});
+```
+
+### Key Files Reference
+
+**Files to modify:**
+```
+backend/shared/types/src/errors.ts              (add METHOD_NOT_ALLOWED)
+backend/shared/types/src/entities.ts            (rename InviteCode fields)
+backend/shared/middleware/src/wrapper.ts         (add request-entry log)
+backend/shared/middleware/src/error-handler.ts   (optional: details.headers support)
+backend/shared/middleware/package.json           (remove validation dep)
+backend/shared/db/src/users.ts                   (fail-fast env var)
+backend/shared/db/src/invite-codes.ts            (fail-fast env var)
+backend/functions/api-keys/handler.ts            (AppError for 405)
+backend/functions/api-keys/handler.test.ts       (ordering + scope + 405 tests)
+backend/functions/invite-codes/handler.ts        (AppError for 405)
+backend/functions/invite-codes/handler.test.ts   (ordering + scope + 405 tests)
+backend/functions/users-me/handler.ts            (AppError for 405)
+backend/functions/users-me/handler.test.ts       (405 test update)
+infra/test/architecture-enforcement/route-completeness.test.ts  (handler identity, orphan fix)
+infra/test/architecture-enforcement/lambda-route-wiring.test.ts (URI validation, orphan fix)
+infra/test/architecture-enforcement/api-gateway-contract.test.ts (status code validation)
+infra/test/helpers/create-test-api-stacks.ts     (handler map helper)
+infra/lib/stacks/core/tables.stack.ts            (env prefix)
+infra/lib/stacks/api/api-gateway.stack.ts        (stageName prop)
+infra/lib/stacks/auth/auth.stack.ts              (narrow IAM)
+infra/bin/app.ts                                  (pass prefix, stageName)
+```
+
+**Files to create:**
+```
+frontend/src/api/client.ts       (typed API client)
+frontend/src/api/hooks.ts        (useApiClient hook)
+frontend/src/api/index.ts        (barrel export)
+frontend/src/api/client.test.ts  (unit tests)
+frontend/.env.example            (VITE_API_URL)
+```
+
+**Files that MUST NOT be modified:**
+```
+infra/config/route-registry.ts       (data file — read only)
+backend/test-utils/                   (existing utilities — use, don't change)
+scripts/smoke-test/                   (D6 work — separate concern)
+```
+
+### Key Types & Imports Reference
+
+**ErrorCode enum** (after Task 3 — 18 values):
+- New: `METHOD_NOT_ALLOWED` → 405
+- Existing: see `backend/shared/types/src/errors.ts`
+
+**InviteCode entity** (after Task 11):
+```typescript
+interface InviteCode {
+  code: string;
+  generatedBy: string;     // was: createdBy
+  redeemedBy?: string;     // was: usedBy
+  redeemedAt?: string;     // was: usedAt
+  generatedAt: string;     // was: createdAt
+  expiresAt?: string;
+}
+```
+
+**Frontend ApiClient** (Task 14):
+```typescript
+// Methods unwrap the { data: T } envelope from ApiSuccessResponse<T> and return T directly.
+// On non-2xx, they throw an ApiError with code/message/requestId from the error envelope.
+class ApiClient {
+  constructor(baseUrl: string, getToken: () => Promise<string | null>);
+  get<T>(path: string): Promise<T>;          // unwraps { data: T } → T
+  post<T>(path: string, body: unknown): Promise<T>;
+  patch<T>(path: string, body: unknown): Promise<T>;
+  delete(path: string): Promise<void>;       // 204 No Content
+}
+```
+
+**Authorizer IAM actions needed** (Task 13):
+- `dynamodb:GetItem` — profile lookup, API key lookup
+- `dynamodb:PutItem` — ensureProfile (create-on-first-auth)
+- `dynamodb:UpdateItem` — lastUsedAt timestamp
+- `dynamodb:Query` — GSI lookups (email GSI, API key hash GSI)
+
+### Risks & Mitigations
+
+1. **Task 6 (fail-fast DB config) could break local dev / test setups** — Mitigate by keeping fallbacks when `NODE_ENV=test`. Verify all test suites set the env var or use the test escape hatch.
+
+2. **Task 7 (table name prefix) changes deployed resource names** — This is a breaking change for existing deployments. The prefix defaults to `"dev"` (matching AC10), so existing dev deployments will see table name changes and require a fresh deploy or data migration. Document this explicitly in the PR as a one-time migration step; do NOT add an unprefixed backward-compatibility mode (that defeats the purpose of environment isolation).
+
+3. **Task 11 (InviteCode field rename) could break consumers** — Search comprehensively for all `createdBy`/`usedBy` references on `InviteCode` type. The rename is a compile-time-safe refactor if TypeScript strict mode catches all references.
+
+4. **Task 14 (frontend API client) depends on Clerk SDK** — The frontend already has `@clerk/clerk-react` in package.json (scaffold setup). The `useAuth()` hook is part of Clerk's React SDK.
+
+### References
+
+- [Source: docs/adversarial-architecture-review-2026-02-20.md] — All 15 findings with file paths, line numbers, and fixes
+- [Source: docs/# AI Learning Hub — Adversarial Architec_codex.md] — Earlier Codex review (F13-F15 originated here)
+- [Source: _bmad-output/implementation-artifacts/2.1-D5-architecture-enforcement-tests.md] — T1-T4 test structure and patterns
+- [Source: _bmad-output/planning-artifacts/architecture.md#ADR-008] — Error response format
+- [Source: _bmad-output/planning-artifacts/architecture.md#ADR-013] — JWT + API Key auth design
+- [Source: _bmad-output/planning-artifacts/architecture.md#ADR-014] — API-first design
+- [Source: backend/shared/types/src/errors.ts] — ErrorCode enum, AppError class, ErrorCodeToStatus
+- [Source: backend/shared/middleware/src/wrapper.ts] — wrapHandler implementation
+- [Source: backend/shared/middleware/src/error-handler.ts] — createErrorResponse, handleError
+- [Source: infra/test/architecture-enforcement/] — T1-T4 test suites
+- [Source: infra/test/helpers/create-test-api-stacks.ts] — Shared CDK test setup
+- [Source: infra/lib/stacks/auth/auth.stack.ts] — Authorizer Lambda definitions + IAM
+- [Source: infra/config/route-registry.ts] — Route source of truth
+- [Source: docs/progress/story-2.5-review-findings-round-1.md] — Earlier 405 finding (Story 2.5 review)
+
+### Git Intelligence
+
+**Commit message pattern:** `feat: <description> (Story 2.1-D7) #<issue>`
+**Branch naming:** `story-2-1-d7-adversarial-review-fixes`
+
+**Suggested commit breakdown** (one per track):
+1. `feat: harden T1-T4 handler identity and status code validation (Story 2.1-D7) #<issue>` — Tasks 1, 2
+2. `feat: add METHOD_NOT_ALLOWED to ErrorCode, migrate handler 405s (Story 2.1-D7) #<issue>` — Tasks 3, 4
+3. `feat: add request-entry logging to wrapHandler (Story 2.1-D7) #<issue>` — Task 5
+4. `feat: fail-fast DB config, env-prefix tables, parameterize stage (Story 2.1-D7) #<issue>` — Tasks 6, 7, 8
+5. `test: add rate-limit ordering and scope enforcement tests (Story 2.1-D7) #<issue>` — Tasks 9, 10
+6. `refactor: align InviteCode types, narrow IAM, remove unused dep (Story 2.1-D7) #<issue>` — Tasks 11, 12, 13
+7. `feat: add frontend typed API client and Clerk auth hook (Story 2.1-D7) #<issue>` — Task 14
+
+## Dev Agent Record
+
+### Agent Model Used
+
+{{agent_model_name_version}}
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/docs/# AI Learning Hub — Adversarial Architec_codex.md
+++ b/docs/# AI Learning Hub — Adversarial Architec_codex.md
@@ -1,0 +1,129 @@
+# AI Learning Hub — Adversarial Architecture & Code Quality Findings
+
+## Overall Assessment
+
+The codebase is functional and not in bad shape, but it is not yet structurally strong enough for rapid scaling across future epics.
+
+Current state is best described as: **good implementation baseline, weak architecture enforcement**.
+
+## Findings (Ordered by Severity)
+
+### 1) Route registry is not truly authoritative
+
+- **Severity:** Critical
+- **Area:** Extensibility / Architecture
+- **What’s wrong:** `infra/config/route-registry.ts` declares routes, but actual route creation is still hand-coded in `infra/lib/stacks/api/auth-routes.stack.ts`, and tests hardcode route expectations too.
+- **Failure mode:** Route drift where registry and deployed API differ.
+- **Impact:** High maintenance cost and brittle route growth.
+
+### 2) Architecture enforcement tests can pass without real deployment wiring
+
+- **Severity:** High
+- **Area:** Test quality / Architecture enforcement (T2/T4)
+- **What’s wrong:** `infra/test/helpers/create-test-api-stacks.ts` wires placeholder/imported Lambda ARNs (`fromFunctionArn`) instead of validating real function constructs from `AuthStack`.
+- **Failure mode:** Tests stay green even if real handler deployment/wiring regresses.
+- **Impact:** False confidence in architecture guardrails.
+
+### 3) API contract test has a vacuous pass path
+
+- **Severity:** High
+- **Area:** Test quality (T1)
+- **What’s wrong:** One T1 auth assertion inspects methods in `ApiGatewayStack`, which intentionally has no routes/methods.
+- **Failure mode:** Critical auth checks can pass while not checking real routes.
+- **Impact:** Security and contract regressions can slip through.
+
+### 4) ADR-008 error contract is inconsistent for 405 responses
+
+- **Severity:** High
+- **Area:** ADR compliance / API consistency
+- **What’s wrong:** Handlers return `METHOD_NOT_ALLOWED`, but this is not in shared `ErrorCode` enum (`backend/shared/types/src/errors.ts`).
+- **Failure mode:** Client-side error handling tied to enum can break.
+- **Impact:** Contract drift and integration fragility.
+
+### 5) Request logging is incomplete for operational readiness
+
+- **Severity:** High
+- **Area:** Ops readiness / Observability
+- **What’s wrong:** `wrapHandler` logs completion/error but does not consistently log sanitized incoming request metadata.
+- **Failure mode:** Harder incident debugging and weaker traceability.
+- **Impact:** Slower production troubleshooting.
+
+### 6) Hardcoded table-name fallbacks in shared DB package
+
+- **Severity:** Medium
+- **Area:** ADR-014 intent / Configuration discipline
+- **What’s wrong:** Shared DB config falls back to literal table names if env vars are absent.
+- **Failure mode:** Misconfigured env can silently target wrong resources.
+- **Impact:** Environment isolation risk and deploy-time surprises.
+
+### 7) Rate limiter intentionally fails open on DynamoDB errors
+
+- **Severity:** Medium
+- **Area:** Operational readiness / Abuse protection
+- **What’s wrong:** `backend/shared/db/src/rate-limiter.ts` allows requests if DDB update fails.
+- **Failure mode:** During DDB incidents, protections are effectively disabled.
+- **Impact:** Temporary abuse/exhaustion risk.
+
+### 8) Shared package footprint is incomplete vs stated architecture
+
+- **Severity:** Medium
+- **Area:** Extensibility / Shared resource strategy
+- **What’s wrong:** Only 5 backend shared packages are present/workspaced; expected event abstraction package is not currently in place.
+- **Failure mode:** Future ad-hoc EventBridge code paths appear.
+- **Impact:** Shared abstraction erosion over time.
+
+### 9) Shared type model drift (`types` vs `db`)
+
+- **Severity:** Medium
+- **Area:** Type safety / Contract integrity
+- **What’s wrong:** Invite code naming differs between shared entity types and DB models (`createdBy/usedBy` vs `generatedBy/redeemedBy`).
+- **Failure mode:** Incorrect assumptions by consumers of `@ai-learning-hub/types`.
+- **Impact:** Subtle integration bugs.
+
+### 10) Frontend integration layer not yet established
+
+- **Severity:** Medium
+- **Area:** Frontend readiness
+- **What’s wrong:** `frontend/src` is scaffold-level (no typed API client, no centralized auth-header flow).
+- **Failure mode:** Future fetch/auth duplication across components.
+- **Impact:** Technical debt once frontend stories accelerate.
+
+### 11) `any` usage in architecture tests
+
+- **Severity:** Low
+- **Area:** Type safety
+- **What’s wrong:** At least one architecture test uses explicit `any` for authorizer ID parsing.
+- **Failure mode:** Reduced compile-time safety in guardrail tests.
+- **Impact:** Small, but avoidable.
+
+## Practical Meaning
+
+- Not bad code.
+- Not "just okay" for long-term architecture confidence.
+- Needs targeted refactoring, not a rewrite.
+
+## Recommended Refactor Scope
+
+### Priority 1 (now)
+
+1. Make route registry executable source of truth (generate route wiring from registry).
+2. Rework T1-T4 to validate real stack/function wiring and fail on real drift.
+3. Normalize ADR-008 errors (including 405) through shared error primitives.
+
+### Priority 2 (next)
+
+4. Remove hardcoded table fallbacks; fail fast on missing env in runtime.
+5. Improve wrapper logging with sanitized inbound request metadata.
+6. Decide/document fail-open vs fail-closed rate limiter behavior.
+
+### Priority 3 (as epics continue)
+
+7. Align shared types with DB models.
+8. Add shared events package and enforce usage.
+9. Establish frontend typed API client and centralized auth token/header pipeline.
+
+## Bottom Line
+
+The repo is viable and moving, but currently has architecture and test blind spots that will become expensive if left untreated.
+
+Fixing the top structural issues now will move it into mostly good shape quickly.

--- a/docs/adversarial-architecture-review-2026-02-20.md
+++ b/docs/adversarial-architecture-review-2026-02-20.md
@@ -1,0 +1,256 @@
+# Adversarial Architecture & Code Quality Review
+
+**Date:** 2026-02-20
+**Scope:** Full monorepo (`backend/`, `infra/`, `frontend/`, `shared/`)
+**Reviewer:** Claude Opus 4.6 (adversarial review mode)
+**Codebase snapshot:** commit `a60ac03` (branch `main`)
+
+---
+
+## Files Reviewed
+
+- **Backend handlers:** 6 Lambda handlers in `backend/functions/`
+- **Shared packages:** 5 packages in `backend/shared/` (db, logging, middleware, types, validation)
+- **CDK stacks:** 7 stacks in `infra/lib/stacks/`, 2 config files, `bin/app.ts`
+- **Tests:** 4 architecture enforcement suites (T1-T4), 6 handler test suites, 2 test utility suites, 14+ infra tests
+- **Frontend:** All source files in `frontend/src/`, config, and tests
+- **Total:** ~80 files across ~12,000 lines
+
+---
+
+## Findings
+
+### [CRITICAL] F1: Architecture enforcement tests cannot detect wrong-handler wiring
+
+**File:** `infra/test/architecture-enforcement/route-completeness.test.ts` (AC5, lines 108-127)
+**File:** `infra/test/architecture-enforcement/lambda-route-wiring.test.ts` (AC9, lines 51-66)
+
+**Issue:** The T2 and T4 architecture enforcement tests verify that each route registry entry has _some_ Lambda integration, but never verify it is the _correct_ Lambda. If `/users/me` were accidentally wired to `apiKeysFunction` instead of `usersMeFunction`, all four test suites (T1-T4) would pass. T4 AC9 uses an extremely weak substring check (`uriStr.includes("lambda") || uriStr.includes("Function")`) — any stringified URI containing "lambda" anywhere passes, regardless of whether it resolves to a real or correct function.
+
+**Fix:** Add a test that, for each route in `ROUTE_REGISTRY`, resolves the `handlerRef` to the expected Lambda logical ID in the CDK template, then verifies the Method's `Integration.Uri` references that specific Lambda's ARN (not just any Lambda). This can be done by building a `handlerRef → Lambda logicalId` map from the template's `AWS::Lambda::Function` resources and cross-referencing against each Method's integration URI.
+
+---
+
+### [CRITICAL] F2: No typed API client or centralized auth flow in frontend
+
+**File:** `frontend/src/App.tsx` (entire file — scaffold only)
+
+**Issue:** The frontend has zero API integration code, zero Clerk auth setup, and zero shared type imports. As Epic 3 (Saves) adds frontend features, the absence of these foundations will force each component to independently implement `fetch()` calls with inline URLs, manual `Authorization` header injection, ad-hoc error parsing, and `any`-typed responses. The backend already exports well-defined types (`ApiSuccessResponse<T>`, `ApiErrorResponse`, `ErrorCode` enum) and the smoke test demonstrates a working centralized client pattern — but nothing bridges this to the frontend build.
+
+**Fix:** Before Epic 3 frontend work begins:
+
+1. Create `frontend/src/api/client.ts` — centralized API client (adapt from `scripts/smoke-test/client.ts`)
+2. Create `frontend/src/api/hooks.ts` — `useApiClient()` hook that injects Clerk JWT automatically
+3. Configure `frontend/tsconfig.json` or Vite aliases so `@ai-learning-hub/types` is importable
+4. Create `frontend/.env.example` with `VITE_API_URL`
+
+---
+
+### [HIGH] F3: T2 AC6 / T4 AC10 orphan detection uses unreliable cardinality comparison
+
+**File:** `infra/test/architecture-enforcement/route-completeness.test.ts` (lines 165-168)
+**File:** `infra/test/architecture-enforcement/lambda-route-wiring.test.ts` (lines 116-125)
+
+**Issue:** Both T2-AC6 and T4-AC10 detect "orphan" Lambdas by comparing `integratedArns.size >= handlerRefs.size`. This counts unique serialized URI strings, not actual Lambda ARNs. If two routes share one Lambda (e.g., `apiKeysFunction` handles both `/users/api-keys` and `/users/api-keys/{id}`), they share one URI — but the test counts it as one. Meanwhile if CDK generates slightly different URI serializations for the same Lambda on different methods, it could be over-counted. The comparison is a loose approximation, not a definitive check.
+
+**Fix:** Parse each Method's integration URI to extract the Lambda function ARN reference (via `Fn::GetAtt` or `Fn::Join`), build a `handlerRef → Lambda ARN` mapping from CDK template resources, and verify every handler ref appears in at least one method's integration.
+
+---
+
+### [HIGH] F4: Wrapper does not log incoming request method or path
+
+**File:** `backend/shared/middleware/src/wrapper.ts` (lines 95-177)
+
+**Issue:** The `wrapHandler` middleware logs the completion of each request with `statusCode` (line 165-167) and creates a logger with `requestId` and `traceId` (lines 104-107), but never logs the HTTP method or resource path at request entry. When debugging operational issues via CloudWatch, you can see _that_ a request completed with a status code, but not _which endpoint_ was called without cross-referencing X-Ray traces. This becomes more important as the number of handlers grows in Epic 3+.
+
+**Fix:** Add a request-entry log line after the logger is created:
+
+```typescript
+logger.info("Request received", {
+  method: event.httpMethod,
+  path: event.path,
+  queryParams: Object.keys(event.queryStringParameters ?? {}),
+});
+```
+
+---
+
+### [HIGH] F5: Gateway Response status codes not validated by T1
+
+**File:** `infra/test/architecture-enforcement/api-gateway-contract.test.ts` (AC2)
+
+**Issue:** T1 AC2 validates that API Gateway's `GatewayResponse` templates contain `error.code` and `error.message` fields in the JSON body, but does NOT validate that the response's HTTP `StatusCode` matches the `ErrorCodeToStatus` mapping. A THROTTLED response could incorrectly return status 400 instead of 429, and this test would pass. Clients relying on status codes for backoff logic (429 → retry with Retry-After) would misbehave.
+
+**Fix:** Enhance AC2 to extract the `StatusCode` property from each `AWS::ApiGateway::GatewayResponse` resource and verify it matches the expected HTTP status code for that response type (e.g., THROTTLED → 429, UNAUTHORIZED → 401).
+
+---
+
+### [MEDIUM] F6: Middleware declares unused `@ai-learning-hub/validation` dependency
+
+**File:** `backend/shared/middleware/package.json` (line 22)
+
+**Issue:** `@ai-learning-hub/validation` is listed as a runtime dependency but is never imported in any middleware source file. This adds unnecessary weight to Lambda bundles (if not tree-shaken), confuses the dependency graph, and suggests either an incomplete refactor or a premature dependency declaration.
+
+**Fix:** Remove `"@ai-learning-hub/validation": "*"` from the `dependencies` section.
+
+---
+
+### [MEDIUM] F7: DynamoDB table names lack environment prefix
+
+**File:** `infra/lib/stacks/core/tables.stack.ts`
+
+**Issue:** All DynamoDB table names are hardcoded as `ai-learning-hub-users`, `ai-learning-hub-saves`, etc. without an environment prefix (e.g., `-dev`, `-staging`, `-prod`). This prevents deploying multiple environments to the same AWS account. The code includes a TODO comment acknowledging this, but it is not yet implemented.
+
+**Fix:** Accept an `environmentPrefix` parameter in `TablesStack` and prepend it to all table names. Pass the prefix from `bin/app.ts` based on the deployment environment. This should be done before any multi-environment deployment story.
+
+---
+
+### [MEDIUM] F8: No handler tests verify rate-limit-before-action ordering
+
+**File:** `backend/functions/api-keys/handler.test.ts`, `backend/functions/invite-codes/handler.test.ts`, `backend/functions/validate-invite/handler.test.ts`
+
+**Issue:** Several handlers call `enforceRateLimit()` before the business operation (e.g., `createApiKey`, `createInviteCode`). Tests verify both functions are called, but don't verify the ordering. If a future refactor accidentally moves the rate limit check after the write, tests would still pass, allowing rate-limited users to perform the action before being blocked.
+
+**Fix:** Track mock call order using a shared counter or ordered array:
+
+```typescript
+const callOrder: string[] = [];
+mockEnforceRateLimit.mockImplementation(async () => {
+  callOrder.push("rateLimit");
+});
+mockCreateApiKey.mockImplementation(async () => {
+  callOrder.push("create");
+  return result;
+});
+await handler(event, context);
+expect(callOrder).toEqual(["rateLimit", "create"]);
+```
+
+---
+
+### [MEDIUM] F9: No scope enforcement tests in handler test suites
+
+**File:** `backend/functions/api-keys/handler.test.ts`, `backend/functions/invite-codes/handler.test.ts`
+
+**Issue:** The `wrapHandler` middleware supports `requiredScope` enforcement for API key auth, and the mock middleware properly simulates it. However, none of the handler test suites test that a request with insufficient API key scopes returns `SCOPE_INSUFFICIENT` (403). If a handler omits the `requiredScope` option from its `wrapHandler` call, no test would catch it.
+
+**Fix:** Add scope enforcement tests to handlers that should require specific scopes:
+
+```typescript
+it("returns 403 when API key lacks required scope", async () => {
+  const event = createMockEvent({
+    authMethod: "api-key",
+    scopes: ["saves:read"],
+  });
+  const result = await handler(event, mockContext);
+  assertADR008Error(result, "SCOPE_INSUFFICIENT", 403);
+});
+```
+
+---
+
+### [MEDIUM] F10: Frontend TypeScript config cannot resolve shared backend types
+
+**File:** `frontend/tsconfig.json`
+
+**Issue:** While `tsconfig.base.json` defines path aliases for `@ai-learning-hub/types` pointing to backend `.ts` source files, the frontend (built with Vite) cannot use these aliases because: (a) the backend packages are not compiled to frontend-compatible output, and (b) Vite needs explicit `resolve.alias` configuration. This means the frontend currently cannot import shared types from the backend without copying them.
+
+**Fix:** Either (a) configure Vite aliases in `vite.config.ts` to resolve `@ai-learning-hub/types` to the source files, or (b) publish shared types as a workspace package the frontend can consume, or (c) use TypeScript project references.
+
+---
+
+### [LOW] F11: Authorizer handlers use `grantReadWriteData` when narrower grants would suffice
+
+**File:** `infra/lib/stacks/auth/auth.stack.ts` (lines 37-115, 131-190)
+
+**Issue:** The JWT and API Key authorizer Lambdas receive `grantReadWriteData` on the users table, which grants 7 DynamoDB actions including `Scan`, `BatchGetItem`, and `BatchWriteItem`. Authorizers only need `GetItem`, `PutItem` (for `ensureProfile`), `UpdateItem` (for `lastUsedAt`), and `Query` (for GSI lookup). The extra actions are unnecessary.
+
+**Fix:** Replace `grantReadWriteData` with explicit `addToRolePolicy` statements scoping to only the required actions. This is a defense-in-depth measure — not urgent, but aligns with least-privilege principles.
+
+---
+
+### [LOW] F12: API Gateway stage name hardcoded to "dev"
+
+**File:** `infra/lib/stacks/api/api-gateway.stack.ts`
+
+**Issue:** The `stageName` for the REST API deployment is hardcoded to `"dev"`. While appropriate for the current single-environment setup, this will need parameterization when staging/prod environments are introduced.
+
+**Fix:** Accept `stageName` as a stack property, defaulting to `"dev"`.
+
+---
+
+### [HIGH] F13: `METHOD_NOT_ALLOWED` error code not in `ErrorCode` enum (ADR-008 contract gap)
+
+**File:** `backend/functions/api-keys/handler.ts` (line 133), `backend/functions/invite-codes/handler.ts` (line 105), `backend/functions/users-me/handler.ts` (line 90)
+**File:** `backend/shared/types/src/errors.ts` (lines 4-27 — `ErrorCode` enum)
+
+**Issue:** Three handlers return 405 responses with `code: "METHOD_NOT_ALLOWED"`, but this string literal is not a member of the `ErrorCode` enum. The responses are hand-built JSON objects that bypass `createErrorResponse`, so they don't go through the ADR-008 normalization path. `assertADR008Error` would reject these responses because it validates the `code` field against the enum. This means 405 error responses are technically non-compliant with ADR-008, and any client-side error handling keyed to `ErrorCode` values will fail to match.
+
+**Fix:** Add `METHOD_NOT_ALLOWED = "METHOD_NOT_ALLOWED"` to the `ErrorCode` enum and `[ErrorCode.METHOD_NOT_ALLOWED]: 405` to `ErrorCodeToStatus`. Then replace the hand-built 405 JSON in each handler with `throw new AppError(ErrorCode.METHOD_NOT_ALLOWED, ...)` and let `wrapHandler` handle the response formatting.
+
+---
+
+### [MEDIUM] F14: DB config silently falls back to hardcoded table names
+
+**File:** `backend/shared/db/src/users.ts` (line 19)
+**File:** `backend/shared/db/src/invite-codes.ts` (lines 22-23)
+
+**Issue:** Table configs use `process.env.USERS_TABLE_NAME ?? "ai-learning-hub-users"` and `process.env.INVITE_CODES_TABLE_NAME ?? "ai-learning-hub-invite-codes"`. If a Lambda is deployed without the env var (CDK misconfiguration, local testing mistake), it silently targets the fallback table name instead of failing fast. In a multi-environment setup, this could cause a Lambda in one environment to read/write data in another environment's table.
+
+**Fix:** Remove the fallback values and fail fast on missing env vars:
+
+```typescript
+const tableName = process.env.USERS_TABLE_NAME;
+if (!tableName)
+  throw new Error("USERS_TABLE_NAME environment variable is required");
+```
+
+Alternatively, keep fallbacks but only when `NODE_ENV === "test"`.
+
+---
+
+### [MEDIUM] F15: Type model drift between `@ai-learning-hub/types` and `@ai-learning-hub/db`
+
+**File:** `backend/shared/types/src/entities.ts` (lines 155-156 — `InviteCode.createdBy`, `InviteCode.usedBy`)
+**File:** `backend/shared/db/src/invite-codes.ts` (lines 36-38 — `InviteCodeItem.generatedBy`, `InviteCodeItem.redeemedBy`)
+
+**Issue:** The shared types package defines `InviteCode` with fields `createdBy` and `usedBy`, while the DB package's `InviteCodeItem` uses `generatedBy` and `redeemedBy` for the same concepts. Any consumer of `@ai-learning-hub/types` would expect `createdBy` but the actual DynamoDB items use `generatedBy`. This drift means the shared entity type does not accurately describe the stored data shape, and mapping code would silently produce undefined values.
+
+**Fix:** Align the naming. Either rename the DB fields to match the types package (`createdBy`/`usedBy`), or update the types package to match the DB (`generatedBy`/`redeemedBy`). Given that the DB is the source of truth for stored data, updating `entities.ts` to use `generatedBy`/`redeemedBy` is likely the lower-risk change. Add a test that asserts field name alignment between the two packages.
+
+---
+
+## What's Working Well (not exhaustive — these are deliberately brief)
+
+- Zero `console.log` calls in any handler — structured logging used everywhere
+- Zero `any` types in production code (shared packages + handlers + CDK stacks)
+- All handlers wrapped with `wrapHandler` — no naked Lambda exports
+- ADR-008 error format enforced consistently through `handleError` + `createErrorResponse`
+- `assertADR008Error` test utility is comprehensive and thoroughly tested (47 tests)
+- Route registry is a genuine single source of truth with typed `HandlerRef` union
+- No direct `@aws-sdk/*` imports in any handler — all DynamoDB access via `@ai-learning-hub/db`
+- No Lambda-to-Lambda calls anywhere in the codebase
+- Cross-stack dependencies properly managed (ARN strings, not construct references)
+- Shared package dependency graph is acyclic: `types → logging → middleware`, `types → db`, `types → validation`
+
+---
+
+## Structural Soundness Score: 7 / 10
+
+The backend is architecturally disciplined — shared libraries are used consistently, error handling follows ADR-008 in most paths, no `console.log` calls, no `any` types in production code, no hardcoded secrets, and the route registry + enforcement test pattern is a genuine strength. The CDK infrastructure is well-structured with proper stack isolation, least-privilege IAM (with minor exceptions), and documented deployment order. However, the architecture enforcement tests have a critical blind spot (wrong-handler wiring goes undetected), the 405 error responses bypass the ADR-008 contract (F13), the DB layer silently falls back to hardcoded table names (F14), there is naming drift between the types and DB packages (F15), the frontend is a blank slate that will accumulate debt rapidly without API client foundations, and several test suites miss important edge cases (ordering, scope enforcement). The codebase is solid for Epic 2 scope but has gaps that will compound as Epics 3-5 add saves, search, and async pipelines.
+
+---
+
+## Top 3 Priorities
+
+### 1. Fix architecture enforcement test blind spot (F1, F3, F5)
+
+The T1-T4 tests are the project's primary defense against CDK misconfiguration. Today they verify _presence_ of wiring but not _correctness_. As Epic 3 adds 3-5 new Lambdas and route stacks, a single mis-wiring (route pointing to wrong handler) would silently ship to production. Enhance tests to verify handler identity, not just handler existence.
+
+### 2. Establish frontend API client and auth foundations before Epic 3 (F2, F10)
+
+Epic 3 (Saves) will be the first story requiring real frontend-to-backend integration. Without a centralized API client, typed responses, and auth token management, each component will independently implement fetch logic. The cost of retrofitting 10+ components later is far higher than establishing the pattern once now. The smoke test's `SmokeClient` class provides a proven starting pattern.
+
+### 3. Add request-entry logging to the wrapper (F4)
+
+As the number of Lambda handlers grows from 6 to 15+, operational debugging becomes harder without knowing which endpoint was called. Adding method/path logging to `wrapHandler` is a one-line change that pays dividends across every handler immediately. This should ship before Epic 3's new handlers are deployed.


### PR DESCRIPTION
## Summary
- Adds the adversarial architecture review report (15 findings, F1-F15, score 7/10)
- Adds the Codex cross-validation review (3 unique findings folded into F13-F15)
- Adds the D7 story spec (`ready-for-dev`) covering all 15 fixes with 20 ACs, 15 tasks

Closes #164

## Changes
- `docs/adversarial-architecture-review-2026-02-20.md` — review report
- `docs/# AI Learning Hub — Adversarial Architec_codex.md` — Codex review
- `_bmad-output/implementation-artifacts/2.1-D7-adversarial-review-fixes.md` — D7 story

## Test plan
- [ ] Docs-only PR — no code changes, no tests affected
- [ ] D7 story format validated (frontmatter, ACs, tasks, dev notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)