### PR TITLE
Epic 3.1: Tech Debt planning artifacts & Epic 3 wrap-up

### DIFF
--- a/.claude/review-findings-3-1b.md
+++ b/.claude/review-findings-3-1b.md
@@ -1,0 +1,187 @@
+# Code Review: Story 3.1b -- Create Save API
+
+## Summary
+
+This review covers the POST /saves endpoint implementation including the Lambda handler, TransactWriteItems helper, EventBridge CDK stack, and Saves Routes CDK stack. The implementation is well-structured and follows established project patterns closely. The two-layer duplicate detection logic is correctly designed. I found **no critical security issues** and **no hardcoded secrets**. There are several important and medium-severity issues around 409 response ADR-008 compliance, missing scope enforcement, GSI query semantics, and IAM over-permissioning.
+
+## Findings
+
+### [HIGH] 409 response does not follow ADR-008 error format
+
+- **File**: `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves/handler.ts:145-156`
+- **Issue**: The 409 duplicate response is constructed manually with `{ error: { code, message, requestId }, existingSave }`. While this has the error fields, it is missing the `X-Request-Id` response header that all other responses include via `createErrorResponse()` or `createSuccessResponse()`. Additionally, the `wrapHandler` middleware at line 180-211 of `wrapper.ts` normalizes 4xx responses: it checks if `parsed?.error?.code` and `parsed?.error?.message` exist; the 409 passes this check, but the `existingSave` sibling field is non-standard for ADR-008. The same issue appears in `handleTransactionFailure()` at lines 273-284.
+- **Fix**: Consider using `createErrorResponse()` from `@ai-learning-hub/middleware` with an AppError that carries the `existingSave` in its details, or at minimum add the `X-Request-Id` header to the manually constructed 409 responses. Example:
+  ```typescript
+  return {
+    statusCode: 409,
+    headers: { "Content-Type": "application/json", "X-Request-Id": requestId },
+    body: JSON.stringify({
+      error: {
+        code: "DUPLICATE_SAVE",
+        message: "URL already saved",
+        requestId,
+      },
+      existingSave: toPublicSave(layer1Result.items[0]),
+    }),
+  };
+  ```
+
+### [HIGH] Missing `requiredScope` on handler export -- API key scope not enforced
+
+- **File**: `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves/handler.ts:368-370`
+- **Issue**: The handler is exported with `wrapHandler(savesCreateHandler, { requireAuth: true })` but without a `requiredScope` option. The reference implementation for api-keys at `backend/functions/api-keys/handler.ts:134` uses `requiredScope: "keys:manage"`. Per ADR-013 and the api-key scope schema in `schemas.ts:159`, `"saves:write"` is a defined scope. Without scope enforcement, an API key with only `saves:read` scope can create saves.
+- **Fix**: Add `requiredScope: "saves:write"` to the wrapHandler options:
+  ```typescript
+  export const handler = wrapHandler(savesCreateHandler, {
+    requireAuth: true,
+    requiredScope: "saves:write",
+  });
+  ```
+  Also add a test case for scope enforcement (403 for API key with insufficient scope).
+
+### [HIGH] Layer 1 GSI query uses `urlHash` as KeyConditionExpression but filters by `PK` -- returns ALL users' saves with that hash
+
+- **File**: `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves/handler.ts:128-141`
+- **Issue**: The `urlHash-index` GSI has `urlHash` as the partition key with no sort key (verified in `tables.stack.ts:80-83`). The query uses `keyConditionExpression: "urlHash = :urlHash"` and `filterExpression: "PK = :pk AND attribute_not_exists(deletedAt)"`. This means DynamoDB reads ALL items with that urlHash across ALL users, then filters client-side. For popular URLs saved by many users, this could read hundreds or thousands of items just to find the one belonging to the current user. This is a performance concern but more critically could cause DynamoDB throttling for hot partition keys.
+- **Issue (secondary)**: The `filterExpression` uses `attribute_not_exists(deletedAt)` on a GSI. DynamoDB GSIs project attributes based on the projection type (ALL in this case), so `deletedAt` is available. However, filter expressions on GSIs are applied AFTER the read, so all items with matching `urlHash` are read regardless.
+- **Fix**: This is an architectural limitation of the current GSI design. For this story, the behavior is functionally correct -- just potentially slow for popular URLs. Document this as a known performance consideration. A future optimization could add a composite GSI with `PK` as sort key, or use a direct GetItem on the marker (`URL#{urlHash}`) to check existence instead of a GSI query.
+
+### [MEDIUM] `updateItem` call in `handleTransactionFailure` catches ALL errors as success
+
+- **File**: `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves/handler.ts:346-349`
+- **Issue**: The `catch` block at line 346 catches any error from the `updateItem` call and treats it as success (returns 200 with the original softDeleted item). But `updateItem` in `helpers.ts:290` throws `AppError(NOT_FOUND)` for `ConditionalCheckFailedException` and `AppError(INTERNAL_ERROR)` for other errors (network failures, DynamoDB service errors, etc.). The comment says "ConditionalCheckFailed means another request already restored it" but the catch will also swallow genuine INTERNAL_ERROR exceptions (e.g., network timeout, IAM permission issue).
+- **Fix**: Narrow the catch to only handle the expected case:
+  ```typescript
+  } catch (error) {
+    if (AppError.isAppError(error) && error.code === ErrorCode.NOT_FOUND) {
+      // ConditionalCheckFailed means another request already restored it
+      return createSuccessResponse(toPublicSave(softDeleted), requestId, 200);
+    }
+    throw error;
+  }
+  ```
+
+### [MEDIUM] EventBridge event bus name hardcoded without environment prefix
+
+- **File**: `/Users/stephen/Documents/ai-learning-hub/infra/lib/stacks/core/events.stack.ts:18`
+- **Issue**: The EventBridge bus name is hardcoded as `"ai-learning-hub-events"` without the `environmentPrefix` that is used for DynamoDB table names (e.g., `${prefix}-ai-learning-hub-saves`). This means all environments (dev, staging, prod) share the same bus name in the same AWS account, which would cause CloudFormation conflicts when deploying multiple environments.
+- **Fix**: Accept `environmentPrefix` as a prop and use it:
+  ```typescript
+  eventBusName: `${environmentPrefix}-ai-learning-hub-events`;
+  ```
+  Or make the EventsStack accept an `environmentPrefix` prop similar to TablesStack.
+
+### [MEDIUM] IAM over-permissioning: `grantReadWriteData` on both tables
+
+- **File**: `/Users/stephen/Documents/ai-learning-hub/infra/lib/stacks/api/saves-routes.stack.ts:108-109`
+- **Issue**: The Lambda gets `grantReadWriteData()` on both the saves table and users table. Comparing to the AuthStack pattern at `auth.stack.ts:70-79`, where least-privilege explicit IAM actions are used (e.g., `dynamodb:GetItem`, `dynamodb:PutItem`). The saves-create handler needs: saves table (Query on GSI, PutItem for save+marker, UpdateItem for restore), users table (UpdateItem for rate limit counters). Using `grantReadWriteData` grants DeleteItem, BatchWriteItem, and other write operations that are not needed.
+- **Fix**: Use explicit IAM policy statements instead:
+  ```typescript
+  this.savesCreateFunction.addToRolePolicy(
+    new iam.PolicyStatement({
+      actions: ["dynamodb:Query", "dynamodb:PutItem", "dynamodb:UpdateItem"],
+      resources: [savesTable.tableArn, `${savesTable.tableArn}/index/*`],
+    })
+  );
+  this.savesCreateFunction.addToRolePolicy(
+    new iam.PolicyStatement({
+      actions: ["dynamodb:UpdateItem"],
+      resources: [usersTable.tableArn],
+    })
+  );
+  ```
+
+### [MEDIUM] `urlSchema` does not enforce URL max length (AC1 mentions length)
+
+- **File**: `/Users/stephen/Documents/ai-learning-hub/backend/shared/validation/src/schemas.ts:17-32`
+- **Issue**: AC1 requires URL length validation, but the `urlSchema` (and therefore `createSaveSchema.url`) has no `.max()` constraint. DynamoDB items have a 400KB limit, but an extremely long URL (e.g., 100KB+ of query parameters) could cause issues with normalization performance, hashing, and storage. The url-normalizer also does not impose a length limit.
+- **Fix**: Add a max length to the URL schema. A common limit is 2048 characters:
+  ```typescript
+  export const urlSchema = z.string().max(2048, "URL must be 2048 characters or less").url()...
+  ```
+  Note: This fix is in the shared validation package (Story 3.1a), not in this story's handler. The handler correctly uses the shared schema, so the fix would be upstream.
+
+### [MEDIUM] Test for AC6 (fire-and-forget) does not actually verify resilience to EventBridge failure
+
+- **File**: `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves/handler.test.ts:496-509`
+- **Issue**: The test comment says "emitEvent is fire-and-forget, so even if it throws internally, the handler should still return 201. Since we mock emitEvent as vi.fn(), it returns undefined (void), simulating the fire-and-forget contract." But the test never actually makes `mockEmitEvent` throw or reject. It only verifies the default mock behavior (returning undefined). A proper AC6 test should make `emitEvent` throw and confirm the handler still returns 201.
+- **Fix**: Add a test that makes `mockEmitEvent` throw:
+
+  ```typescript
+  it("returns 201 even when emitEvent throws", async () => {
+    mockQueryItems.mockResolvedValue({ items: [], hasMore: false });
+    mockTransactWriteItems.mockResolvedValue(undefined);
+    mockEmitEvent.mockImplementation(() => {
+      throw new Error("EventBridge down");
+    });
+
+    const event = createSaveEvent({ url: "https://example.com" }, "user_123");
+    const result = await handler(event, mockContext);
+    expect(result.statusCode).toBe(201);
+  });
+  ```
+
+  Note: Since `emitEvent` returns `void` (not a promise) and catches internally via its detached IIFE, throwing from the mock might not actually test the right thing. The real contract is that `emitEvent` never propagates errors to callers. The current test implicitly validates this since the mock returns `void`, but a more explicit test would be better.
+
+### [LOW] Redundant `EVENT_BUS_NAME` fallback chain
+
+- **File**: `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves/handler.ts:222`
+- **Issue**: `const busName = EVENT_BUS_NAME ?? process.env.EVENT_BUS_NAME ?? ""` -- `EVENT_BUS_NAME` is assigned from `process.env.EVENT_BUS_NAME` at line 49, so the second `?? process.env.EVENT_BUS_NAME` is always redundant. If `EVENT_BUS_NAME` is undefined (only possible in test due to the guard at line 50-51), the env var has not changed, so `process.env.EVENT_BUS_NAME` would also be undefined. The same pattern appears at line 322.
+- **Fix**: Simplify to `const busName = EVENT_BUS_NAME ?? "";` or better, make `EVENT_BUS_NAME` read lazily for testability.
+
+### [LOW] `SaveItem.contentType` is typed as `string` instead of `ContentType` enum
+
+- **File**: `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves/handler.ts:68`
+- **Issue**: The `SaveItem` interface defines `contentType: string` but the value is always a `ContentType` enum value (from `detectContentType`). Using the `ContentType` type would provide stronger type safety and catch type mismatches at compile time.
+- **Fix**: Import and use `ContentType`:
+  ```typescript
+  contentType: ContentType;
+  ```
+
+### [LOW] No test for URL max length validation (AC1)
+
+- **File**: `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves/handler.test.ts`
+- **Issue**: AC1 specifies URL length validation, but no test validates that extremely long URLs are rejected. This is related to the missing max length constraint in `urlSchema`.
+- **Fix**: Add a test for excessively long URLs once the schema enforces a max length.
+
+### [NIT] Missing function-name CfnOutput in SavesRoutesStack
+
+- **File**: `/Users/stephen/Documents/ai-learning-hub/infra/lib/stacks/api/saves-routes.stack.ts`
+- **Issue**: The AuthStack exports `CfnOutput` for both ARN and function name for each Lambda (e.g., `ApiKeysFunctionArn` and `ApiKeysFunctionName`). The SavesRoutesStack does not export any `CfnOutput` for the saves-create function. While not strictly required since the function is created in this stack, it breaks consistency with the established pattern.
+- **Fix**: Add CfnOutput entries for the saves-create function ARN and name.
+
+### [NIT] Test mocks `TransactionCancelledError` as a separate class instead of importing
+
+- **File**: `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves/handler.test.ts:24-31`
+- **Issue**: The test creates `_MockTransactionCancelledError` inside the `vi.mock` factory and also imports `TransactionCancelledError` from the mock at line 72. The mock class matches the real class shape, but the `instanceof` check in the handler (`error instanceof TransactionCancelledError`) works because the import resolves to the same mock class. This is correct but fragile -- if someone changes the mock factory, the `instanceof` check in tests could silently break.
+- **Fix**: This is fine as-is and follows the pattern used for mocking. No change needed, just noting for awareness.
+
+### [NIT] CDK `NODEJS_LATEST` may cause runtime drift
+
+- **File**: `/Users/stephen/Documents/ai-learning-hub/infra/lib/stacks/api/saves-routes.stack.ts:84`
+- **Issue**: Using `lambda.Runtime.NODEJS_LATEST` is consistent with all other stacks in this project, and there is already a CDK Nag suppression for it. This is a project-wide decision, not specific to this story.
+- **Fix**: No change needed -- consistent with existing pattern.
+
+## Summary Table
+
+| Severity | Count | Key Issues                                                                               |
+| -------- | ----- | ---------------------------------------------------------------------------------------- |
+| CRITICAL | 0     | No security vulnerabilities or hardcoded secrets found                                   |
+| HIGH     | 3     | Missing X-Request-Id header on 409, no scope enforcement, GSI query reads all users      |
+| MEDIUM   | 4     | Broad error catch, no env prefix on event bus, IAM over-permissioning, no URL max length |
+| LOW      | 3     | Redundant fallback, string type instead of enum, missing length test                     |
+| NIT      | 3     | Missing CfnOutput, mock pattern note, NODEJS_LATEST note                                 |
+
+## Acceptance Criteria Coverage
+
+| AC  | Status  | Notes                                                                                                 |
+| --- | ------- | ----------------------------------------------------------------------------------------------------- |
+| AC1 | Partial | URL format, protocol, credentials validated. Max length NOT enforced (schema issue).                  |
+| AC2 | Pass    | 201 with ULID, normalizedUrl, urlHash, contentType, tags default. PK/SK stripped.                     |
+| AC3 | Pass    | 409 with existingSave returned. Note: missing X-Request-Id header (HIGH finding).                     |
+| AC4 | Pass    | SaveCreated event emitted after write.                                                                |
+| AC5 | Pass    | Auto-detection works, user override takes precedence.                                                 |
+| AC6 | Partial | Fire-and-forget pattern correct via emitEvent's void return. Test does not verify failure resilience. |
+| AC7 | Pass    | Rate limiting at 200/hr using enforceRateLimit.                                                       |
+| AC8 | Pass    | Two-layer detection: GSI query + TransactWriteItems with condition.                                   |
+| AC9 | Pass    | Soft-deleted save auto-restored with 200 + SaveRestored event.                                        |

--- a/.claude/review-findings-3-2.md
+++ b/.claude/review-findings-3-2.md
@@ -1,0 +1,145 @@
+# Story 3.2 Review Findings -- Round 1
+
+**Reviewer:** Agent (Fresh Context)
+**Date:** 2026-02-22
+**Branch:** main (commit 6992e53)
+
+## Critical Issues (Must Fix)
+
+_No critical issues found._
+
+## Important Issues (Should Fix)
+
+1. **getItem overload uses fragile duck-typing instead of proper TypeScript overloads**
+
+   **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/db/src/helpers.ts:54-66`
+   **Problem:** The `getItem` function signature was changed to accept either `{ consistentRead?: boolean }` or `Logger` as the 4th argument, distinguished at runtime by checking `"info" in options`. This is fragile: any object with an `info` property would be misidentified as a Logger. The TypeScript union type `{ consistentRead?: boolean } | Logger` also makes call-site type checking weaker -- TypeScript will not warn if someone passes a Logger where options are expected or vice versa.
+   **Impact:** A future caller could accidentally pass an object with an `info` property as options and have it silently treated as a Logger, losing the `consistentRead` setting. More practically, the code is hard to reason about for future maintainers.
+   **Fix:** Use proper TypeScript function overloads:
+
+   ```typescript
+   export async function getItem<T>(
+     client: DynamoDBDocumentClient,
+     config: TableConfig,
+     key: Record<string, unknown>,
+     logger?: Logger
+   ): Promise<T | null>;
+   export async function getItem<T>(
+     client: DynamoDBDocumentClient,
+     config: TableConfig,
+     key: Record<string, unknown>,
+     options: { consistentRead?: boolean },
+     logger?: Logger
+   ): Promise<T | null>;
+   export async function getItem<T>(
+     client: DynamoDBDocumentClient,
+     config: TableConfig,
+     key: Record<string, unknown>,
+     optionsOrLogger?: { consistentRead?: boolean } | Logger,
+     logger?: Logger
+   ): Promise<T | null> {
+     // ... implementation
+   }
+   ```
+
+   This gives callers proper type inference and autocompletion while keeping the same runtime behavior.
+
+2. **Missing unit tests for `consistentRead` support added to `getItem` and `queryItems` in helpers.ts**
+
+   **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/db/test/helpers.test.ts`
+   **Problem:** Story 3.2 adds `consistentRead` support to both `getItem` (line 54, 72) and `queryItems` (line 172, 220) in `helpers.ts`, but neither function has a corresponding unit test verifying that `ConsistentRead: true` is actually passed to the DynamoDB SDK when the option is set. The handler-level tests mock `getItem`/`queryItems` entirely, so they do not exercise this wiring. The only `consistentRead` unit test is in `query-all.test.ts` for the new `queryAllItems` function.
+   **Impact:** If the spread logic `...(opts.consistentRead && { ConsistentRead: true })` in `getItem` or `...(params.consistentRead && { ConsistentRead: true })` in `queryItems` were accidentally removed or broken, no test would catch it. AC8 (ConsistentRead on all saves-table reads) would silently regress.
+   **Fix:** Add tests in `helpers.test.ts`:
+
+   ```typescript
+   it("should pass ConsistentRead: true to DynamoDB when consistentRead option is set", async () => {
+     mockSend.mockResolvedValueOnce({ Item: { id: "1" } });
+     await getItem(
+       mockClient,
+       tableConfig,
+       { PK: "test" },
+       { consistentRead: true }
+     );
+     const input = mockSend.mock.calls[0][0].input;
+     expect(input.ConsistentRead).toBe(true);
+   });
+   ```
+
+   And similar for `queryItems`.
+
+3. **`decodeNextToken` try/catch is dead code -- `Buffer.from` with `base64url` never throws**
+
+   **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-list/handler.ts:31-37`
+   **Problem:** The `decodeNextToken` function wraps `Buffer.from(token, 'base64url')` in a try/catch, expecting it to throw on malformed input. However, `Buffer.from` with `base64url` encoding silently accepts ANY input string and produces garbage bytes rather than throwing. The catch block on line 34 is unreachable dead code. The function ALWAYS returns a string (never `undefined`), making the `!cursorSaveId` guard on line 79 also effectively dead code (it only catches the empty-string edge case).
+   **Impact:** The behavior is still correct because garbage-decoded saveIds will not match any item in `findIndex`, falling through to the `idx === -1` check on line 86 which returns the proper 400 error. However, the code misleads readers into thinking malformed tokens are caught at the decode stage, when they are actually caught at the lookup stage. If someone refactors to rely on `decodeNextToken` returning `undefined` for invalid input (as the function signature promises), they would introduce a bug.
+   **Fix:** Either (a) add ULID format validation on the decoded string:
+
+   ```typescript
+   function decodeNextToken(token: string): string | undefined {
+     const decoded = Buffer.from(token, "base64url").toString("utf-8");
+     return /^[0-9A-Z]{26}$/.test(decoded) ? decoded : undefined;
+   }
+   ```
+
+   Or (b) remove the try/catch and document that validation happens via `findIndex`.
+
+## Minor Issues (Nice to Have)
+
+1. **`saves-list/handler.ts` line 48: redundant `?? DEFAULT_LIMIT` fallback**
+
+   **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-list/handler.ts:48`
+   **Problem:** `const limit = params.limit ?? DEFAULT_LIMIT;` -- The Zod schema on line 23 already has `.default(DEFAULT_LIMIT)`, so `params.limit` will never be `undefined` after validation. The `?? DEFAULT_LIMIT` is redundant.
+   **Impact:** No functional impact. Slightly misleading -- suggests the default might not have been applied.
+   **Fix:** Simplify to `const limit = params.limit;`
+
+2. **No max-pages safety valve in `queryAllItems` loop**
+
+   **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/db/src/query-all.ts:43-77`
+   **Problem:** The `do...while` loop has no maximum iteration guard. If a partition has a very large number of items that are all filtered out (e.g., millions of soft-deleted items with few active ones), the loop would make many DynamoDB query calls (each fetching 500 items) before exhausting the partition. This would cause the Lambda to timeout.
+   **Impact:** At boutique scale this is extremely unlikely. However, a corrupted or unexpectedly large partition could cause Lambda timeout and high DynamoDB read costs.
+   **Fix:** Add a `MAX_PAGES` constant (e.g., 50) and break with `truncated = true` if exceeded:
+
+   ```typescript
+   const MAX_PAGES = 50;
+   // ...inside loop:
+   if (pages >= MAX_PAGES) {
+     truncated = true;
+     break;
+   }
+   ```
+
+3. **Test helper `createSaveItem` in `saves-get/handler.test.ts` has a 26-char ULID constant that is valid but could be more clearly named**
+
+   **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-get/handler.test.ts:47`
+   **Problem:** `const VALID_SAVE_ID = "01HXYZ1234567890ABCDEFGHIJ"` -- This is 26 uppercase alphanumeric characters and matches the ULID regex `/^[0-9A-Z]{26}$/`. However, a real ULID uses Crockford's Base32 encoding which excludes I, L, O, U. The test constant contains `I` and `J` which are not valid Crockford Base32 characters. While the code only validates with the regex (which accepts these characters), this constant could cause confusion if someone assumes it represents a real ULID.
+   **Impact:** No functional impact -- the regex allows these characters. But if ULID validation were tightened later, these tests would break.
+   **Fix:** Use a valid Crockford Base32 ULID, e.g., `"01HXY01234567890ABCDEFGHKK"`.
+
+4. **`toPublicSave` returns `PublicSave` type which still includes `userId` -- intentional per story but worth noting**
+
+   **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/types/src/entities.ts:55`
+   **Problem:** `PublicSave = Omit<SaveItem, 'PK' | 'SK' | 'deletedAt'>` still includes `userId`. The story explicitly documents this ("Included for API client convenience") but it means the userId is exposed in list responses, which is redundant information (the user already knows their own userId from auth).
+   **Impact:** No security issue since users can only see their own saves. Minor data redundancy in responses.
+   **Fix:** None needed -- explicitly documented as intentional in the story.
+
+## Summary
+
+- **Total findings:** 7
+- **Critical:** 0
+- **Important:** 3
+- **Minor:** 4
+- **Recommendation:** PASS with suggested improvements
+
+The implementation is thorough and correctly implements all 10 acceptance criteria. The handler patterns, shared library usage, CDK wiring, route registry, and test coverage are all solid. The architecture compliance (ADR-001 key patterns, ADR-005 no L2L calls, ADR-008 error handling, NFR-R7 ConsistentRead) is properly followed.
+
+The three Important findings are:
+
+- The `getItem` overload duck-typing is functional but fragile and should use proper TypeScript overloads for long-term maintainability.
+- Missing unit tests for `consistentRead` in the modified `getItem`/`queryItems` functions create a regression risk for AC8.
+- The `decodeNextToken` function has a dead try/catch that misleads about where malformed token validation actually happens.
+
+None of these are correctness bugs -- the code produces correct results in all cases. They are maintainability and test coverage improvements that would strengthen the codebase.
+
+## Verdict
+
+PASS (0 must-fix blocking bugs). The Important findings are recommended improvements but do not block merge -- the code is functionally correct and meets all acceptance criteria.

--- a/.claude/review-findings-3-3-round-1.md
+++ b/.claude/review-findings-3-3-round-1.md
@@ -1,0 +1,82 @@
+# Story 3.3 Code Review Findings - Round 1
+
+**Reviewer:** Agent (Fresh Context)
+**Date:** 2026-02-23
+**Branch:** story-3-3-update-delete-restore-api
+
+## Critical Issues (Must Fix)
+
+1. **Delete handler does not use shared `createNoContentResponse` helper and omits `X-Request-Id` header**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-delete/handler.ts`, lines 46, 103, 130
+   - **Problem:** The handler destructures `ctx` as `{ event, auth, logger }` without extracting `requestId`. It then manually constructs 204 responses as `{ statusCode: 204, headers: {}, body: "" }` in two places (the idempotent branch at line 103 and the happy path at line 130). The shared middleware exports `createNoContentResponse(requestId)` (see `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/error-handler.ts` lines 129-139) which includes `X-Request-Id` in the response headers. The CLAUDE.md mandates "Use shared libraries (@ai-learning-hub/\*)" and the story's Library/Framework Requirements section explicitly lists `createSuccessResponse` from `@ai-learning-hub/middleware`. Other handlers in the codebase (e.g., `api-keys/handler.ts` line 109) already use `createNoContentResponse`.
+   - **Impact:** All 204 responses from the delete endpoint will be missing the `X-Request-Id` header, which breaks observability consistency with other endpoints (ADR-008 compliance) and makes it harder for clients to correlate requests with responses. This also violates the project's "ALWAYS use shared libraries" mandate.
+   - **Fix:** Add `requestId` to the ctx destructuring (`const { event, auth, logger, requestId } = ctx;`). Import `createNoContentResponse` from `@ai-learning-hub/middleware`. Replace both manual 204 returns with `return createNoContentResponse(requestId);`.
+
+2. **Rate limit operation bucket mismatch between saves-create and the new handlers**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-update/handler.ts` line 67, `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-delete/handler.ts` line 58, `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-restore/handler.ts` line 62, vs. `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves/handler.ts` line 99
+   - **Problem:** The three new handlers all use `operation: "saves-write"` for their rate limit bucket, while the existing saves-create handler (from Story 3.1b) uses `operation: "saves-create"`. The rate limiter constructs its DynamoDB key as `RATELIMIT#<operation>#<identifier>` (see `/Users/stephen/Documents/ai-learning-hub/backend/shared/db/src/rate-limiter.ts` line 91). This means there are two independent rate limit counters: one for create (200/hour) and one for update+delete+restore (200/hour). A user can therefore perform 200 creates + 200 other writes = 400 total save writes per hour.
+   - **Impact:** The story explicitly warns: "Do not accidentally multiply the limit by choosing a distinct operation bucket per endpoint" and "treat update/delete/restore as save write operations. Use the same effective limit as create (200/hour per user)". While the new handlers share a bucket with each other, the overall system allows 2x the intended rate because the create handler uses a different operation name. This violates the story's rate limiting requirement.
+   - **Fix:** Either (a) change the saves-create handler to also use `operation: "saves-write"` so all four endpoints share one 200/hour bucket, or (b) change the new handlers to use `operation: "saves-create"` to match the existing bucket. Option (a) is the correct approach since "saves-write" is the more semantically correct name, but note this changes existing create behavior (a user who previously did 200 creates + 200 updates would now be limited to 200 total). Document this decision.
+
+## Important Issues (Should Fix)
+
+3. **Event detail types are not a true discriminated union as required by story**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/events/src/events/saves.ts`, lines 23-66
+   - **Problem:** The story (Task 1.1) explicitly requires: "Implement event detail typing as a **discriminated union by `detailType`**". The current implementation defines `SavesEventDetail = SaveCreatedRestoredDetail | SaveUpdatedDetail | SaveDeletedDetail` as a plain union, but none of the member interfaces include a `detailType` discriminant field. Combined with the `emitEvent<TDetailType, TDetail>` signature where `TDetailType` and `TDetail` are independent type parameters, TypeScript cannot enforce that a `"SaveDeleted"` event carries a `SaveDeletedDetail` payload. A developer could accidentally pass `detailType: "SaveUpdated"` with a `SaveDeletedDetail` payload and it would compile without error.
+   - **Impact:** Reduced type safety. No runtime bug today since all current call sites use correct pairings, but future code has no compile-time guard against mismatched detailType/detail combinations. The story specifically called for this protection.
+   - **Fix:** Add a `detailType` discriminant field to each interface (e.g., `SaveUpdatedDetail { detailType: "SaveUpdated"; ... }`) and create a proper discriminated union. Alternatively, refactor `emitEvent` to accept a mapped type that enforces the detailType-to-detail mapping, such as:
+     ```typescript
+     type SavesEventMap = {
+       SaveCreated: SaveCreatedRestoredDetail;
+       SaveRestored: SaveCreatedRestoredDetail;
+       SaveUpdated: SaveUpdatedDetail;
+       SaveDeleted: SaveDeletedDetail;
+     };
+     ```
+     Note: this may require changes to the `emitEvent` generic signature which is a broader refactor.
+
+4. **Delete handler uses `returnValues: "ALL_OLD"` despite story specifying `"NONE"` for performance**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-delete/handler.ts`, line 82
+   - **Problem:** The story's Technical Requirements section states: "**Performance hint**: for the delete update, pass `returnValues: "NONE"` to `updateItem` (204 response does not need attributes)." The handler uses `returnValues: "ALL_OLD"` to obtain `normalizedUrl` and `urlHash` for the event detail. However, this data could be obtained from the `getItem` call that already happens in the error path, or the handler could do a pre-read only when it needs to emit the event (i.e., on the happy path before the update).
+   - **Impact:** The `ALL_OLD` return forces DynamoDB to return the full item on every successful delete, consuming additional read capacity units and slightly increasing response latency. For a 204 response that returns no body, this data is only used to populate the fire-and-forget event. The performance impact is small but real, and the implementation contradicts an explicit story requirement.
+   - **Fix:** Change to `returnValues: "NONE"` and do a `getItem` before the `updateItem` to get the data needed for the event, or accept the trade-off and add a code comment explaining why `ALL_OLD` is preferred (one round-trip for happy path instead of two). If keeping `ALL_OLD`, document the deviation from the story's performance hint.
+
+5. **Missing test for `createSuccessResponse` wrapper call in update handler**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-update/handler.test.ts`
+   - **Problem:** The update handler calls `createSuccessResponse(toPublicSave(updated!), requestId)` which wraps the result in `{ data: ... }` and adds `X-Request-Id` header. But the saves-get handler (Story 3.2) returns `toPublicSave(item)` directly (not wrapped with `createSuccessResponse`), which causes the `wrapHandler` to call `createSuccessResponse` automatically. The update handler wraps it explicitly at line 147 with `requestId`. The tests check `body.data.title` which works with the mock's `createSuccessResponse`, but there's no test verifying the `requestId` is forwarded or that response headers are correct. This is a minor gap but reduces confidence.
+   - **Impact:** If the requestId propagation breaks, no test would catch it.
+   - **Fix:** Add an assertion checking `result.headers["X-Request-Id"]` is present in at least one test case.
+
+## Minor Issues (Nice to Have)
+
+6. **Duplicated `saveIdPathSchema` definition across three handlers**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-update/handler.ts` lines 43-47, `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-delete/handler.ts` lines 35-39, `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-restore/handler.ts` lines 40-44, and also `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-get/handler.ts` lines 18-22
+   - **Problem:** The `saveIdPathSchema` Zod object is identically defined in four separate handler files. This duplicates the ULID regex `/^[0-9A-Z]{26}$/` and the error message across all of them.
+   - **Impact:** If the ULID format or error message needs to change, all four files must be updated independently. Risk of divergence over time. The project CLAUDE.md says "NEVER create utility functions without checking /shared first".
+   - **Fix:** Extract `saveIdPathSchema` to `@ai-learning-hub/validation` alongside the other save schemas, then import it in all handlers. This is a follow-up item since it also affects Story 3.2's handler.
+
+7. **Inconsistent `@aws-sdk/client-ssm` bundling exclusion**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/infra/lib/stacks/api/saves-routes.stack.ts`, lines 99-108 vs. 216-220, 259-263, 299-304
+   - **Problem:** The saves-create function's `externalModules` includes `"@aws-sdk/client-ssm"` but the three new functions (saves-update, saves-delete, saves-restore) omit it. All four handlers import from `@ai-learning-hub/middleware` which includes SSM-dependent code.
+   - **Impact:** In practice, tree-shaking likely eliminates the unused SSM dependency from the bundle. However, the inconsistency could confuse future developers examining the CDK stack. If tree-shaking behavior changes or a transitive dependency pulls in SSM code, bundles may unexpectedly include the SDK.
+   - **Fix:** Either add `"@aws-sdk/client-ssm"` to the new functions' `externalModules` for consistency, or remove it from the create function. Prefer consistency across all functions in the same stack.
+
+8. **Non-null assertions (`!`) on `updated` and `restored` variables**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-update/handler.ts` lines 139, 140, 147; `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-restore/handler.ts` lines 123, 124, 125, 132
+   - **Problem:** After the `updateItem` call, the result is typed as `SaveItem | null`. The handlers use `updated!.normalizedUrl`, `restored!.url`, etc. with non-null assertions. While `updateItem` with `returnValues: "ALL_NEW"` or `"ALL_OLD"` should always return attributes on success (and the catch block handles errors), the non-null assertion bypasses TypeScript's null safety.
+   - **Impact:** If `updateItem` ever returns null on success (theoretically possible per the type signature), the handler would throw a cryptic runtime error at the assertion point rather than a meaningful error.
+   - **Fix:** Add a guard after the `updateItem` call: `if (!updated) throw new AppError(ErrorCode.INTERNAL_ERROR, "Update returned no data");` and remove the non-null assertions. This is defensive programming that improves error clarity.
+
+9. **`updateSaveSchema` allows `tags` with `tagsSchema.optional()` which has `.default([])`**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/validation/src/schemas.ts` lines 236-262
+   - **Problem:** In `updateSaveSchema`, `tags` is `tagsSchema.optional()`. The base `tagsSchema` has `.default([])`, which means if tags is omitted the `.default` would resolve to `[]`. However, since it's wrapped with `.optional()`, Zod should handle this as truly optional. The potential issue is the interaction between `.default([])` and `.optional()` in Zod v3. If `.default` fires before `.optional`, an omitted `tags` field might become `[]` rather than `undefined`, which would cause the handler to write an empty array to DynamoDB even when the user didn't include `tags` in the PATCH body (overwriting existing tags with an empty array).
+   - **Impact:** Potential data loss if tags get overwritten with `[]` on every PATCH that doesn't include tags. However, the handler checks `if (body.tags !== undefined)` before adding tags to the update expression, so if `.optional()` correctly returns `undefined` for omitted fields, this is a non-issue. This needs verification via a test.
+   - **Fix:** Verify with the existing test suite that omitting `tags` from a PATCH body results in `body.tags === undefined` after validation (not `[]`). If it does produce `[]`, change the schema to use `z.array(...).max(20).transform(...).optional()` without the `.default([])`.
+
+## Summary
+
+- **Total findings:** 9
+- **Critical:** 2
+- **Important:** 3
+- **Minor:** 4
+- **Recommendation:** REQUEST CHANGES -- The two critical issues must be fixed before merge. Finding #1 (missing `createNoContentResponse` / `X-Request-Id`) is a concrete violation of both the shared library mandate and ADR-008 observability requirements. Finding #2 (rate limit bucket mismatch) creates a real 2x rate limit multiplication that contradicts an explicit story constraint. The important issues (type safety gap in events, performance hint deviation, and test coverage gap) should also be addressed in this round.

--- a/.claude/review-findings-3-3-round-2.md
+++ b/.claude/review-findings-3-3-round-2.md
@@ -1,0 +1,87 @@
+# Story 3.3 Code Review Findings - Round 2
+
+**Reviewer:** Agent (Fresh Context)
+**Date:** 2026-02-23
+**Branch:** story-3-3-update-delete-restore-api
+
+## Critical Issues (Must Fix)
+
+No critical issues found. No hardcoded secrets, AWS account IDs, API keys, private key material, or connection strings were detected in any changed files. All environment variables are loaded via `process.env` or `requireEnv()`.
+
+## Important Issues (Should Fix)
+
+1. **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-restore/handler.ts`, lines 123-126 and 132
+   **Problem:** Non-null assertions (`restored!`) on a value typed as `SaveItem | null`. The `updateItem` helper explicitly returns `(result.Attributes as T) ?? null` (see `/Users/stephen/Documents/ai-learning-hub/backend/shared/db/src/helpers.ts` line 315), meaning `null` is a possible return even with `returnValues: "ALL_NEW"` if DynamoDB returns no attributes (e.g., an empty item or SDK-level edge case). An unguarded `!` assertion would cause a runtime `TypeError` (cannot read property of null) that would surface as a 500 error instead of a meaningful message.
+   **Impact:** If `updateItem` returns `null` despite a successful conditional update (unlikely but not impossible), the handler would crash with an unhandled TypeError rather than returning a proper error response.
+   **Fix:** Add a null guard after the `updateItem` call:
+
+   ```typescript
+   if (!restored) {
+     throw new AppError(
+       ErrorCode.INTERNAL_ERROR,
+       "Failed to retrieve restored save"
+     );
+   }
+   ```
+
+   Then remove the `!` assertions below. The same pattern applies to `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-update/handler.ts` lines 139-141 and 147 where `updated!` is used.
+
+2. **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-delete/handler.ts`, lines 132-133
+   **Problem:** The event detail falls back to empty strings for `normalizedUrl` and `urlHash` when `previousItem` is null (`previousItem?.normalizedUrl ?? ""`). If `updateItem` with `returnValues: "ALL_OLD"` returns null, the `SaveDeleted` event would be emitted with empty strings for both fields. Downstream consumers expecting valid normalizedUrl/urlHash values for search index removal or deduplication would malfunction.
+   **Impact:** A `SaveDeleted` event with empty `normalizedUrl` and `urlHash` would be published to EventBridge, potentially causing downstream consumers to fail silently (e.g., not removing the correct item from a search index).
+   **Fix:** Add a null guard similar to finding #1. If `previousItem` is null after a successful conditional update, either skip event emission or throw an internal error:
+   ```typescript
+   if (previousItem) {
+     emitEvent<SavesEventDetailType, SavesEventDetail>(
+       ebClient,
+       busName,
+       {
+         source: SAVES_EVENT_SOURCE,
+         detailType: "SaveDeleted",
+         detail: {
+           userId,
+           saveId,
+           normalizedUrl: previousItem.normalizedUrl,
+           urlHash: previousItem.urlHash,
+         },
+       },
+       logger
+     );
+   }
+   ```
+
+## Minor Issues (Nice to Have)
+
+1. **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-update/handler.ts`, line 37
+   **Problem:** Missing blank line between the last import statement (line 36) and the `EVENT_BUS_NAME` assignment (line 37). All other handlers (`saves-delete/handler.ts` line 32, `saves-restore/handler.ts` line 33) have a blank line after the imports block. This is a minor style inconsistency.
+   **Impact:** Cosmetic only; does not affect functionality.
+   **Fix:** Add a blank line after line 36 (the closing `} from "@ai-learning-hub/events";`) and before line 37 (`const EVENT_BUS_NAME = ...`).
+
+2. **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-restore/handler.ts`, lines 86-110
+   **Problem:** Narrow race condition in disambiguation path: between the failed conditional update and the `getItem` call, another request could soft-delete the item. In that case, `getItem` would return an item with `deletedAt` set. The code at line 101 (`if (existing && !existing.deletedAt)`) would fall through to the 404 path even though the item exists (it was just deleted between calls). This is not a functional bug per se since the story ACs do not address this race, and the behavior (returning 404) is conservative and safe.
+   **Impact:** In an extremely narrow race window, a restore attempt on a concurrently-deleted item would return 404 instead of retrying the restore. This is acceptable behavior for the current story scope.
+   **Fix:** No immediate fix needed. Document this as a known edge case for future reference. If desired, the disambiguation could be wrapped in a retry loop, but this adds complexity without meaningful benefit.
+
+3. **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/events/src/events/saves.ts`, lines 76-81
+   **Problem:** The `SavesEventMap` type is exported but not used by `emitEvent` to enforce compile-time coupling between `detailType` and `detail` shape. Currently, `emitEvent<SavesEventDetailType, SavesEventDetail>()` accepts any combination of detailType and detail from the union, meaning you could pass `detailType: "SaveDeleted"` with a `SaveCreatedRestoredDetail` payload without a type error. This is a pre-existing design limitation of the `emitEvent` generic signature, not introduced by this PR, but the new `SavesEventMap` type was created precisely to solve this problem and remains unused.
+   **Impact:** A developer could accidentally pair the wrong detailType with the wrong detail shape. No runtime issue today since all three handlers currently pass correct pairings, but this is a type-safety gap for future development.
+   **Fix:** This could be addressed in a follow-up story by refactoring `emitEvent` to accept a mapped type constraint, or by using the `SavesEventMap` to create a type-safe `emitSavesEvent` wrapper function.
+
+4. **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-delete/handler.test.ts`
+   **Problem:** The delete handler test mocks do not include `toPublicSave` in the `@ai-learning-hub/db` mock (lines 22-38), unlike the update and restore handler tests which include it (e.g., `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-update/handler.test.ts` lines 36-39). This is correct since the delete handler does not import or use `toPublicSave` (it returns 204 with no body), so this is just an observation that the mock surface area is appropriately minimal. No change needed.
+   **Impact:** None.
+   **Fix:** None needed.
+
+## Summary
+
+- **Total findings:** 6
+- **Critical:** 0
+- **Important:** 2
+- **Minor:** 4 (including 1 observation requiring no change)
+- **Recommendation:** APPROVE WITH MINOR CHANGES
+
+The implementation is well-structured, follows existing patterns consistently, and satisfies all acceptance criteria from the story file. The three new handlers (update, delete, restore) correctly implement the conditional write patterns with proper disambiguation logic, idempotency guarantees, error message normalization ("Save not found" instead of "Item not found"), rate limiting with shared "saves-write" bucket, and event emission. The infra wiring (CDK stack, route registry, architecture enforcement tests) is complete and consistent.
+
+The two Important findings are defensive-coding improvements around null guards for `updateItem` return values. While `returnValues: "ALL_NEW"` / `"ALL_OLD"` should always return attributes on successful writes, the type signature returns `T | null`, and production code should guard against the null case rather than using non-null assertions. These are not blocking issues but represent good practice for Lambda handlers where a 500 error is harder to diagnose than a well-formed error response.
+
+All other findings are minor style or documentation concerns. The code is ready for merge after considering the Important findings.

--- a/.claude/review-findings-3-4-round-1.md
+++ b/.claude/review-findings-3-4-round-1.md
@@ -1,0 +1,144 @@
+# Story 3.4 Code Review Findings - Round 1
+
+**Reviewer:** Agent (Fresh Context)
+**Date:** 2026-02-23
+**Branch:** story-3-4-save-filtering-sorting
+
+## Critical Issues (Must Fix)
+
+No critical issues found. No hardcoded secrets, no AWS resource IDs, no private keys, no connection strings, no API keys detected in any changed file.
+
+## Important Issues (Should Fix)
+
+1. **Sort by `lastAccessedAt` with `order=asc` is untested**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-list/handler.test.ts`
+   - **Problem:** The test suite only covers `sort=lastAccessedAt&order=desc` (AC6 test at line ~373). There is no test for `sort=lastAccessedAt&order=asc`. The handler has special null-to-bottom logic that bypasses the order direction multiplier (lines 96-99 of the handler), which means null items always sort to bottom regardless of `asc` or `desc`. This is the correct and intended behavior per the spec, but it is a non-obvious code path that deserves explicit test coverage. If a future refactor broke the null-to-bottom logic for ascending order, no test would catch it.
+   - **Impact:** A regression in the ascending-order null handling for `lastAccessedAt` would go undetected.
+   - **Fix:** Add a test case:
+     ```typescript
+     it("sorts lastAccessedAt ascending with null at bottom", async () => {
+       const items = [
+         createSaveItem("01SAVE0000000000000000001A", {
+           lastAccessedAt: "2026-02-22T00:00:00Z",
+         }),
+         createSaveItem("01SAVE0000000000000000002A", {
+           lastAccessedAt: undefined,
+         }),
+         createSaveItem("01SAVE0000000000000000003A", {
+           lastAccessedAt: "2026-02-20T00:00:00Z",
+         }),
+       ];
+       mockQueryAllItems.mockResolvedValueOnce({ items, truncated: false });
+       const event = createListEvent({ sort: "lastAccessedAt", order: "asc" });
+       const result = await handler(event, mockContext);
+       const body = JSON.parse(result.body);
+       expect(body.data.items[0].lastAccessedAt).toBe("2026-02-20T00:00:00Z");
+       expect(body.data.items[1].lastAccessedAt).toBe("2026-02-22T00:00:00Z");
+       expect(body.data.items[2].lastAccessedAt).toBeUndefined();
+     });
+     ```
+
+2. **Sort by `title` with `order=desc` is untested**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-list/handler.test.ts`
+   - **Problem:** The test suite only covers `sort=title&order=asc` (AC7 test at line ~403). There is no test for `sort=title&order=desc`. Similar to the previous finding, the empty-to-bottom logic for title sort bypasses the order direction, and a descending title sort with empty-title items at the bottom is an important edge case.
+   - **Impact:** A regression in descending title sort with empty/null titles would go undetected.
+   - **Fix:** Add a test case:
+     ```typescript
+     it("sorts title descending with empty title at bottom", async () => {
+       const items = [
+         createSaveItem("01SAVE0000000000000000001A", { title: "Alpha" }),
+         createSaveItem("01SAVE0000000000000000002A", { title: undefined }),
+         createSaveItem("01SAVE0000000000000000003A", { title: "Zebra" }),
+       ];
+       mockQueryAllItems.mockResolvedValueOnce({ items, truncated: false });
+       const event = createListEvent({ sort: "title", order: "desc" });
+       const result = await handler(event, mockContext);
+       const body = JSON.parse(result.body);
+       expect(body.data.items[0].title).toBe("Zebra");
+       expect(body.data.items[1].title).toBe("Alpha");
+       expect(body.data.items[2].title).toBeUndefined();
+     });
+     ```
+
+3. **AC9 test for `linkStatus` and `sort` does not verify valid options are listed in the error**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-list/handler.test.ts`, lines ~544-556
+   - **Problem:** AC9 explicitly requires that the 400 error response includes "valid options listed." The test for `contentType=invalid` (line ~533) correctly checks that the error output contains valid option names (`expect(msg).toMatch(/article|video|podcast/)`). However, the tests for `linkStatus=foo` (line ~544) and `sort=invalid` (line ~551) only call `assertADR008Error` and do NOT verify that the valid options ("linked", "unlinked" for linkStatus; "createdAt", "lastAccessedAt", "title" for sort) appear in the error. This means AC9 is only partially verified.
+   - **Impact:** If the Zod error message format changes in a future version and stops including enum values, the test suite would not catch this regression for `linkStatus` and `sort`.
+   - **Fix:** Add assertions similar to the contentType test:
+
+     ```typescript
+     // For linkStatus:
+     const body = JSON.parse(result.body);
+     const msg = JSON.stringify(body.error);
+     expect(msg).toMatch(/linked|unlinked/);
+
+     // For sort:
+     const body = JSON.parse(result.body);
+     const msg = JSON.stringify(body.error);
+     expect(msg).toMatch(/createdAt|lastAccessedAt|title/);
+     ```
+
+4. **Combined filter test (AC8) does not include `linkStatus` in the combination**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-list/handler.test.ts`, lines ~486-526
+   - **Problem:** AC8 specifies "All filters AND-combined." The combined test only exercises `contentType + search + sort`. There is no test that combines `linkStatus` with other filters. Since `linkStatus` is a logically distinct filter path (`linkedProjectCount` check), the AND-combination with other filters should be explicitly tested.
+   - **Impact:** A bug in the filter ordering or interaction between `linkStatus` and `contentType`/`search` filters would go undetected.
+   - **Fix:** Add a combined test that includes `linkStatus`:
+     ```typescript
+     it("applies contentType + linkStatus + search together", async () => {
+       const items = [
+         createSaveItem("01SAVE0000000000000000001A", {
+           contentType: ContentType.VIDEO,
+           title: "React",
+           linkedProjectCount: 1,
+         }),
+         createSaveItem("01SAVE0000000000000000002A", {
+           contentType: ContentType.VIDEO,
+           title: "React Adv",
+           linkedProjectCount: 0,
+         }),
+       ];
+       mockQueryAllItems.mockResolvedValueOnce({ items, truncated: false });
+       const event = createListEvent({
+         contentType: "video",
+         linkStatus: "linked",
+         search: "react",
+       });
+       const result = await handler(event, mockContext);
+       const body = JSON.parse(result.body);
+       expect(body.data.items).toHaveLength(1);
+     });
+     ```
+
+## Minor Issues (Nice to Have)
+
+1. **Redundant `DEFAULT_LIMIT` fallback**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-list/handler.ts`, line ~129
+   - **Problem:** `const limit = params.limit ?? DEFAULT_LIMIT;` is redundant because `listSavesQuerySchema` already specifies `.default(25)` for the `limit` field. After Zod parsing, `params.limit` will always be a number (never `undefined`). The `?? DEFAULT_LIMIT` fallback can never trigger.
+   - **Impact:** No functional impact; purely a code clarity issue. A reader might wonder if there's a case where the Zod default isn't applied.
+   - **Fix:** Simplify to `const limit = params.limit;` or keep as-is for defensive coding (acceptable either way).
+
+2. **Pagination with filtered results: no test for filtered + paginated (multi-page)**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-list/handler.test.ts`
+   - **Problem:** The test suite tests pagination in the "Base" section (no filters) and tests filters in the AC sections (no pagination). There is no test that combines a filter with a limit small enough to produce multiple pages, and then paginates to page 2 using `nextToken`. This is the most realistic usage pattern: filter by contentType, get page 1 with `nextToken`, then request page 2 with the same filter and the returned `nextToken`.
+   - **Impact:** Low. The code paths are individually tested. But end-to-end interaction between filter + sort + paginate is not validated.
+   - **Fix:** Add a multi-page filtered pagination test.
+
+3. **`localeCompare` for title sort may produce inconsistent ordering across Lambda invocations**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-list/handler.ts`, line ~107
+   - **Problem:** `aVal.localeCompare(bVal)` for title sort uses the default locale collation. Different Lambda execution environments could theoretically have different default locales, leading to inconsistent sort orders. While AWS Lambda Node.js images typically use "en_US.UTF-8", this is not guaranteed.
+   - **Impact:** Very low in practice. Could cause subtle inconsistency in title ordering for edge cases (e.g., accented characters, mixed-case).
+   - **Fix:** Consider using a deterministic comparison: `aVal.localeCompare(bVal, 'en', { sensitivity: 'base' })` or simply `aVal < bVal ? -1 : aVal > bVal ? 1 : 0` for strict lexicographic ordering.
+
+4. **Removed stale-cursor test from Story 3.2 section without re-adding assertADR008Error check**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-list/handler.test.ts`
+   - **Problem:** The diff shows the Story 3.2 "AC10: Stale nextToken returns 400" test block was deleted (lines 79-112 of the diff). The equivalent functionality was re-added in the "nextToken with filter changes" section at the end, which is correct. However, the old test at line 97 checked `expect(body.error.message).toContain("nextToken is invalid")` which verified the specific error message. The new stale-cursor test (line ~697) uses `assertADR008Error` but does NOT check the error message content. This is a minor reduction in assertion specificity.
+   - **Impact:** Very low. The `assertADR008Error` utility verifies the error shape and code, which is sufficient.
+   - **Fix:** Optionally add `expect(body.error.message).toContain("nextToken")` to the stale cursor test for consistency.
+
+## Summary
+
+- **Total findings:** 8
+- **Critical:** 0
+- **Important:** 4
+- **Minor:** 4
+- **Recommendation:** REVISE -- The implementation is clean and correct for the happy paths. All 11 ACs have corresponding test coverage at a basic level. The handler logic for filtering, sorting, and the nextToken-with-filter-change behavior is well-structured and correct. The important findings are all about missing test coverage for edge cases (reverse sort orders with null/empty-to-bottom semantics, combined filters with linkStatus, and AC9 valid-options verification for all enum fields). These gaps should be addressed to ensure the null/empty-to-bottom sort behavior is robust against regressions.

--- a/.claude/review-findings-3-4-round-2.md
+++ b/.claude/review-findings-3-4-round-2.md
@@ -1,0 +1,72 @@
+# Story 3.4 Code Review Findings - Round 2
+
+**Reviewer:** Agent (Fresh Context)
+**Date:** 2026-02-23
+**Branch:** story-3-4-save-filtering-sorting
+
+## Critical Issues (Must Fix)
+
+No critical issues found. All changed files were scanned for hardcoded secrets (AWS account IDs, access keys, resource IDs, API keys, private key material, connection strings, ARNs). None detected.
+
+## Important Issues (Should Fix)
+
+No important issues found.
+
+All six findings from Round 1 have been addressed in the `fix: address code review round 1` commit (19ebc83):
+
+1. **Sort by lastAccessedAt with order=asc** -- Now tested ("sorts lastAccessedAt ascending with null at bottom" at `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-list/handler.test.ts` line ~502). Verified the test asserts null at bottom and correct ascending order.
+2. **Sort by title with order=desc** -- Now tested ("sorts title descending with empty title at bottom" at line ~543). Verified the test asserts empty/undefined title at bottom and correct descending order.
+3. **AC9 linkStatus/sort valid options in error** -- Now both the linkStatus test (line ~610, `expect(msg).toMatch(/linked|unlinked/)`) and the sort test (line ~620, `expect(msg).toMatch(/createdAt|lastAccessedAt|title/)`) verify that valid options appear in the error output.
+4. **Combined filter with linkStatus** -- Now tested ("applies contentType + linkStatus + search together" at line ~625). Verifies AND-combination of all three filter types.
+5. **Multi-page filtered pagination** -- Now tested ("paginates filtered results across multiple pages" at line ~870). Verifies that page 1 returns nextToken and page 2 correctly returns the remaining filtered items.
+6. **Stale cursor message check** -- Now tested with `expect(body.error.message).toContain("nextToken")` at line ~867.
+
+## Minor Issues (Nice to Have)
+
+1. **Redundant `?? DEFAULT_LIMIT` fallback (carried from Round 1)**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-list/handler.ts`, line 128
+   - **Problem:** `const limit = params.limit ?? DEFAULT_LIMIT;` is redundant because `listSavesQuerySchema` specifies `.default(25)` for the `limit` field. After Zod parsing, `params.limit` is always a number and can never be `undefined`. The `?? DEFAULT_LIMIT` fallback is dead code.
+   - **Impact:** No functional impact. Purely a code clarity concern. A reader might wonder if there is a case where the Zod default is not applied.
+   - **Fix:** Simplify to `const limit = params.limit;`. Alternatively, keep as-is for defensive coding -- this is acceptable.
+
+2. **ULID regex in `decodeNextToken` is more permissive than Crockford Base32 (pre-existing from Story 3.2)**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-list/handler.ts`, line 33
+   - **Problem:** The regex `/^[0-9A-Z]{26}$/` accepts characters I, L, O, U which are not part of the Crockford Base32 character set used by ULID. The correct pattern is `/^[0-9A-HJKMNP-TV-Z]{26}$/` (as used in the users.test.ts at `/Users/stephen/Documents/ai-learning-hub/backend/shared/db/test/users.test.ts` line 347). This means a crafted nextToken containing these invalid characters would pass decoding but fail to match any real saveId in the `findIndex` lookup, resulting in either a 400 error (stale cursor) or a first-page reset (filtered out) -- both safe outcomes.
+   - **Impact:** No security or correctness impact. Invalid ULIDs containing I/L/O/U will never match a real saveId, so the cursor lookup will fail gracefully. This is a pre-existing issue from Story 3.2, not introduced by 3.4.
+   - **Fix:** Change regex to `/^[0-9A-HJKMNP-TV-Z]{26}$/` for strict ULID validation, or defer to a future cleanup task.
+
+3. **`localeCompare` for title sort may produce inconsistent ordering across Lambda invocations (carried from Round 1)**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-list/handler.ts`, line 107
+   - **Problem:** `aVal.localeCompare(bVal)` for title sort uses the default locale collation. Different Lambda execution environments could theoretically have different default locales, leading to inconsistent sort orders for edge cases (accented characters, mixed case).
+   - **Impact:** Very low in practice. AWS Lambda Node.js images consistently use en_US.UTF-8. This would only matter for internationalized content.
+   - **Fix:** Consider `aVal.localeCompare(bVal, 'en', { sensitivity: 'base' })` for deterministic ordering, or use simple lexicographic comparison (`aVal < bVal ? -1 : aVal > bVal ? 1 : 0`). Low priority.
+
+## Verification Checklist
+
+The following was verified during this review:
+
+- **AC1 (contentType filter):** Handler applies `s.contentType === params.contentType` filter. Test covers `contentType=video`. PASS.
+- **AC2 (linkStatus=linked):** Handler uses `(s.linkedProjectCount ?? 0) > 0`. Test verifies items with count > 0 are returned. PASS.
+- **AC3 (linkStatus=unlinked):** Handler uses `(s.linkedProjectCount ?? 0) === 0`. Tests verify items with count 0 and missing field. PASS.
+- **AC4 (search):** Handler applies case-insensitive substring match on `(s.title ?? '')` and `s.url`. Tests cover title match, url match, and missing title. PASS.
+- **AC5 (sort createdAt asc):** Handler sorts by `a.createdAt.localeCompare(b.createdAt)` with asc/desc multiplier. Test verifies ascending order. PASS.
+- **AC6 (sort lastAccessedAt desc, null bottom):** Handler returns 1 for null aVal and -1 for null bVal (always bottom). Tests cover desc and asc with null at bottom. PASS.
+- **AC7 (sort title asc, empty bottom):** Handler returns 1 for empty aVal and -1 for empty bVal. Tests cover asc and desc with empty at bottom. PASS.
+- **AC8 (combined filters AND sort):** Tests verify contentType+linkStatus+search and contentType+search+sort combinations. PASS.
+- **AC9 (invalid filter/sort 400):** Tests verify 400 for invalid contentType, linkStatus, sort, order, limit. Tests verify valid options appear in error output for contentType, linkStatus, sort. Uses `assertADR008Error`. PASS.
+- **AC10 (empty result, not error):** Test verifies `{ items: [], hasMore: false }` when filters exclude all items. PASS.
+- **AC11 (truncated flag):** Handler uses `...(truncated && { truncated: true })`. Tests verify `truncated: true` when ceiling hit and `truncated` absent when not. TODO(story-3.4) comment removed. PASS.
+- **nextToken + filter change:** Handler checks cursor in unfiltered set (stale -> 400), then in filtered set (missing -> first page). Tests cover malformed token, stale cursor, filter-changed cursor, and multi-page filtered pagination. PASS.
+- **Shared library usage:** Uses `@ai-learning-hub/validation` (`listSavesQuerySchema`, `validateQueryParams`), `@ai-learning-hub/db` (`queryAllItems`, `toPublicSave`, etc.), `@ai-learning-hub/middleware` (`wrapHandler`), `@ai-learning-hub/types` (`AppError`, `ErrorCode`). PASS.
+- **ADR-008 compliance:** All validation errors use `AppError(ErrorCode.VALIDATION_ERROR, ...)`. Error responses include `{ error: { code, message, requestId } }`. PASS.
+- **No new endpoints or Lambdas:** Only `GET /saves` handler modified. PASS.
+- **Schema exported:** `listSavesQuerySchema` exported from `@ai-learning-hub/validation` index. PASS.
+- **No hardcoded secrets or sensitive data:** PASS.
+
+## Summary
+
+- **Total findings:** 3
+- **Critical:** 0
+- **Important:** 0
+- **Minor:** 3
+- **Recommendation:** APPROVE -- All Round 1 findings have been addressed. The implementation is clean, correct, and thoroughly tested. All 11 acceptance criteria have explicit test coverage including edge cases (null/empty sorts to bottom in both directions, missing linkedProjectCount, missing title during search, combined filters, filter-changed pagination, stale cursors). The three remaining minor findings are cosmetic (redundant fallback, permissive regex inherited from 3.2, locale-sensitive comparison) with no functional or security impact.

--- a/_bmad-output/implementation-artifacts/3-1-1-extract-shared-schemas-constants.md
+++ b/_bmad-output/implementation-artifacts/3-1-1-extract-shared-schemas-constants.md
@@ -1,0 +1,164 @@
+---
+id: "3.1.1"
+title: "Extract Shared Schemas & Constants"
+status: ready-for-dev
+depends_on: []
+touches:
+  - backend/shared/validation/src/schemas.ts
+  - backend/shared/validation/src/index.ts
+  - backend/shared/db/src/saves.ts
+  - backend/shared/db/src/index.ts
+  - backend/shared/events/src/index.ts
+  - backend/functions/saves-get/handler.ts
+  - backend/functions/saves-update/handler.ts
+  - backend/functions/saves-delete/handler.ts
+  - backend/functions/saves-restore/handler.ts
+  - backend/functions/saves/handler.ts
+risk: low
+---
+
+# Story 3.1.1: Extract Shared Schemas & Constants
+
+Status: ready-for-dev
+
+## Story
+
+As a developer,
+I want duplicated schemas, constants, and helpers extracted into shared packages,
+so that policy changes (rate limits, validation rules, EventBridge config) only need to be updated in one place.
+
+## Acceptance Criteria
+
+| #   | Given                                                                                                    | When                                                            | Then                                                                                                                  |
+| --- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| AC1 | `saveIdPathSchema` defined locally in 4 handlers (saves-get, saves-update, saves-delete, saves-restore)  | Schema extracted to `@ai-learning-hub/validation`               | All 4 handlers import from shared package; no local `saveIdPathSchema` definitions remain in any handler file         |
+| AC2 | Rate limit config `{ operation: "saves-write", limit: 200, windowSeconds: 3600 }` repeated in 4 handlers | Config extracted to `@ai-learning-hub/db/saves`                 | All 4 handlers import `SAVES_WRITE_RATE_LIMIT` constant; no inline rate limit config objects remain                   |
+| AC3 | EventBridge init boilerplate repeated in 4 handlers                                                      | Helper `requireEventBus()` created in `@ai-learning-hub/events` | All 4 handlers call `requireEventBus()` instead of inline `process.env.EVENT_BUS_NAME` + guard + `getDefaultClient()` |
+| AC4 | All existing tests pass                                                                                  | After all extractions                                           | `npm test` passes with 0 failures; no behavioral changes                                                              |
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Extract `saveIdPathSchema` (AC: #1)
+  - [ ] 1.1 Add `saveIdPathSchema` to `backend/shared/validation/src/schemas.ts` alongside existing `createSaveSchema`, `updateSaveSchema`, `listSavesQuerySchema`. Use this exact definition (must match current handler definitions character-for-character):
+    ```typescript
+    export const saveIdPathSchema = z.object({
+      saveId: z
+        .string()
+        .regex(/^[0-9A-Z]{26}$/, "saveId must be a 26-character ULID"),
+    });
+    ```
+  - [ ] 1.2 Export from `backend/shared/validation/src/index.ts`
+  - [ ] 1.3 Rebuild validation package: `npm run -w @ai-learning-hub/validation build`
+  - [ ] 1.4 Update imports in `saves-get/handler.ts`, `saves-update/handler.ts`, `saves-delete/handler.ts`, `saves-restore/handler.ts`
+  - [ ] 1.5 Remove local `saveIdPathSchema` definitions from all 4 handlers
+  - [ ] 1.6 Verify: `grep -r "const saveIdPathSchema" backend/functions/` returns no matches
+
+- [ ] Task 2: Extract rate limit constant (AC: #2)
+  - [ ] 2.1 Add to `backend/shared/db/src/saves.ts`:
+    ```typescript
+    export const SAVES_WRITE_RATE_LIMIT = {
+      operation: "saves-write",
+      limit: 200,
+      windowSeconds: 3600,
+    } as const;
+    ```
+  - [ ] 2.2 Export from `backend/shared/db/src/index.ts`
+  - [ ] 2.3 Update `saves/handler.ts`, `saves-update/handler.ts`, `saves-delete/handler.ts`, `saves-restore/handler.ts` to use:
+    ```typescript
+    await enforceRateLimit(client, USERS_TABLE_CONFIG.tableName, {
+      ...SAVES_WRITE_RATE_LIMIT,
+      identifier: userId,
+    }, logger);
+    ```
+
+- [ ] Task 3: Extract EventBridge init helper (AC: #3)
+  - [ ] 3.1 Add `requireEventBus()` to the events package (e.g., `backend/shared/events/src/index.ts` or a new `init.ts`):
+    ```typescript
+    export function requireEventBus() {
+      const busName = process.env.EVENT_BUS_NAME;
+      if (!busName && process.env.NODE_ENV !== "test")
+        throw new Error("EVENT_BUS_NAME env var is not set");
+      return { busName: busName ?? "", ebClient: getDefaultClient() };
+    }
+    ```
+  - [ ] 3.2 If `requireEventBus` is implemented in a new file (e.g., `init.ts`), re-export it from `backend/shared/events/src/index.ts` so the public API remains `@ai-learning-hub/events`
+  - [ ] 3.3 Update all 4 handlers: at module scope, set `const eventBus = requireEventBus();`. In the handler body, use `eventBus.ebClient` and `eventBus.busName` for all `emitEvent(...)` calls. Do not call `requireEventBus()` inside the handler function or retain a separate EventBridge client getter.
+  - [ ] 3.4 Remove the 4 inline `const EVENT_BUS_NAME = ...` + guard + `getDefaultEBClient()` blocks
+  - [ ] 3.5 Update test mocks: in each of the 4 handler test files that mock `@ai-learning-hub/events` (saves, saves-update, saves-delete, saves-restore), add `requireEventBus` to the mock: `requireEventBus: () => ({ busName: "test-event-bus", ebClient: {} })`. Without this, handler module-level `requireEventBus()` calls will fail on test load.
+
+- [ ] Task 4: Verify all tests pass (AC: #4)
+  - [ ] 4.1 Run `npm test` — all tests must pass
+  - [ ] 4.2 Run `npm run type-check` — clean
+  - [ ] 4.3 Run `npm run lint` — clean
+
+## Dev Notes
+
+### Key principle: behavioral equivalence
+
+This story makes ZERO behavioral changes. Every extraction must produce identical runtime behavior. If any test breaks, the extraction introduced a regression — fix the extraction, not the test.
+
+### Validation package rebuild required
+
+After modifying `backend/shared/validation/src/schemas.ts`, you MUST run `npm run -w @ai-learning-hub/validation build` before running tests. The handlers import from the compiled output, not the source. This was a lesson from Story 3.4 implementation.
+
+### EventBridge helper design
+
+The `requireEventBus()` function must be called once at module scope (cold start), not inside the handler function body. Store the result: `const eventBus = requireEventBus();`. In handler body code, reference `eventBus.busName` and `eventBus.ebClient` for `emitEvent(...)` calls. This preserves the existing behavior where the env guard and client init run once on cold start.
+
+### Rate limit constant design
+
+Use `as const` on the rate limit config to get literal types. Handlers spread it with `{ ...SAVES_WRITE_RATE_LIMIT, identifier: userId }` to add the per-request `identifier` field.
+
+## Architecture Compliance
+
+| ADR / NFR           | How This Story Must Comply                                                    |
+| ------------------- | ----------------------------------------------------------------------------- |
+| **NFR-M1 (DRY)**   | Primary purpose — eliminate duplication                                        |
+| **ADR-008**         | No changes to error response format                                           |
+| **Shared libs**     | Extractions go INTO shared libs (`@ai-learning-hub/validation`, `db`, `events`) |
+
+## Testing Requirements
+
+### No new tests required
+
+This story only moves existing code into shared packages. Existing tests validate the behavior. If a test breaks, the extraction is wrong.
+
+### Quality gates (must be green)
+
+- `npm test`
+- `npm run lint`
+- `npm run type-check`
+
+## Previous Story Intelligence
+
+### From Epic 3 Stories 3.1a–3.4
+
+- **Validation package rebuild**: After adding exports to `@ai-learning-hub/validation`, always rebuild before running tests
+- **Event mock in tests**: The 4 handler test files that mock `@ai-learning-hub/events` MUST add `requireEventBus` to the mock (see Task 3.5). Handlers call `requireEventBus()` at module scope — if the mock doesn't provide it, tests will fail on import
+
+## File Structure Requirements
+
+### Modify
+
+- `backend/shared/validation/src/schemas.ts` — add `saveIdPathSchema`
+- `backend/shared/validation/src/index.ts` — add export
+- `backend/shared/db/src/saves.ts` — add `SAVES_WRITE_RATE_LIMIT`
+- `backend/shared/db/src/index.ts` — add export
+- `backend/shared/events/src/index.ts` — add `requireEventBus()`
+- `backend/functions/saves-get/handler.ts` — update imports, remove local schema
+- `backend/functions/saves-update/handler.ts` — update imports, remove local schema + rate limit + EB boilerplate
+- `backend/functions/saves-delete/handler.ts` — update imports, remove local schema + rate limit + EB boilerplate
+- `backend/functions/saves-restore/handler.ts` — update imports, remove local schema + rate limit + EB boilerplate
+- `backend/functions/saves/handler.ts` — update rate limit + EB boilerplate (schema already centralized)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+{{agent_model_name_version}}
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/3-1-2-shared-test-utilities.md
+++ b/_bmad-output/implementation-artifacts/3-1-2-shared-test-utilities.md
@@ -1,0 +1,215 @@
+---
+id: "3.1.2"
+title: "Shared Test Utilities for Saves Domain"
+status: ready-for-dev
+depends_on:
+  - 3-1-1-extract-shared-schemas-constants
+touches:
+  - backend/test-utils/save-factories.ts (new)
+  - backend/test-utils/mock-events.ts (new)
+  - backend/test-utils/mock-db.ts (new)
+  - backend/test-utils/index.ts
+risk: low
+---
+
+# Story 3.1.2: Shared Test Utilities for Saves Domain
+
+Status: ready-for-dev
+
+## Story
+
+As a developer,
+I want shared test factories, mock helpers, and assertion utilities for the saves domain,
+so that new saves handlers can be tested with minimal boilerplate and existing tests are easier to maintain.
+
+## Acceptance Criteria
+
+| #   | Given                                                                  | When                                                               | Then                                                                                                                                                             |
+| --- | ---------------------------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC1 | `createSaveItem` factory defined in 5 test files with minor variations | Factory extracted to `backend/test-utils/save-factories.ts`        | Single `createTestSaveItem(saveId?, overrides?)` function exported; signature supports all variations across existing test files                                  |
+| AC2 | Events mock block identical in 4 test files                            | Mock factory extracted to `backend/test-utils/mock-events.ts`      | `mockEventsModule()` function exported (matching `mockMiddlewareModule()` pattern); returns `{ emitEvent, getDefaultClient, SAVES_EVENT_SOURCE }`                |
+| AC3 | DB mock blocks with heavy overlap across 6 test files                  | Composable mock factory created in `backend/test-utils/mock-db.ts` | `mockDbModule(mockFns)` function providing `SAVES_TABLE_CONFIG`, `USERS_TABLE_CONFIG`, `toPublicSave`, `requireEnv`, `getDefaultClient` with override capability |
+| AC4 | `VALID_SAVE_ID` constant defined in 4 test files                       | Constant extracted to `backend/test-utils/save-factories.ts`       | Single export `VALID_SAVE_ID`; value matches existing: `"01HXYZ1234567890ABCDEFGHIJ"`                                                                           |
+| AC5 | All existing tests pass                                                | After creating all new test utilities                              | `npm test` passes with 0 failures; new utilities are importable and working                                                                                      |
+| AC6 | One test file updated as proof-of-concept                              | `saves-get/handler.test.ts` migrated to use new utilities          | Test file uses `createTestSaveItem`, `mockDbModule`, `VALID_SAVE_ID` from `backend/test-utils/`; all tests still pass                                            |
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Create `backend/test-utils/save-factories.ts` (AC: #1, #4)
+  - [ ] 1.1 Implement `createTestSaveItem(saveId?, overrides?)`:
+    ```typescript
+    import { ContentType } from "@ai-learning-hub/types";
+    import type { SaveItem } from "@ai-learning-hub/types";
+
+    export const VALID_SAVE_ID = "01HXYZ1234567890ABCDEFGHIJ";
+
+    export function createTestSaveItem(
+      saveId: string = VALID_SAVE_ID,
+      overrides: Partial<SaveItem> = {}
+    ): SaveItem {
+      return {
+        PK: "USER#user123",
+        SK: `SAVE#${saveId}`,
+        userId: "user123",
+        saveId,
+        url: `https://example.com/${saveId}`,
+        normalizedUrl: `https://example.com/${saveId}`,
+        urlHash: `hash-${saveId}`,
+        contentType: ContentType.ARTICLE,
+        tags: [],
+        isTutorial: false,
+        linkedProjectCount: 0,
+        createdAt: "2026-02-20T00:00:00Z",
+        updatedAt: "2026-02-20T00:00:00Z",
+        ...overrides,
+      };
+    }
+    ```
+  - [ ] 1.2 Export from `backend/test-utils/index.ts`
+
+- [ ] Task 2: Create `backend/test-utils/mock-events.ts` (AC: #2)
+  - [ ] 2.1 Implement `mockEventsModule()`:
+    ```typescript
+    import { vi } from "vitest";
+
+    export function mockEventsModule() {
+      const mockEmitEvent = vi.fn();
+      return {
+        emitEvent: (...args: unknown[]) => mockEmitEvent(...args),
+        getDefaultClient: () => ({}),
+        SAVES_EVENT_SOURCE: "ai-learning-hub.saves",
+        // Expose the mock for assertions
+        _mockEmitEvent: mockEmitEvent,
+      };
+    }
+    ```
+  - [ ] 2.2 Export from `backend/test-utils/index.ts`
+  - [ ] 2.3 Consider: should `requireEventBus` (from Story 3.1.1) also be mocked here? If so, add `requireEventBus: () => ({ busName: "test-event-bus", ebClient: {} })`
+
+- [ ] Task 3: Create `backend/test-utils/mock-db.ts` (AC: #3)
+  - [ ] 3.1 Implement `mockDbModule(mockFns)`. Note: this provides shared static config (table configs, toPublicSave, requireEnv, rate limit constant). Callers MUST pass handler-specific operation mocks (e.g., `getItem`, `updateItem`, `queryItems`, `queryAllItems`, `enforceRateLimit`, `transactWriteItems`) via `mockFns` — these vary per handler and are not included in defaults:
+    ```typescript
+    import { vi } from "vitest";
+    import type { SaveItem } from "@ai-learning-hub/types";
+
+    export function mockDbModule(
+      mockFns: Record<string, ReturnType<typeof vi.fn>> = {}
+    ) {
+      return {
+        getDefaultClient: () => ({}),
+        SAVES_TABLE_CONFIG: {
+          tableName: "ai-learning-hub-saves",
+          partitionKey: "PK",
+          sortKey: "SK",
+        },
+        USERS_TABLE_CONFIG: {
+          tableName: "ai-learning-hub-users",
+          partitionKey: "PK",
+          sortKey: "SK",
+        },
+        toPublicSave: (item: SaveItem) => {
+          const { PK: _PK, SK: _SK, deletedAt: _del, ...rest } = item;
+          return rest;
+        },
+        requireEnv: (name: string, fallback: string) =>
+          process.env[name] ?? fallback,
+        SAVES_WRITE_RATE_LIMIT: {
+          operation: "saves-write",
+          limit: 200,
+          windowSeconds: 3600,
+        },
+        ...mockFns,
+      };
+    }
+    ```
+  - [ ] 3.2 Export from `backend/test-utils/index.ts`
+
+- [ ] Task 4: Update `backend/test-utils/index.ts` exports (AC: #1-#4)
+  - [ ] 4.1 Add re-exports for all new modules
+  - [ ] 4.2 Ensure existing exports (`createMockLogger`, `mockCreateLoggerModule`, `createMockContext`, `createMockEvent`, `mockMiddlewareModule`, `assertADR008Error`) are preserved
+
+- [ ] Task 5: Proof-of-concept migration (AC: #6)
+  - [ ] 5.1 Update `saves-get/handler.test.ts` to import `createTestSaveItem`, `VALID_SAVE_ID` from `backend/test-utils/`
+  - [ ] 5.2 Update `saves-get/handler.test.ts` to use `mockDbModule()` for the `@ai-learning-hub/db` mock. Callers must pass handler-specific mocks (e.g., `getItem`, `updateItem`) via `mockFns` — `mockDbModule` only provides shared static config. Example: `mockDbModule({ getItem: (...args: unknown[]) => mockGetItem(...args), updateItem: (...args: unknown[]) => mockUpdateItem(...args) })`
+  - [ ] 5.3 Note: the shared factory uses parameterized defaults (`url: \`https://example.com/${saveId}\``). The current saves-get test asserts against fixed strings (`"https://example.com/article"`). Either pass overrides (e.g., `createTestSaveItem(VALID_SAVE_ID, { url: "https://example.com/article", urlHash: "hash123" })`) or update test assertions to match the new defaults. The parameterized defaults are intentional — they're needed by saves-list tests that create multiple items with distinct URLs.
+  - [ ] 5.4 Run `saves-get` tests to confirm no regressions
+
+- [ ] Task 6: Verify (AC: #5)
+  - [ ] 6.1 Run `npm test` — all tests pass
+  - [ ] 6.2 Run `npm run type-check` — clean
+
+## Dev Notes
+
+### Design pattern: match `mockMiddlewareModule()`
+
+The existing `mockMiddlewareModule()` in `backend/test-utils/mock-wrapper.ts` is the gold standard for how mock factories should work in this codebase. Study it before implementing `mockEventsModule()` and `mockDbModule()`. Key patterns:
+- Returns a plain object (not a class)
+- Mock functions are created inside the factory
+- Consumers use `vi.mock("@ai-learning-hub/events", () => mockEventsModule())`
+
+### `vi.mock()` hoisting constraint
+
+`vi.mock()` calls are hoisted to the top of the test file by Vitest. The factory function passed to `vi.mock()` cannot reference variables defined later in the file. This means:
+- Mock functions like `mockUpdateItem` must be declared BEFORE the `vi.mock()` call
+- The `mockDbModule()` factory must accept mock functions as parameters (not create them internally) if the test file needs direct references to them for assertions
+- Alternative: `mockDbModule()` creates its own mocks and the test file accesses them via `vi.mocked()` — this is cleaner but requires the test to know the internal structure
+
+### Proof-of-concept scope
+
+Only migrate `saves-get/handler.test.ts` in this story. The full migration of all 6 test files happens in Story 3.1.3. This keeps the story small and validates the utility design before committing to it across all files.
+
+### `assertADR008Error` adoption
+
+This utility already exists in `backend/test-utils/assert-adr008.ts`. It does NOT need to be created — it needs to be adopted in more test files. That adoption happens in Story 3.1.3 (AC5), not here. This story only ensures it's properly exported from `backend/test-utils/index.ts` (which it already should be).
+
+## Architecture Compliance
+
+| ADR / NFR         | How This Story Must Comply                                      |
+| ----------------- | --------------------------------------------------------------- |
+| **NFR-M1 (DRY)** | Reduce test boilerplate through shared utilities                |
+| **Test patterns** | Follow existing `mockMiddlewareModule()` pattern for consistency |
+
+## Testing Requirements
+
+### Test the utilities themselves
+
+The utilities are tested implicitly — the proof-of-concept migration in Task 5 validates they work correctly. If `saves-get` tests pass using the new utilities, the utilities are correct.
+
+### Quality gates
+
+- `npm test`
+- `npm run lint`
+- `npm run type-check`
+
+## Previous Story Intelligence
+
+### From Story 3.1.1
+
+- Shared packages may have been updated (new exports like `saveIdPathSchema`, `SAVES_WRITE_RATE_LIMIT`, `requireEventBus`)
+- `mockDbModule()` should include `SAVES_WRITE_RATE_LIMIT` in its default returns
+- `mockEventsModule()` should include `requireEventBus` mock if Story 3.1.1 introduced it
+
+## File Structure Requirements
+
+### New
+
+- `backend/test-utils/save-factories.ts` — `createTestSaveItem`, `VALID_SAVE_ID`
+- `backend/test-utils/mock-events.ts` — `mockEventsModule()`
+- `backend/test-utils/mock-db.ts` — `mockDbModule()`
+
+### Modify
+
+- `backend/test-utils/index.ts` — add re-exports
+- `backend/functions/saves-get/handler.test.ts` — proof-of-concept migration
+
+## Dev Agent Record
+
+### Agent Model Used
+
+{{agent_model_name_version}}
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/3-1-3-handler-test-consolidation.md
+++ b/_bmad-output/implementation-artifacts/3-1-3-handler-test-consolidation.md
@@ -1,0 +1,219 @@
+---
+id: "3.1.3"
+title: "Handler & Test Consolidation"
+status: ready-for-dev
+depends_on:
+  - 3-1-1-extract-shared-schemas-constants
+  - 3-1-2-shared-test-utilities
+touches:
+  - backend/functions/saves/handler.ts
+  - backend/functions/saves/handler.test.ts
+  - backend/functions/saves-get/handler.test.ts
+  - backend/functions/saves-list/handler.test.ts
+  - backend/functions/saves-update/handler.ts
+  - backend/functions/saves-update/handler.test.ts
+  - backend/functions/saves-delete/handler.ts
+  - backend/functions/saves-delete/handler.test.ts
+  - backend/functions/saves-restore/handler.ts
+  - backend/functions/saves-restore/handler.test.ts
+risk: medium
+---
+
+# Story 3.1.3: Handler & Test Consolidation
+
+Status: ready-for-dev
+
+## Story
+
+As a developer,
+I want all saves handlers and test files to use shared code from `@ai-learning-hub/*` packages and `backend/test-utils/`,
+so that the codebase is DRY, consistent, and easy to maintain.
+
+## Acceptance Criteria
+
+| #   | Given                                                                                         | When                                           | Then                                                                                                                                                      |
+| --- | --------------------------------------------------------------------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC1 | `saves/handler.ts` defines local `SAVES_TABLE_CONFIG`, `SaveItem`, `toPublicSave`             | Handler retrofitted to use shared packages     | Imports `SAVES_TABLE_CONFIG`, `toPublicSave` from `@ai-learning-hub/db`; imports `SaveItem` from `@ai-learning-hub/types`; no local definitions remain    |
+| AC2 | Local `toPublicSave` in `saves/handler.ts` does not strip `deletedAt`                         | Shared `toPublicSave` used everywhere          | `deletedAt` is stripped from all API responses including 409 `existingSave`; verified by test |
+| AC3 | 409 duplicate response built twice within `saves/handler.ts`                                  | Extracted to local helper                      | Single `createDuplicateResponse(existingSave, requestId)` function; both call sites use it                                                                |
+| AC4 | `AppError.isAppError()` not used consistently across handlers                                 | All handlers standardized                      | No manual `instanceof Error && "code" in error` checks remain in any saves handler; all use `AppError.isAppError(error)` |
+| AC5 | `saves-update` and `saves-restore` use unnecessary explicit `createSuccessResponse()` for 200 | Standardized to auto-wrap pattern              | Both handlers return plain data objects for 200 responses; `wrapHandler` auto-wraps them |
+| AC6 | All 6 test files have duplicated factory/mock/assertion code                                  | All test files use shared utilities from 3.1.2 | Each test file imports from `backend/test-utils/`: `createTestSaveItem`, `mockEventsModule`, `mockDbModule`, `VALID_SAVE_ID`, `assertADR008Error` as applicable |
+| AC7 | All existing tests pass                                                                       | After all changes                              | `npm test` passes with 0 failures; no behavioral changes except AC2 (`deletedAt` stripping) |
+| AC8 | No local schema definitions remain in handler files                                           | After cleanup                                  | `grep -r "const saveIdPathSchema" backend/functions/` returns no matches; `grep -r "const SAVES_TABLE_CONFIG" backend/functions/` returns no matches |
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Retrofit `saves/handler.ts` (AC: #1, #2, #3)
+  - [ ] 1.1 Replace local `SAVES_TABLE_CONFIG` with import from `@ai-learning-hub/db`
+  - [ ] 1.2 Replace local `SaveItem` interface with `import type { SaveItem } from "@ai-learning-hub/types"`
+  - [ ] 1.3 Replace local `toPublicSave` with import from `@ai-learning-hub/db` — this CHANGES behavior: `deletedAt` is now stripped from 409 responses
+  - [ ] 1.4 Extract 409 response into `createDuplicateResponse(existingSave: PublicSave, requestId: string)` local helper function
+  - [ ] 1.5 Replace both 409 response construction sites with `createDuplicateResponse()` call: (1) the block returning 409 with `existingSave` from the Layer 1 GSI query result, and (2) the block returning 409 with `existingSave` from `activeResult` in `handleTransactionFailure`
+  - [ ] 1.6 Update `saves/handler.test.ts` to verify `deletedAt` is NOT present in 409 `existingSave` response
+
+- [ ] Task 2: Standardize `AppError` usage across handlers (AC: #4)
+  - [ ] 2.1 In `saves-update/handler.ts`: replace manual `instanceof Error && "code" in error && (error as AppError).code` with `AppError.isAppError(error) && error.code`
+  - [ ] 2.2 In `saves-delete/handler.ts`: same replacement
+  - [ ] 2.3 In `saves-restore/handler.ts`: same replacement
+  - [ ] 2.4 Verify `AppError` is imported from `@ai-learning-hub/types` (where `isAppError` static method lives)
+
+- [ ] Task 3: Standardize response wrapping (AC: #5)
+  - [ ] 3.1 In `saves-update/handler.ts`: change from `return createSuccessResponse(toPublicSave(updated), requestId)` to `return toPublicSave(updated)` — `wrapHandler` will auto-wrap with 200
+  - [ ] 3.2 In `saves-restore/handler.ts`: change from `return createSuccessResponse(toPublicSave(restored), requestId)` to `return toPublicSave(restored)`
+  - [ ] 3.3 Remove unused `createSuccessResponse` imports from both handlers
+  - [ ] 3.4 Verify tests still pass — the response shape is identical (wrapHandler produces same output)
+
+- [ ] Task 4: Migrate all 6 test files to shared utilities (AC: #6)
+  - [ ] 4.1 `saves/handler.test.ts`:
+    - Import `createTestSaveItem` from test-utils. Use overrides for any create-specific defaults (e.g., `createTestSaveItem(saveId, { url: "...", tags: ["test"] })`). Do NOT keep a local factory — if `createTestSaveItem` doesn't support a needed shape, extend it via overrides.
+    - Use `mockEventsModule()` for events mock
+    - Use `mockDbModule()` for db mock
+    - Use `assertADR008Error` for error assertions
+  - [ ] 4.2 `saves-get/handler.test.ts`:
+    - Already migrated in Story 3.1.2 proof-of-concept
+    - Add `assertADR008Error` usage for error response structural checks
+    - **Important:** `assertADR008Error` validates status code and error code but NOT the error message. Keep existing `expect(body.error.message).toBe("Save not found")` assertions alongside `assertADR008Error`. This applies to all test files — `assertADR008Error` supplements existing message assertions, it does not replace them.
+  - [ ] 4.3 `saves-list/handler.test.ts`:
+    - Import `createTestSaveItem` from test-utils
+    - Use `mockDbModule()` for db mock
+    - `assertADR008Error` already used — no changes needed
+  - [ ] 4.4 `saves-update/handler.test.ts`:
+    - Import `createTestSaveItem`, `VALID_SAVE_ID` from test-utils
+    - Use `mockEventsModule()`, `mockDbModule()`
+    - Use `assertADR008Error` for error assertions
+  - [ ] 4.5 `saves-delete/handler.test.ts`:
+    - Import `createTestSaveItem`, `VALID_SAVE_ID` from test-utils
+    - Use `mockEventsModule()`, `mockDbModule()`
+    - Use `assertADR008Error` for error assertions
+  - [ ] 4.6 `saves-restore/handler.test.ts`:
+    - Import `createTestSaveItem`, `VALID_SAVE_ID` from test-utils
+    - Use `mockEventsModule()`, `mockDbModule()`
+    - Use `assertADR008Error` for error assertions
+
+- [ ] Task 5: Verification (AC: #7, #8)
+  - [ ] 5.1 Run `npm test` — all tests pass
+  - [ ] 5.2 Run `npm run type-check` — clean
+  - [ ] 5.3 Run `npm run lint` — clean
+  - [ ] 5.4 Verify: `grep -r "const saveIdPathSchema" backend/functions/` — no matches (cross-check: Story 3.1.1 already removed these; this confirms nothing was re-introduced)
+  - [ ] 5.5 Verify: `grep -r "const SAVES_TABLE_CONFIG" backend/functions/` — no matches
+  - [ ] 5.6 Verify: `grep -rn "instanceof Error" backend/functions/saves` — no AppError detection patterns remain
+
+## Dev Notes
+
+### This is the largest story — plan for methodical execution
+
+This story touches all 6 handlers and all 6 test files. Work through one handler+test pair at a time, running tests after each pair to catch regressions early.
+
+**Recommended order:**
+1. `saves/handler.ts` + test (most complex — local definitions, 409 helper, toPublicSave)
+2. `saves-update/handler.ts` + test (AppError + response wrapping changes)
+3. `saves-restore/handler.ts` + test (mirrors update pattern)
+4. `saves-delete/handler.ts` + test (AppError change only, no response wrapping change)
+5. `saves-get/handler.test.ts` (test-only — handler already clean; adds assertADR008Error)
+6. `saves-list/handler.test.ts` (test-only — handler already clean; factory migration)
+
+### Behavioral change: `toPublicSave` in `saves/handler.ts`
+
+The only intentional behavioral change in this story is AC2: the shared `toPublicSave` strips `deletedAt`, while the local version does not. This means the 409 `existingSave` object will no longer include `deletedAt` if it was somehow present. This is the CORRECT behavior — `deletedAt` is an internal field that should never be exposed in API responses.
+
+Add a test to `saves/handler.test.ts` that explicitly verifies `deletedAt` is NOT in the 409 response body.
+
+### Response wrapping equivalence
+
+`wrapHandler` at line ~214 of `backend/shared/middleware/src/wrapper.ts` detects when a handler returns a plain object (no `statusCode`) and auto-wraps it with `createSuccessResponse(result, requestId)`. This means:
+- Handler returns `toPublicSave(updated)` → wrapHandler returns `{ statusCode: 200, headers: {...}, body: JSON.stringify({ data: toPublicSave(updated) }) }`
+- Handler returns `createSuccessResponse(toPublicSave(updated), requestId)` → wrapHandler returns this directly (it has `statusCode`)
+
+The output is identical. Existing tests validate the response shape and will catch any divergence.
+
+### `vi.mock()` migration strategy
+
+When migrating from inline mocks to `mockDbModule()`, be careful about mock function references. If a test file does:
+
+```typescript
+const mockUpdateItem = vi.fn();
+vi.mock("@ai-learning-hub/db", () => ({
+  updateItem: (...args) => mockUpdateItem(...args),
+  // ...
+}));
+```
+
+And you want to use `mockDbModule()`, you need to ensure the test file still has a reference to `mockUpdateItem` for assertion purposes. Two approaches:
+
+**Approach A — pass mocks in:**
+```typescript
+const mockUpdateItem = vi.fn();
+vi.mock("@ai-learning-hub/db", () => mockDbModule({ updateItem: (...args) => mockUpdateItem(...args) }));
+```
+
+**Approach B — use vi.mocked():**
+```typescript
+vi.mock("@ai-learning-hub/db", () => mockDbModule());
+import { updateItem } from "@ai-learning-hub/db";
+const mockUpdateItem = vi.mocked(updateItem);
+```
+
+Approach A is recommended for consistency with the existing codebase patterns.
+
+## Architecture Compliance
+
+| ADR / NFR           | How This Story Must Comply                                                          |
+| ------------------- | ----------------------------------------------------------------------------------- |
+| **NFR-M1 (DRY)**   | Primary purpose — remove all remaining duplication                                   |
+| **ADR-008**         | No changes to error response format; `assertADR008Error` validates conformance       |
+| **Shared libs**     | All handlers must import from `@ai-learning-hub/*`; no local copies                  |
+
+## Testing Requirements
+
+### Modified tests must pass
+
+All 6 test files are modified. Every test must continue to pass. No new test cases are needed except AC2 (verify `deletedAt` stripping in 409).
+
+### Quality gates
+
+- `npm test`
+- `npm run lint`
+- `npm run type-check`
+
+## Previous Story Intelligence
+
+### From Story 3.1.1
+
+- `saveIdPathSchema` now in `@ai-learning-hub/validation` — handlers already import it
+- `SAVES_WRITE_RATE_LIMIT` now in `@ai-learning-hub/db` — handlers already import it
+- `requireEventBus()` now in `@ai-learning-hub/events` — handlers already import it
+
+### From Story 3.1.2
+
+- `createTestSaveItem`, `VALID_SAVE_ID` available from `backend/test-utils/save-factories`
+- `mockEventsModule()` available from `backend/test-utils/mock-events`
+- `mockDbModule()` available from `backend/test-utils/mock-db`
+- `saves-get/handler.test.ts` already migrated as proof-of-concept
+
+## File Structure Requirements
+
+### Modify
+
+- `backend/functions/saves/handler.ts` — retrofit to shared packages
+- `backend/functions/saves/handler.test.ts` — migrate to shared utilities + add deletedAt test
+- `backend/functions/saves-get/handler.test.ts` — add assertADR008Error usage
+- `backend/functions/saves-list/handler.test.ts` — migrate factory to shared
+- `backend/functions/saves-update/handler.ts` — AppError + response wrapping
+- `backend/functions/saves-update/handler.test.ts` — migrate to shared utilities
+- `backend/functions/saves-delete/handler.ts` — AppError standardization
+- `backend/functions/saves-delete/handler.test.ts` — migrate to shared utilities
+- `backend/functions/saves-restore/handler.ts` — AppError + response wrapping
+- `backend/functions/saves-restore/handler.test.ts` — migrate to shared utilities
+
+## Dev Agent Record
+
+### Agent Model Used
+
+{{agent_model_name_version}}
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/3-1-4-dedup-scan-agent-pipeline.md
+++ b/_bmad-output/implementation-artifacts/3-1-4-dedup-scan-agent-pipeline.md
@@ -1,0 +1,239 @@
+---
+id: "3.1.4"
+title: "Deduplication Scan Agent & Pipeline Integration"
+status: ready-for-dev
+depends_on:
+  - 3-1-3-handler-test-consolidation
+touches:
+  - .claude/agents/epic-dedup-scanner.md (new)
+  - .claude/agents/epic-dedup-fixer.md (new)
+  - .claude/skills/epic-orchestrator/dedup-scan-loop.md (new)
+  - .claude/skills/epic-orchestrator/SKILL.md
+risk: medium
+---
+
+# Story 3.1.4: Deduplication Scan Agent & Pipeline Integration
+
+Status: ready-for-dev
+
+## Story
+
+As the epic orchestrator,
+I want a deduplication scan step in the pipeline that catches cross-handler code duplication before code reaches the adversarial reviewer,
+so that DRY violations are caught and fixed automatically, and the reviewer can focus on correctness and security.
+
+## Acceptance Criteria
+
+| #   | Given                                    | When                                                                                       | Then                                                                                                                                                                                                                                                                      |
+| --- | ---------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC1 | New agent definition created             | `.claude/agents/epic-dedup-scanner.md` exists                                              | Agent has read-only tools (Read, Glob, Grep, Bash, Write), fresh context, scoped to cross-handler duplication detection                                                                                                                                                   |
+| AC2 | New fixer agent created                  | `.claude/agents/epic-dedup-fixer.md` exists                                                | Agent has full edit tools (Read, Glob, Grep, Bash, Write, Edit), guided by dedup findings document                                                                                                                                                                        |
+| AC3 | Orchestrator pipeline updated            | Step 2.3b "Dedup Scan Loop" added between quality gates (2.2) and adversarial review (2.4) | Dedup scan runs with max 2 rounds; gate requires 0 Important+ findings before proceeding to reviewer                                                                                                                                                                      |
+| AC4 | Supporting protocol doc created          | `.claude/skills/epic-orchestrator/dedup-scan-loop.md` exists                               | Documents the 2-round loop, scanner prompt template, fixer prompt template, gate criteria, escalation path, and dry-run behavior                                                                                                                                          |
+| AC5 | Scanner checks for specific patterns     | When scanner runs                                                                          | It reads ALL handler files in the same domain (e.g., all `backend/functions/saves-*/handler.ts`), not just the branch diff, and flags: duplicate schema definitions, duplicate constants, duplicate helper functions, code that exists in shared packages but is defined locally |
+| AC6 | Scanner output follows structured format | When scanner writes findings                                                               | Output uses `Critical/Important/Minor` format identical to the reviewer's findings format so the orchestrator parses it the same way                                                                                                                                      |
+| AC7 | Pipeline gate enforced                   | When dedup scan has Important+ findings after 2 rounds                                     | Orchestrator escalates to human with same option set as reviewer round 3 escalation (fix manually / accept / override limit)                                                                                                                                              |
+| AC8 | Reviewer remains unchanged               | After pipeline integration                                                                 | `epic-reviewer.md` agent definition is NOT modified; reviewer continues to operate on branch diff with fresh context                                                                                                                                                      |
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Create `epic-dedup-scanner` agent definition (AC: #1, #5, #6)
+  - [ ] 1.1 Create `.claude/agents/epic-dedup-scanner.md`
+  - [ ] 1.2 Agent frontmatter: name, description, tools (Read, Glob, Grep, Bash, Write), disallowedTools (Edit, Task)
+  - [ ] 1.3 Define scanner methodology:
+    - Receive domain pattern, branch name, base branch, story file, output path
+    - Discover all handler files in the domain (e.g., glob `backend/functions/saves*/handler.ts`)
+    - Read ALL handler files (not just diff) to compare cross-handler patterns
+    - Read shared package exports (`@ai-learning-hub/validation`, `db`, `events`, `types`, `logging`, `middleware`) to check what's already centralized
+    - Flag: local definitions that duplicate shared exports, identical code blocks across handlers, constants that should be shared
+    - **Bash is read-only/analysis-only** (e.g., grep, diff, npm run type-check). Do not run commands that modify the repo, mutate state, or push.
+  - [ ] 1.4 Define severity categories:
+    - **Critical:** Local copy of shared export with semantic divergence (e.g., `toPublicSave` that behaves differently from shared version)
+    - **Important:** Identical code block in 2+ handlers that should be in a shared package; local schema/constant that already exists in shared package
+    - **Minor:** Similar (not identical) patterns across handlers; style inconsistencies
+  - [ ] 1.5 Define output format: same markdown structure as `epic-reviewer.md` findings (Story ID, Round, Critical/Important/Minor sections, Summary with counts and recommendation)
+
+- [ ] Task 2: Create `epic-dedup-fixer` agent definition (AC: #2)
+  - [ ] 2.1 Create `.claude/agents/epic-dedup-fixer.md`
+  - [ ] 2.2 Agent frontmatter: name, description, tools (Read, Glob, Grep, Bash, Write, Edit), disallowedTools (Task)
+  - [ ] 2.3 Define fixer methodology:
+    - Read findings document
+    - For Important+: extract duplicated code to appropriate shared package, update all handler imports, run tests
+    - For duplicate schemas: move to `@ai-learning-hub/validation`
+    - For duplicate constants: move to `@ai-learning-hub/db` or `@ai-learning-hub/events`
+    - For duplicate helpers: prefer existing shared packages by domain (DynamoDB helpers → `@ai-learning-hub/db`, event helpers → `@ai-learning-hub/events`, validation helpers → `@ai-learning-hub/validation`). If no clear home exists, document in the findings and leave for human decision rather than creating a new package.
+    - Stage and commit fixes. **Commit only on current branch. Do NOT push. Do NOT switch branches.** Same branch locality rules as the review-loop fixer.
+    - Report which findings were addressed
+
+- [ ] Task 3: Create pipeline protocol document (AC: #4)
+  - [ ] 3.1 Create `.claude/skills/epic-orchestrator/dedup-scan-loop.md`
+  - [ ] 3.2 Document protocol overview:
+    - Max rounds: 2 (scan → fix → scan → gate)
+    - Clean state: 0 MUST-FIX findings (Critical + Important)
+    - Exit conditions: clean state OR max rounds exceeded
+  - [ ] 3.3 Document Step A: Spawn scanner subagent
+    - Task tool with `subagent_type: "epic-dedup-scanner"`
+    - Prompt template including: story ID, domain pattern, branch, base branch, story file path, round, output path
+    - Domain pattern derivation from `story.touches` (e.g., touches `backend/functions/saves-update/*` → domain = `backend/functions/saves*/handler.ts`)
+    - **Skip rule:** If `touches` contains no paths under `backend/functions/`, skip the dedup scan loop entirely (proceed directly to 2.4). Stories that only touch shared packages have no handler domain to scan.
+    - **Single primary domain:** If `touches` includes handlers from multiple disjoint domains (e.g., both `saves*` and `auth*`), derive the primary domain from the domain with the most touched files. Do not scan across unrelated domains.
+  - [ ] 3.4 Document Step B: Decision point
+    - Same MUST-FIX counting as review-loop.md
+    - Same decision matrix (0 findings → proceed, >0 and round <2 → fix, >0 and round ==2 → escalate)
+  - [ ] 3.5 Document Step C: Spawn fixer subagent
+    - Task tool with `subagent_type: "epic-dedup-fixer"`
+    - Prompt template including: story ID, domain pattern, branch, findings path, round, story file
+  - [ ] 3.6 Document Step D: Loop back (same as review-loop.md)
+  - [ ] 3.7 Document escalation (same format as review-loop.md round 3). Options: (a) fix manually, (b) accept and mark complete, (c) override — allow one additional dedup round. **Hard cap: 3 dedup rounds total** — after round 3, only options (a) or (b) are available.
+  - [ ] 3.8 Document dry-run behavior: skip subagent spawning, log dry-run messages
+
+- [ ] Task 4: Update orchestrator SKILL.md (AC: #3, #7)
+  - [ ] 4.1 Add new section `### 2.3b Dedup Scan Loop` between existing `### 2.3 Mark for Review` and `### 2.4 Code Review Loop`
+  - [ ] 4.2 Content of the new section:
+    ```markdown
+    ### 2.3b Dedup Scan Loop
+
+    **Read `dedup-scan-loop.md` in this skill directory for the full protocol.**
+
+    The dedup scan loop detects cross-handler code duplication BEFORE the adversarial review.
+    Unlike the reviewer (which diffs the branch), the scanner reads ALL handler files in the
+    same domain to compare patterns.
+
+    Summary of the loop:
+
+    1. **Derive domain pattern** from `story.touches` (e.g., `backend/functions/saves*/handler.ts`)
+    2. **Spawn `epic-dedup-scanner` subagent** (Task tool, `subagent_type: "epic-dedup-scanner"`) — fresh context, writes findings doc
+    3. **Read findings doc**, count MUST-FIX items (Critical + Important)
+    4. **If clean (0 MUST-FIX):** Exit loop, proceed to 2.4 (Code Review Loop)
+    5. **If not clean AND round < 2:** Spawn `epic-dedup-fixer` subagent — reads findings, extracts to shared, commits locally
+    6. **If not clean AND round == 2:** Escalate to human (same options as reviewer escalation)
+    7. Loop back to step 2 with fresh scanner
+
+    **In `--dry-run` mode:** Skip subagent spawning, log dry-run messages, proceed directly to 2.4.
+    ```
+  - [ ] 4.3 Update the Phase 2 section overview to mention the new step in the pipeline flow
+  - [ ] 4.4 Ensure step numbering is consistent (2.1 → 2.2 → 2.3 → 2.3b → 2.4 → 2.5 → 2.6 → 2.7)
+
+- [ ] Task 5: Verify reviewer is unchanged and update agent registry (AC: #8)
+  - [ ] 5.1 Confirm `.claude/agents/epic-reviewer.md` has no modifications
+  - [ ] 5.2 Confirm review-loop.md has no modifications
+  - [ ] 5.3 Update `.claude/agents/README.md`: add rows for `epic-dedup-scanner` and `epic-dedup-fixer` in the Current Subagents table (file, purpose, tools, spawned by)
+
+## Dev Notes
+
+### Domain pattern derivation
+
+The orchestrator derives the "domain" for the dedup scan from the story's `touches` field. Algorithm:
+
+1. Extract handler directory paths from `touches` (e.g., `backend/functions/saves-update/handler.ts` → `backend/functions/saves-update`)
+2. **If no paths under `backend/functions/` exist in `touches`, skip the dedup scan loop entirely** (proceed directly to 2.4). Stories that only touch shared packages have no handler domain to scan.
+3. Find common prefix: `backend/functions/saves` (strip the handler-specific suffix like `-update`, `-delete`)
+4. If `touches` includes handlers from multiple disjoint domains (e.g., both `saves*` and `auth*`), use the domain with the most touched files as the primary domain. Do not scan across unrelated handler domains.
+5. Build glob pattern: `backend/functions/saves*/handler.ts`
+6. Also include shared packages: `backend/shared/*/src/**/*.ts`
+
+For non-saves domains in future epics, the same logic applies: `backend/functions/auth*/handler.ts`, `backend/functions/projects*/handler.ts`, etc.
+
+### Findings output path convention
+
+Dedup scan findings go to a different path than reviewer findings to avoid confusion:
+
+- Dedup findings: `.claude/dedup-findings-{story.id}-round-{round}.md`
+- Review findings: `.claude/review-findings-{story.id}-round-{round}.md`
+
+### Relationship to existing pipeline
+
+```
+Quality Gates (2.2) → Mark for Review (2.3) → Dedup Scan (2.3b) → Code Review (2.4) → Commit & PR (2.5)
+                                                ↕                       ↕
+                                          epic-dedup-scanner       epic-reviewer
+                                          epic-dedup-fixer         epic-fixer
+                                            max 2 rounds             max 3 rounds
+```
+
+The dedup scan catches DRY/structural issues. The reviewer catches correctness/security/test issues. Neither overlaps with the other.
+
+### What the scanner SHOULD flag vs SHOULD NOT
+
+**Flag (Important):**
+- A Zod schema defined in a handler that already exists in `@ai-learning-hub/validation`
+- A constant defined locally that matches one in `@ai-learning-hub/db` or `@ai-learning-hub/events`
+- Identical 5+ line code blocks appearing in 2+ handlers
+- A function defined locally that has an equivalent in a shared package
+
+**Flag (Minor):**
+- Similar but not identical patterns (e.g., same structure, different variable names)
+- Missing `AppError.isAppError()` usage (style issue)
+- Response wrapping inconsistency
+
+**Do NOT flag:**
+- Handler-specific business logic that is unique to each handler
+- Different DynamoDB condition expressions (these are intentionally different per handler)
+- Test files (the scanner focuses on production code; test dedup is handled by Story 3.1.2/3.1.3)
+
+### Testing this story
+
+This story creates documentation and agent definitions — it does NOT create executable code. Testing is manual:
+- Verify agent files parse correctly (valid YAML frontmatter)
+- Verify SKILL.md edits are consistent with existing structure
+- Verify dedup-scan-loop.md follows the same format as review-loop.md
+
+## Architecture Compliance
+
+| ADR / NFR         | How This Story Must Comply                                                      |
+| ----------------- | ------------------------------------------------------------------------------- |
+| **NFR-M1 (DRY)** | This story CREATES the automated enforcement mechanism for DRY                   |
+| **Safety**        | New agents must not modify reviewer or existing agent definitions                |
+| **Pipeline**      | New step must integrate cleanly without disrupting existing review/fix loop      |
+
+## Testing Requirements
+
+### No automated tests
+
+This story creates agent definitions and documentation. There is no production code to test. Validation is structural:
+- Agent `.md` files have valid YAML frontmatter
+- SKILL.md edits maintain valid markdown structure
+- Protocol doc follows established format (compare to review-loop.md)
+
+### Quality gates
+
+- `npm run lint` — unchanged (no source code modified)
+- `npm run type-check` — unchanged
+- Manual review of all 4 new/modified files
+
+## Previous Story Intelligence
+
+### From Stories 3.1.1–3.1.3
+
+- After those stories complete, the saves domain will be DRY. The dedup scanner would report 0 findings on the current codebase.
+- The scanner's value is PREVENTIVE — it catches NEW duplication introduced by future stories.
+
+### From review-loop.md
+
+- The dedup-scan-loop.md should follow the exact same structure: Protocol Overview, Step A (spawn scanner), Step B (decision point), Step C (spawn fixer), Step D (loop back), Dry Run Behavior.
+- Same finding severity definitions: MUST-FIX (Critical + Important), NICE-TO-HAVE (Minor).
+
+## File Structure Requirements
+
+### New
+
+- `.claude/agents/epic-dedup-scanner.md` — dedup scanner agent definition
+- `.claude/agents/epic-dedup-fixer.md` — dedup fixer agent definition
+- `.claude/skills/epic-orchestrator/dedup-scan-loop.md` — protocol document
+
+### Modify
+
+- `.claude/skills/epic-orchestrator/SKILL.md` — add Step 2.3b
+- `.claude/agents/README.md` — add epic-dedup-scanner and epic-dedup-fixer to agent registry
+
+## Dev Agent Record
+
+### Agent Model Used
+
+{{agent_model_name_version}}
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/3-3-update-delete-restore-api.md
+++ b/_bmad-output/implementation-artifacts/3-3-update-delete-restore-api.md
@@ -1,0 +1,376 @@
+---
+id: "3.3"
+title: "Update, Delete & Restore Saves API"
+status: ready-for-dev
+depends_on:
+  - 3-1b-create-save-api
+  - 3-2-list-get-saves-api
+touches:
+  - backend/functions/saves-update/handler.ts (new)
+  - backend/functions/saves-delete/handler.ts (new)
+  - backend/functions/saves-restore/handler.ts (new)
+  - backend/shared/events/src/events/saves.ts
+  - infra/lib/stacks/api/saves-routes.stack.ts
+  - infra/config/route-registry.ts
+risk: medium
+---
+
+# Story 3.3: Update, Delete & Restore Saves API
+
+Status: ready-for-dev
+
+## Story
+
+As a user,  
+I want to edit save metadata, delete saves I no longer need, and undo accidental deletes,  
+so that I can keep my library organized and recover from mistakes.
+
+## Acceptance Criteria
+
+| #    | Given                                | When                                                                           | Then                                                                                                                                                                                                                                                          |
+| ---- | ------------------------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC1  | User authenticated, save exists      | `PATCH /saves/:saveId` with body `{ title?, userNotes?, contentType?, tags? }` | Updates specified fields + sets `updatedAt`; returns updated save; omitted fields unchanged                                                                                                                                                                   |
+| AC2  | Save updated successfully            | After DynamoDB write                                                           | EventBridge event emitted: `detailType: 'SaveUpdated'`, detail includes updated fields + `userId`, `saveId`, `urlHash`, `normalizedUrl`                                                                                                                     |
+| AC3  | User authenticated, save exists      | `DELETE /saves/:saveId`                                                        | Sets `deletedAt` = ISO 8601 timestamp (soft delete); returns 204 No Content                                                                                                                                                                                   |
+| AC4  | Save soft-deleted                    | After DynamoDB write                                                           | EventBridge event emitted: `detailType: 'SaveDeleted'`, detail includes `userId`, `saveId`, `urlHash`, `normalizedUrl`                                                                                                                                        |
+| AC5  | Save does not exist, is deleted, or wrong user | `PATCH /saves/:saveId`                                                         | Returns 404 `{ error: { code: 'NOT_FOUND', message: 'Save not found', requestId } }`. **Handler must not allow** db helper message `"Item not found"` to surface (catch-and-rethrow `AppError(ErrorCode.NOT_FOUND, 'Save not found')`). |
+| AC6  | Save does not exist or wrong user    | `DELETE /saves/:saveId`                                                        | Returns 404 `{ error: { code: 'NOT_FOUND', message: 'Save not found', requestId } }`. **Handler must throw** `new AppError(ErrorCode.NOT_FOUND, 'Save not found')` for this path (do not bubble `"Item not found"`). |
+| AC7  | Save already soft-deleted            | `PATCH /saves/:saveId`                                                         | Returns 404 (treat soft-deleted as not found for normal PATCH)                                                                                                                                                                                                |
+| AC8  | Save already soft-deleted            | `DELETE /saves/:saveId`                                                        | Returns 204 (idempotent — already deleted)                                                                                                                                                                                                                    |
+| AC9  | Invalid field values in PATCH body   | Validation                                                                     | Returns 400 `{ error: { code: 'VALIDATION_ERROR', message: '...', requestId } }` with field-level error details                                                                                                                                               |
+| AC10 | Save is soft-deleted (has deletedAt) | `POST /saves/:saveId/restore`                                                  | Clears `deletedAt` field; returns 200 with restored save. This endpoint bypasses the `attribute_not_exists(deletedAt)` guard.                                                                                                                                |
+| AC11 | Save is NOT soft-deleted             | `POST /saves/:saveId/restore`                                                  | Returns 200 with current save (idempotent — already active)                                                                                                                                                                                                   |
+| AC12 | Save does not exist or wrong user    | `POST /saves/:saveId/restore`                                                  | Returns 404 `{ error: { code: 'NOT_FOUND', message: 'Save not found', requestId } }`. **Handler must throw** `new AppError(ErrorCode.NOT_FOUND, 'Save not found')` for this path (do not bubble `"Item not found"`). |
+| AC13 | Save successfully restored           | After DynamoDB write                                                           | EventBridge event emitted: `detailType: 'SaveRestored'`, detail includes `userId`, `saveId`, `urlHash`, `normalizedUrl`. Downstream consumers should treat as re-activation (a `SaveDeleted` may be followed by a `SaveRestored` within seconds).                |
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Extend Saves domain event types in `@ai-learning-hub/events` (AC: #2, #4, #13)
+  - [ ] 1.1 Update `backend/shared/events/src/events/saves.ts`:
+    - Extend `SavesEventDetailType` to include `"SaveUpdated"` and `"SaveDeleted"`
+    - Implement event detail typing as a **discriminated union by `detailType`** so existing call sites keep compiling without payload changes
+    - Extend the detail typing to support:
+      - `SaveUpdated`: `{ userId, saveId, urlHash, normalizedUrl, updatedFields: string[] }`
+      - `SaveDeleted`: `{ userId, saveId, urlHash, normalizedUrl }`
+      - Keep `SaveCreated`/`SaveRestored` working without changes to call sites (current payload includes `url` and `contentType`; do not break it)
+    - Concrete requirement: `SaveCreated` and `SaveRestored` must continue to accept the current detail shape `{ userId, saveId, url, normalizedUrl, urlHash, contentType }` emitted by `backend/functions/saves/handler.ts`
+  - [ ] 1.2 Ensure `backend/functions/saves/handler.ts` compiles with the updated types
+  - [ ] 1.3 Add/update tests in `backend/shared/events/test/` if needed (at minimum: type-level compilation via existing test suite + runtime emitter tests unchanged)
+
+- [ ] Task 2: Create `saves-update` Lambda handler (PATCH) (AC: #1, #2, #5, #7, #9)
+  - [ ] 2.1 Create `backend/functions/saves-update/handler.ts` using `wrapHandler` + `HandlerContext`
+  - [ ] 2.2 Validate `saveId` path param (ULID regex) using `validatePathParams`
+  - [ ] 2.3 Validate JSON body using `validateJsonBody(updateSaveSchema, ...)`
+  - [ ] 2.4 Enforce write rate limit using `enforceRateLimit` with the same effective limit as `saves-create` (**200/hour per user**). Do not accidentally multiply the limit by choosing a distinct operation bucket per endpoint.
+  - [ ] 2.5 Use `updateItem` with `ConditionExpression: attribute_exists(PK) AND attribute_not_exists(deletedAt)`
+  - [ ] 2.5a Catch `AppError` with `ErrorCode.NOT_FOUND` from `updateItem` and throw `new AppError(ErrorCode.NOT_FOUND, "Save not found")` (do not return `"Item not found"`)
+  - [ ] 2.6 Return the updated save object (public shape)
+  - [ ] 2.7 Emit `SaveUpdated` via `emitEvent` with `updatedFields` list + `normalizedUrl` + `urlHash`
+
+- [ ] Task 3: Create `saves-delete` Lambda handler (DELETE) (AC: #3, #4, #6, #8)
+  - [ ] 3.1 Create `backend/functions/saves-delete/handler.ts`
+  - [ ] 3.2 Validate `saveId` path param (ULID regex)
+  - [ ] 3.3 Enforce write rate limit
+  - [ ] 3.4 Attempt conditional soft delete via `updateItem` with `ConditionExpression: attribute_exists(PK) AND attribute_not_exists(deletedAt)` setting `deletedAt` + `updatedAt`
+  - [ ] 3.5 Catch `AppError` with `ErrorCode.NOT_FOUND` from `updateItem`; in the catch block call `getItem` to disambiguate missing vs already deleted
+    - Missing → 404
+    - Already deleted → 204
+  - [ ] 3.5a When returning 404, throw `new AppError(ErrorCode.NOT_FOUND, "Save not found")`
+  - [ ] 3.6 Emit `SaveDeleted` only on active → deleted transition
+
+- [ ] Task 4: Create `saves-restore` Lambda handler (POST /restore) (AC: #10, #11, #12, #13)
+  - [ ] 4.1 Create `backend/functions/saves-restore/handler.ts`
+  - [ ] 4.2 Validate `saveId` path param (ULID regex)
+  - [ ] 4.3 Enforce write rate limit
+  - [ ] 4.4 Attempt conditional restore update via `updateItem` with `ConditionExpression: attribute_exists(PK) AND attribute_exists(deletedAt)` removing `deletedAt` and setting `updatedAt`
+  - [ ] 4.5 Catch `AppError` with `ErrorCode.NOT_FOUND` from `updateItem`; in the catch block call `getItem` to disambiguate missing vs already active
+    - Missing → 404
+    - Already active → 200 with current save (no event)
+  - [ ] 4.5a When returning 404, throw `new AppError(ErrorCode.NOT_FOUND, "Save not found")`
+  - [ ] 4.6 Emit `SaveRestored` only on deleted → active transition
+
+- [ ] Task 5: Extend `SavesRoutesStack` (infra wiring) (AC: all)
+  - [ ] 5.1 In `infra/lib/stacks/api/saves-routes.stack.ts`, add:
+    - `public readonly savesUpdateFunction`
+    - `public readonly savesDeleteFunction`
+    - `public readonly savesRestoreFunction`
+  - [ ] 5.2 Create three `NodejsFunction`s with env vars: `SAVES_TABLE_NAME`, `USERS_TABLE_NAME`, `EVENT_BUS_NAME`
+  - [ ] 5.3 IAM: grant `savesTable.grantReadWriteData()` + `usersTable.grantReadWriteData()`; allow `events:PutEvents` on the bus
+  - [ ] 5.4 Wire API Gateway resources/methods under `/saves`:
+    - `/saves/{saveId}`: `PATCH`, `DELETE`
+    - `/saves/{saveId}/restore`: `POST`
+
+- [ ] Task 6: Update route registry (architecture enforcement) (AC: all)
+  - [ ] 6.1 Update `infra/config/route-registry.ts` `HandlerRef` union to include:
+    - `savesUpdateFunction`, `savesDeleteFunction`, `savesRestoreFunction`
+  - [ ] 6.2 Add the 3 routes to `ROUTE_REGISTRY` with `authType: 'jwt-or-apikey'` and `epic: 'Epic-3'`
+
+- [ ] Task 7: Tests + repo quality gates
+  - [ ] 7.1 Add handler tests for update/delete/restore, including idempotency + event emission assertions
+  - [ ] 7.2 Ensure architecture enforcement tests still pass
+  - [ ] 7.3 Run `npm test`, `npm run lint`, `npm run build`, `npm run type-check`, `npm run format`
+
+## Developer Context (Read First)
+
+- **Do not reinvent shared modules**:
+  - **Validation**: use `updateSaveSchema` + `validateJsonBody` from `@ai-learning-hub/validation` (already exists).
+  - **DynamoDB**: use `getDefaultClient`, `getItem`, `updateItem`, `queryItems` from `@ai-learning-hub/db` (no raw AWS SDK in handlers).
+  - **Events**: emit domain events using `emitEvent` + `SAVES_EVENT_SOURCE` from `@ai-learning-hub/events` (fire-and-forget, non-fatal).
+- **URL immutability**: `url`, `normalizedUrl`, and `urlHash` are **immutable** after creation (do not allow updates via PATCH).
+- **PATCH empty body is invalid**: `updateSaveSchema` requires at least one of `title`, `userNotes`, `contentType`, `tags`. `{}` must return 400 `VALIDATION_ERROR`.
+- **Soft delete semantics**:
+  - `DELETE` sets `deletedAt` (ISO string) and should be **idempotent** (already deleted ⇒ 204, no error).
+  - `restore` clears `deletedAt` and should be **idempotent** (already active ⇒ 200 with current item).
+- **Per-user isolation**: all reads/writes must be scoped to `PK=USER#<userId>` so “wrong user” behaves like “not found” (404, never 403).
+- **404 message must match ACs**: any 404 for a save must return `message: "Save not found"` (do not let `@ai-learning-hub/db` propagate `"Item not found"`).
+- **Rate limiting**: treat update/delete/restore as save **write** operations. Use the same effective limit as create (**200/hour per user**) and do not accidentally multiply it by using separate operation buckets per endpoint.
+- **Event ordering reality**: a `SaveDeleted` can be followed quickly by `SaveRestored` (undo window). Downstream consumers must already be idempotent; do not add delays/queues in this story.
+
+## Technical Requirements
+
+### Endpoint: `PATCH /saves/{saveId}` (Update metadata)
+
+- **Auth**: `jwt-or-apikey`, require scope `saves:write`.
+- **Path validation**: validate `saveId` as ULID (`/^[0-9A-Z]{26}$/`), using `validatePathParams`.
+- **Body validation**: `validateJsonBody(updateSaveSchema, event.body)` (schema already exists in `@ai-learning-hub/validation`).
+- **Update rules**:
+  - Only fields present in the request body are updated (`title`, `userNotes`, `contentType`, `tags`).
+  - Always set `updatedAt = now()`.
+  - Do **not** touch `url`, `normalizedUrl`, `urlHash`, `createdAt`, `linkedProjectCount`, `isTutorial`.
+- **Conditional write**: `ConditionExpression: attribute_exists(PK) AND attribute_not_exists(deletedAt)` (deleted items behave like 404).
+- **Response**: 200 with the **updated** save (same public shape as `POST /saves` / `GET /saves/:saveId`; never include `PK`, `SK`, `deletedAt`).
+- **404 behavior (AC5/AC7)**: `updateItem` throws `AppError(ErrorCode.NOT_FOUND, "Item not found")` on conditional failure. The handler must catch that path and throw `new AppError(ErrorCode.NOT_FOUND, "Save not found")` to satisfy the AC message.
+- **Events (AC2)**:
+  - Emit `SaveUpdated` after successful update.
+  - Detail MUST include `userId`, `saveId`, `urlHash`, `normalizedUrl`, and an explicit list of updated fields (names).
+
+### Endpoint: `DELETE /saves/{saveId}` (Soft delete)
+
+- **Auth**: `jwt-or-apikey`, require scope `saves:write`.
+- **Path validation**: same ULID validation as PATCH.
+- **Delete rules**:
+  - Soft delete by setting `deletedAt = now()` and `updatedAt = now()`.
+  - Do **not** delete the item or the `URL#<urlHash>` uniqueness marker (marker is never removed; see Story 3.1b).
+- **Idempotency requirements**:
+  - If item exists and is active → perform the update, return 204, emit `SaveDeleted`.
+  - If item exists but already deleted → return 204 **without** changing timestamps and **do not** emit another delete event (do not perform any write in this case).
+  - If item does not exist → return 404.
+  - Implementation hint (required control flow): do a conditional `updateItem` and catch `AppError` with `ErrorCode.NOT_FOUND`; in the catch block, call `getItem` to distinguish “missing” vs “already deleted”.
+  - **404 message (AC6)**: when returning 404, throw `new AppError(ErrorCode.NOT_FOUND, "Save not found")`.
+- **Performance hint**: for the delete update, pass `returnValues: "NONE"` to `updateItem` (204 response does not need attributes).
+- **Events (AC4)**:
+  - Emit `SaveDeleted` only when transitioning active → deleted.
+  - Detail MUST include `userId`, `saveId`, `urlHash`, `normalizedUrl`.
+
+### Endpoint: `POST /saves/{saveId}/restore` (Undo delete)
+
+- **Auth**: `jwt-or-apikey`, require scope `saves:write`.
+- **Path validation**: same ULID validation as PATCH/DELETE.
+- **Restore rules**:
+  - If item has `deletedAt` → clear it (`UpdateExpression: REMOVE deletedAt SET updatedAt = :now`), return 200 updated save, emit `SaveRestored`.
+  - If item exists and is already active → return 200 with current item (no-op), do not emit `SaveRestored`.
+  - If item does not exist → return 404.
+  - Implementation hint (required control flow): do a conditional restore `updateItem` and catch `AppError` with `ErrorCode.NOT_FOUND`; in the catch block, call `getItem` to disambiguate “already active” vs “missing”.
+  - **404 message (AC12)**: when returning 404, throw `new AppError(ErrorCode.NOT_FOUND, "Save not found")`.
+- **Events (AC13)**:
+  - Emit `SaveRestored` only when transitioning deleted → active.
+  - Detail MUST include `userId`, `saveId`, `urlHash`, `normalizedUrl`, and should also include `url` and `contentType` to remain consistent with the existing `SaveRestored` payload emitted in Story 3.1b.
+
+### Error handling & response shape (ADR-008)
+
+- Validation failures: 400 with `{ error: { code: 'VALIDATION_ERROR', message, requestId } }` (field-level details from shared middleware/validation helpers).
+- Not found (missing or wrong user, or deleted where applicable): 404 with `{ error: { code: 'NOT_FOUND', message: 'Save not found', requestId } }`.
+- **Non-negotiable**: on all 404 paths in this story, throw `new AppError(ErrorCode.NOT_FOUND, "Save not found")` from the handler layer. Do not allow `@ai-learning-hub/db`’s default NOT_FOUND message (`"Item not found"`) to become the response message.
+- Successful delete: 204 with empty body.
+
+## Architecture Compliance
+
+| ADR / NFR | How This Story Must Comply |
+|---|---|
+| **ADR-001 (DynamoDB key patterns)** | Saves are stored as `PK=USER#<userId>`, `SK=SAVE#<saveId>`. No cross-user access; wrong-user looks like missing. |
+| **ADR-003 (EventBridge)** | Emit domain events (`SaveUpdated`, `SaveDeleted`, `SaveRestored`) via the shared `@ai-learning-hub/events` emitter. Events are **non-fatal** and must not block API responses. |
+| **ADR-005 (No Lambda-to-Lambda)** | No direct Lambda invocations. Only DynamoDB + EventBridge interactions. |
+| **ADR-008 (Standardized errors)** | All errors must be raised as `AppError`/`ErrorCode` (or handler returns the ADR-008 shape) and wrapped by shared middleware. |
+| **ADR-014 (API-first)** | Endpoints must be consistent with existing REST conventions: PATCH for partial update, DELETE for soft delete, POST for restore action. |
+| **NFR-S4 (Per-user isolation)** | Enforced by PK scoping + 404-not-403 behavior. |
+| **NFR-P2 (Warm perf)** | Avoid extra reads on the happy path. Use `UpdateItem` with return values to avoid “read-before-write” where possible. |
+
+## Library / Framework Requirements
+
+### Required shared packages (do not bypass)
+
+- `@ai-learning-hub/middleware`
+  - `wrapHandler`, `createSuccessResponse`, `type HandlerContext`
+- `@ai-learning-hub/validation`
+  - `updateSaveSchema`, `validateJsonBody`, `validatePathParams`, `z` (for the path schema)
+- `@ai-learning-hub/db`
+  - `getDefaultClient`, `getItem`, `updateItem`, `enforceRateLimit`, `USERS_TABLE_CONFIG`, `requireEnv`, `type TableConfig`
+- `@ai-learning-hub/types`
+  - `AppError`, `ErrorCode`, and the `ContentType` enum (for typing only; validation comes from `contentTypeSchema`)
+- `@ai-learning-hub/events`
+  - `emitEvent`, `getDefaultClient` (EventBridge), `SAVES_EVENT_SOURCE`, and typed saves event detail types
+
+### Version notes (do not “upgrade in story”)
+
+- Workspace uses **Node.js \(>=20\)** (root `package.json`).
+- Validation currently depends on **Zod `^3.22.0`** (`backend/shared/validation/package.json`). Zod v4 exists, but do **not** upgrade as part of Story 3.3 unless explicitly planned.
+- Tests use **Vitest `^3.2.4`** across workspaces.
+
+## File Structure Requirements
+
+### New Lambda handlers (Lambda-per-concern)
+
+Create exactly these directories (one handler each):
+
+- `backend/functions/saves-update/handler.ts` — `PATCH /saves/{saveId}`
+- `backend/functions/saves-delete/handler.ts` — `DELETE /saves/{saveId}`
+- `backend/functions/saves-restore/handler.ts` — `POST /saves/{saveId}/restore`
+
+Do **not** add these endpoints to `backend/functions/saves/handler.ts` (that file is for `POST /saves` from Story 3.1b).
+
+### Shared packages to modify
+
+- `backend/shared/events/src/events/saves.ts`
+  - Extend `SavesEventDetailType` to include `SaveUpdated` and `SaveDeleted`.
+  - Extend the detail typing to support the new event shapes without breaking existing `SaveCreated`/`SaveRestored` usage.
+
+### Infra to modify
+
+- `infra/lib/stacks/api/saves-routes.stack.ts`
+  - Add three `NodejsFunction`s for update/delete/restore.
+  - Wire API Gateway resources:
+    - `/saves/{saveId}`: `PATCH` + `DELETE`
+    - `/saves/{saveId}/restore`: `POST`
+  - Ensure CORS preflight exists on the existing `/saves/{saveId}` resource (it should already exist from Story 3.2).
+  - Add CORS preflight on the new `/saves/{saveId}/restore` resource.
+  - Grant IAM: `savesTable.grantReadWriteData()` and `usersTable.grantReadWriteData()` for rate limiting + writes; plus `events:PutEvents` on the event bus ARN.
+- `infra/config/route-registry.ts`
+  - Extend `HandlerRef` with `savesUpdateFunction`, `savesDeleteFunction`, `savesRestoreFunction`.
+  - Add three route entries (Epic-3) matching the CDK wiring.
+
+## Testing Requirements
+
+### Handler tests (Vitest)
+
+Add tests alongside each handler (same folder) following the existing patterns from:
+- `backend/functions/saves/handler.test.ts` (Story 3.1b)
+- `backend/functions/saves-get/handler.test.ts` / `backend/functions/saves-list/handler.test.ts` (Story 3.2, once implemented)
+
+Required test scenarios:
+
+- **PATCH /saves/{saveId}**
+  - 200 updates only provided fields; omitted fields unchanged; `updatedAt` changes.
+  - 400 invalid `saveId` format.
+  - 400 invalid body (e.g., title too long; tags > 20; empty strings) → `VALIDATION_ERROR`.
+  - 404 missing save or wrong user.
+  - 404 soft-deleted save.
+  - Emits `SaveUpdated` with correct `updatedFields` list and includes `normalizedUrl` + `urlHash`.
+
+- **DELETE /saves/{saveId}**
+  - 204 on first delete (active → deleted); `deletedAt` set; emits `SaveDeleted`.
+  - 204 on second delete (already deleted) and does **not** emit a second event.
+  - 404 when save truly does not exist (after disambiguation) or belongs to another user.
+
+- **POST /saves/{saveId}/restore**
+  - 200 restores when deleted (`deletedAt` removed); emits `SaveRestored`.
+  - 200 no-op when already active; does not emit `SaveRestored`.
+  - 404 missing save or belongs to another user.
+
+### Event typing tests / sanity
+
+When updating `@ai-learning-hub/events` saves event types, ensure:
+- Existing Story 3.1b handler still compiles and its tests still pass.
+- New handlers can emit the new event types without type casts.
+
+### Quality gates (must be green before implementation PR)
+
+- `npm test`
+- `npm run lint`
+- `npm run build`
+- `npm run type-check`
+- `npm run format`
+
+## Previous Story Intelligence (3.1b + 3.2)
+
+### From Story 3.1b (Create Save API)
+
+- **Event emission pattern** is already implemented and should be mirrored:
+  - `emitEvent(...)` is fire-and-forget and **must not** be awaited (see `backend/shared/events/src/emitter.ts`).
+  - Event source constant: `SAVES_EVENT_SOURCE` (do not repeat string literals).
+- **Config pattern**:
+  - Use `requireEnv()` from `@ai-learning-hub/db` for `SAVES_TABLE_NAME`/`USERS_TABLE_NAME` in handlers (avoid hardcoding).
+  - CDK sets env vars; handlers fail fast at cold start if missing (except tests).
+- **Rate limiting**:
+  - Write endpoints call `enforceRateLimit(...)` and therefore need `usersTable.grantReadWriteData()` in CDK.
+
+### From Story 3.2 (List & Get Saves API)
+
+- **Handler signature guardrail**: every Lambda handler is `async (ctx: HandlerContext) => ...` and exported via `wrapHandler(...)`.
+- **Save ID validation**: use a strict ULID regex for `saveId` path params.
+- **Public response shape**: never return internal DynamoDB keys (`PK`, `SK`) or `deletedAt`.
+
+## Git Intelligence Summary
+
+Recent commit subjects (most recent first) show the current patterns in-flight:
+
+- `feat: implement Story 3.1b — Create Save API (POST /saves) (#182)`
+- `Implement Story 3.1c: EventBridge Shared Package (@ai-learning-hub/events) (#177)`
+- `feat: foundations hardening — adversarial review remediation (Story 2.1-D9) (#175)`
+
+Implications for Story 3.3:
+
+- Extend the existing `SavesRoutesStack` (`infra/lib/stacks/api/saves-routes.stack.ts`) rather than creating a new stack.
+- Extend the route registry (`infra/config/route-registry.ts`) and keep it in sync with CDK to satisfy architecture enforcement tests.
+- Add new event detail types to `backend/shared/events/src/events/saves.ts` (it explicitly notes 3.3 will add `SaveUpdated`/`SaveDeleted`).
+
+## Latest Tech Information (Quick Notes)
+
+- **Zod**: Latest stable Zod is v4.x (as of early 2026), but this repo is pinned to `zod@^3.22.0` in `@ai-learning-hub/validation`. Do not upgrade Zod as part of Story 3.3.
+- **DynamoDB conditional writes**: failed `ConditionExpression` results in `ConditionalCheckFailedException` (AWS SDK v3). Treat this as an expected control-flow signal for:
+  - PATCH on deleted/missing → 404
+  - RESTORE on already-active/missing → disambiguate with `getItem`
+  - DELETE idempotency → disambiguate “already deleted” vs “missing” with `getItem`
+
+## Adversarial Review Fixes Applied
+
+- Any 404 for a save must return **`"Save not found"`** (not the db helper’s `"Item not found"`).
+- Conditional-update flows now explicitly require **catching** `AppError(ErrorCode.NOT_FOUND)` and then using `getItem` to disambiguate idempotent success vs missing.
+- Saves events typing is explicitly required to be a **discriminated union** to avoid breaking existing `SaveCreated` / `SaveRestored` call sites.
+
+## Project Context Reference
+
+- Story definition + ACs source of truth: `docs/progress/epic-3-stories-and-plan.md#Story-3.3`
+- Architecture constraints: `_bmad-output/planning-artifacts/architecture.md` (ADR-001/003/005/008/014/016)
+- Prior story context:
+  - `_bmad-output/implementation-artifacts/3-1b-create-save-api.md`
+  - `_bmad-output/implementation-artifacts/3-2-list-get-saves-api.md`
+- Note: no `project-context.md` file was found under `docs/` in this repo at story creation time.
+
+## Story Completion Status
+
+- **Status**: ready-for-dev
+- **Completion note**: Ultimate context engine analysis completed — comprehensive developer guide created
+
+## References
+
+- [Source: docs/progress/epic-3-stories-and-plan.md#Story-3.3] — ACs + technical notes
+- [Source: backend/shared/validation/src/schemas.ts] — `updateSaveSchema`, tags constraints
+- [Source: backend/shared/events/src/events/saves.ts] — saves event catalog (3.3 extends)
+- [Source: backend/shared/events/src/emitter.ts] — fire-and-forget event emission contract
+- [Source: backend/functions/saves/handler.ts] — existing saves create handler patterns (rate limit, env var requirements, event emission)
+- [Source: infra/lib/stacks/api/saves-routes.stack.ts] — CDK wiring pattern for `/saves`
+- [Source: infra/config/route-registry.ts] — route registry + handler ref pattern
+- [Source: _bmad-output/implementation-artifacts/3-2-list-get-saves-api.md] — handler signature + saveId validation pattern
+
+## Dev Agent Record
+
+### Agent Model Used
+
+{{agent_model_name_version}}
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List
+

--- a/_bmad-output/implementation-artifacts/3-4-save-filtering-sorting.md
+++ b/_bmad-output/implementation-artifacts/3-4-save-filtering-sorting.md
@@ -1,0 +1,182 @@
+---
+id: "3.4"
+title: "Save Filtering & Sorting"
+status: ready-for-dev
+depends_on:
+  - 3-2-list-get-saves-api
+touches:
+  - backend/functions/saves-list/handler.ts
+  - backend/shared/validation/src/schemas.ts (list filter/sort query schema — extend inline or add listSavesQuerySchema)
+  - backend/shared/validation/src/index.ts (if listSavesQuerySchema added)
+risk: low
+---
+
+# Story 3.4: Save Filtering & Sorting
+
+Status: ready-for-dev
+
+## Story
+
+As a user,
+I want to filter saves by type and linkage, search by title/source, and sort my list,
+so that I can quickly find the saves I'm looking for.
+
+## Acceptance Criteria
+
+| #    | Given                                    | When                                                       | Then                                                                                                                                 |
+| ---- | ---------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| AC1  | User has saves with various contentTypes | `GET /saves?contentType=video`                             | Returns only saves where `contentType` = video; combinable with other filters                                                        |
+| AC2  | User has linked and unlinked saves       | `GET /saves?linkStatus=linked`                             | Returns saves where `linkedProjectCount > 0`                                                                                         |
+| AC3  | User has linked and unlinked saves       | `GET /saves?linkStatus=unlinked`                           | Returns saves where `linkedProjectCount = 0`                                                                                         |
+| AC4  | User has saves                           | `GET /saves?search=react`                                  | Returns saves where `title` or `url` contains "react" (case-insensitive)                                                             |
+| AC5  | User has saves                           | `GET /saves?sort=createdAt&order=asc`                      | Returns saves sorted by creation date ascending                                                                                      |
+| AC6  | User has saves                           | `GET /saves?sort=lastAccessedAt&order=desc`                | Returns saves sorted by last accessed date descending; saves never accessed sort to bottom                                          |
+| AC7  | User has saves                           | `GET /saves?sort=title&order=asc`                          | Returns saves sorted alphabetically by title; saves without titles sort to bottom                                                   |
+| AC8  | Multiple filters applied                 | `GET /saves?contentType=video&search=react&sort=createdAt`  | All filters AND-combined; sorting applied after filtering                                                                            |
+| AC9  | Invalid filter or sort value             | `GET /saves?contentType=invalid`                           | Returns 400 `{ error: { code: 'VALIDATION_ERROR', message: '...', requestId } }` with valid options listed                          |
+| AC10 | No saves match filters                   | `GET /saves?contentType=podcast`                           | Returns `{ items: [], hasMore: false }` (empty result, not an error)                                                               |
+| AC11 | User has >1000 saves                     | Any filtered/sorted query                                  | Response includes `truncated: true` flag indicating results are from the most recent 1000 saves only. Logged as warning server-side. |
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Add list filter/sort query schema to `@ai-learning-hub/validation` (AC: #1–#9)
+  - [ ] 1.1 Add optional query params: `contentType` (contentTypeSchema.optional()), `linkStatus` (z.enum(['linked','unlinked']).optional()), `search` (z.string().min(1).max(200).optional()), `sort` (z.enum(['createdAt','lastAccessedAt','title']).optional()), `order` (z.enum(['asc','desc']).optional()). Defaults: sort=createdAt, order=desc for date sorts and order=asc for title.
+  - [ ] 1.2 Export schema (e.g. `listSavesQuerySchema`) from validation package and use in saves-list handler.
+  - [ ] 1.3 Invalid values (e.g. contentType=invalid, linkStatus=foo, sort=invalid) → 400 VALIDATION_ERROR. For enum failures, ensure valid options are listed in `error.message` or in `error.details` so AC9 is satisfied (e.g. "contentType must be one of: article, video, podcast, ...").
+
+- [ ] Task 2: Extend saves-list handler — filter/sort/search + truncated (AC: all)
+  - [ ] 2.1 In `backend/functions/saves-list/handler.ts`, extend query validation to include new params (contentType, linkStatus, search, sort, order) using the new schema. Keep existing limit + nextToken validation.
+  - [ ] 2.2 After fetching active saves via `queryAllItems` (unchanged call — same filterExpression, ceiling, scanIndexForward from Story 3.2), apply in-memory filters in order: contentType (if provided), linkStatus (linked ⇒ `(item.linkedProjectCount ?? 0) > 0`, unlinked ⇒ `(item.linkedProjectCount ?? 0) === 0`), search (case-insensitive includes on `(item.title ?? '')` and `item.url`).
+  - [ ] 2.3 Apply in-memory sort: by sort key (createdAt | lastAccessedAt | title) and order (asc | desc). For lastAccessedAt: null/undefined sorts to bottom. For title: null/empty sorts to bottom. When `order` is omitted, set in handler after parse: `desc` when sort is createdAt or lastAccessedAt, `asc` when sort is title.
+  - [ ] 2.4 Apply ULID cursor pagination on the filtered+sorted array (same semantics as Story 3.2). **nextToken + filter change (epic):** If nextToken resolves to a saveId that is **not present in the current filtered/sorted list** (e.g. client changed filters between requests), **ignore nextToken** and return the first page (same as omitting nextToken). Do not return 400. Return 400 only for **malformed** nextToken (unparseable or invalid ULID) or when the saveId is not in the **unfiltered** result set (stale cursor).
+  - [ ] 2.5 Include `truncated` in the response **only when** `queryAllItems` returned truncated (remove TODO(story-3.4) comment). Use `...(truncated && { truncated: true })`; omit when not truncated. Response shape: `{ items, nextToken?, hasMore, truncated? }`.
+  - [ ] 2.6 When sort=createdAt (default), keep using scanIndexForward: false in queryAllItems so DynamoDB returns newest-first; then apply order=asc in-memory if needed. When sort=lastAccessedAt or sort=title, fetch with same query (newest-first by SK) then sort in-memory (no DynamoDB sort key change).
+
+- [ ] Task 3: Tests + quality gates
+  - [ ] 3.1 Handler tests: filter by contentType; filter by linkStatus (linked / unlinked); search by title substring (including missing title); search by url substring; sort=createdAt&order=asc/desc; sort=lastAccessedAt&order=desc (null lastAccessedAt at bottom); sort=title&order=asc (empty title at bottom); default order when only sort provided (desc for dates, asc for title); combined filters + sort; invalid contentType/linkStatus/sort → 400; response body (message or details) includes valid options (AC9); use `assertADR008Error(result, ErrorCode.VALIDATION_ERROR, 400)` for validation error paths; no matches → { items: [], hasMore: false }; truncated=true in response only when ceiling hit; malformed nextToken → 400; nextToken with saveId not in filtered/sorted list → first page returned (no 400, per epic).
+  - [ ] 3.2 Ensure existing saves-list and architecture enforcement tests still pass.
+  - [ ] 3.3 Run `npm test`, `npm run lint`, `npm run build`, `npm run type-check`, `npm run format`.
+
+## Dev Notes
+
+- **Extends Story 3.2 only:** No new Lambdas, no new routes. Only `GET /saves` handler and optional validation schema changes.
+- **In-memory strategy:** Story 3.2 already fetches up to 1000 active saves. Story 3.4 adds filter/sort/search on that same result set. Pagination contract unchanged (nextToken = base64url of saveId).
+- **linkStatus:** Uses `linkedProjectCount` on Save (default 0). Treat missing as 0: linked ⇒ `(item.linkedProjectCount ?? 0) > 0`, unlinked ⇒ `(item.linkedProjectCount ?? 0) === 0`. Until Epic 5, all saves have 0 so linkStatus=linked returns empty.
+- **Search:** Case-insensitive substring on `(item.title ?? '')` and `item.url` (full url). NOT full-text search (Epic 7).
+- **Sort:** createdAt (default), lastAccessedAt, title. order: asc | desc. When `order` is omitted, set in handler after parse: `desc` for createdAt/lastAccessedAt, `asc` for title.
+- **Truncation (AC11):** Include `truncated` in response only when true (`...(truncated && { truncated: true })`); omit when not truncated. Server-side warn log already exists; ensure it remains.
+
+### Project Structure Notes
+
+- Single handler change: `backend/functions/saves-list/handler.ts`.
+- Use a single list query schema: either extend the inline schema in the handler with the new params, or add `listSavesQuerySchema` in `@ai-learning-hub/validation` and use it in the handler. If added to validation, export from the package index and reference in File Structure Requirements.
+
+### References
+
+- [Source: docs/progress/epic-3-stories-and-plan.md#Story-3.4] — ACs and technical notes
+- [Source: _bmad-output/implementation-artifacts/3-2-list-get-saves-api.md] — queryAllItems, cursor pagination, TODO(story-3.4) truncated
+- [Source: backend/shared/validation/src/schemas.ts] — contentTypeSchema for filter validation
+- [Source: backend/shared/types/src/entities.ts] — Save has linkedProjectCount, lastAccessedAt, title, url
+
+## Developer Context (Read First)
+
+- **Do not add new endpoints or Lambdas.** This story extends the existing `GET /saves` handler only.
+- **Reuse `queryAllItems`:** Same call as Story 3.2 (filterExpression for deletedAt, ceiling 1000, consistentRead). Filtering and sorting happen in-memory after the fetch.
+- **Validation:** Add a list-query schema that allows optional contentType, linkStatus, search, sort, order. Use `validateQueryParams` with the extended schema. For invalid enum values return 400 with a message that lists valid options (AC9).
+- **nextToken + filter change (epic):** If nextToken resolves to a saveId not in the current filtered/sorted list (e.g. filters changed between requests), **ignore nextToken** and return the first page. Do not return 400. Return 400 only for malformed nextToken (unparseable or invalid ULID) or when the cursor save is not in the unfiltered result set (stale).
+
+## Technical Requirements
+
+### GET /saves query parameters (extended)
+
+- **Existing:** limit (1–100, default 25), nextToken (optional).
+- **New (all optional):**
+  - contentType: one of contentTypeSchema values (article, video, podcast, github_repo, newsletter, tool, reddit, linkedin, other).
+  - linkStatus: `linked` | `unlinked`.
+  - search: non-empty string, max length 200; applied as case-insensitive substring match on title and url.
+  - sort: `createdAt` | `lastAccessedAt` | `title`. Default `createdAt`.
+  - order: `asc` | `desc`. Default `desc` for createdAt/lastAccessedAt, `asc` for title.
+- **Validation:** Invalid enum/value → 400 VALIDATION_ERROR. Message or error.details must list valid options (AC9); e.g. custom message "contentType must be one of: article, video, podcast, ...".
+
+### Response shape
+
+- `{ items: PublicSave[], nextToken?: string, hasMore: boolean, truncated?: boolean }`.
+- Include `truncated` only when true (omit when not truncated). Set when the user has more than 1000 active saves and the list was capped at 1000 (AC11).
+
+### Filter and sort order
+
+1. Fetch: same as 3.2 (queryAllItems with filterExpression deletedAt, ceiling 1000, scanIndexForward: false).
+2. Filter in-memory: contentType (if present) → linkStatus (if present) → search (if present). AND between filters.
+3. Sort in-memory: by chosen sort key and order. lastAccessedAt null/undefined → bottom. title null/empty → bottom.
+4. Paginate: slice filtered+sorted array using nextToken (cursor) and limit; compute nextToken and hasMore as in 3.2.
+
+## Architecture Compliance
+
+| ADR / NFR | How This Story Must Comply |
+|-----------|----------------------------|
+| **ADR-001 (DynamoDB keys)** | No schema change. Same PK/SK query as 3.2. |
+| **ADR-008 (Standardized errors)** | 400 for invalid query params via AppError(ErrorCode.VALIDATION_ERROR, ...). |
+| **ADR-014 (API-first)** | GET /saves remains the only list endpoint; query params extend the contract. |
+| **NFR-P2 (Warm perf)** | In-memory filter/sort on ≤1000 items; stay under 1s warm. |
+
+## Library / Framework Requirements
+
+- `@ai-learning-hub/validation`: extend or add list query schema; use `validateQueryParams`, `contentTypeSchema`.
+- `@ai-learning-hub/db`: `queryAllItems`, `SAVES_TABLE_CONFIG`, `toPublicSave` — no changes to db package.
+- `@ai-learning-hub/middleware`: `wrapHandler`, `HandlerContext` — unchanged.
+- `@ai-learning-hub/types`: `SaveItem`, `PublicSave`, `AppError`, `ErrorCode` — unchanged.
+
+## File Structure Requirements
+
+- **Modify:** `backend/functions/saves-list/handler.ts` (add query parsing, filter/sort/search logic, include truncated in response).
+- **Schema:** Either extend the handler’s inline list query schema with new params or add `listSavesQuerySchema` in `backend/shared/validation/src/schemas.ts` and export from index.
+
+## Testing Requirements
+
+- **saves-list handler tests:** Cover AC1–AC11: each filter alone; linkStatus linked/unlinked (including items with missing linkedProjectCount); search on title (including missing title) and url; sort/order combinations; default order when only sort provided; lastAccessedAt null at bottom; title empty at bottom; combined filters + sort; invalid params → 400; response (message or details) includes valid options; use `assertADR008Error(result, ErrorCode.VALIDATION_ERROR, 400)` for validation error paths; empty result → items [], hasMore false; truncated present only when ceiling hit; malformed nextToken → 400; nextToken with saveId not in filtered/sorted list → first page (no 400).
+- **No new infra or route registry changes** — same GET /saves route.
+
+## Previous Story Intelligence (3.2, 3.3)
+
+### From Story 3.2 (List & Get Saves API)
+
+- **queryAllItems** already used with filterExpression, ceiling, scanIndexForward. Story 3.4 does not change the DynamoDB call; only post-processing.
+- **TODO(story-3.4): expose truncated in response** — remove the TODO and add `truncated` to the returned object when `truncated === true`.
+- **Cursor pagination:** nextToken = base64url(saveId); decode and find index in array; slice(startIndex, startIndex + limit). If nextToken decode fails or saveId not in list → 400.
+- **ConsistentRead: true** and filterExpression for deletedAt remain as-is.
+
+### From Story 3.3 (Update, Delete, Restore)
+
+- No direct impact. 3.4 is read-only list extension. Save shape (linkedProjectCount, lastAccessedAt, contentType) is already used in 3.2/3.3.
+
+## Git Intelligence Summary
+
+- Recent work: 3.2 list/get, 3.3 update/delete/restore. Saves-list handler is in `backend/functions/saves-list/handler.ts`; extend it in place.
+- Route registry and CDK: no changes for 3.4 (same GET /saves).
+
+## Latest Tech Information
+
+- No new dependencies. Use existing Zod schemas and query validation pattern from 3.2.
+
+## Project Context Reference
+
+- Story source: `docs/progress/epic-3-stories-and-plan.md` (Story 3.4).
+- Prior story: `_bmad-output/implementation-artifacts/3-2-list-get-saves-api.md`.
+- Architecture: `_bmad-output/planning-artifacts/architecture.md` (ADR-001, ADR-008, ADR-014).
+
+## Story Completion Status
+
+- **Status**: ready-for-dev
+- **Completion note**: Ultimate context engine analysis completed — comprehensive developer guide created
+
+## Dev Agent Record
+
+### Agent Model Used
+
+{{agent_model_name_version}}
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -88,9 +88,9 @@ development_status:
   3-1a-save-validation-modules: done # PR #156 merged 2026-02-19
   3-1c-events-shared-package: done # PR #177 merged 2026-02-22
   3-1b-create-save-api: done # PR #182 created 2026-02-22
-  3-2-list-get-saves-api: ready-for-dev
-  3-3-update-delete-restore-api: backlog
-  3-4-save-filtering-sorting: backlog
+  3-2-list-get-saves-api: done # PR #186 merged 2026-02-23
+  3-3-update-delete-restore-api: done # PR #188 merged 2026-02-23
+  3-4-save-filtering-sorting: done # PR #190 created 2026-02-23
   3-5-ios-shortcut-capture: backlog
   3-6-pwa-share-target: backlog
   3-6a-ui-foundation-design-system: backlog
@@ -98,6 +98,14 @@ development_status:
   3-8-save-filtering-sorting-ui: backlog
   3-9-save-actions-feedback: backlog
   epic-3-retrospective: optional
+
+  # Epic 3.1: Tech Debt — Saves Domain DRY Consolidation (4 stories)
+  epic-3-1-debt: backlog
+  3-1-1-extract-shared-schemas-constants: ready-for-dev
+  3-1-2-shared-test-utilities: ready-for-dev
+  3-1-3-handler-test-consolidation: ready-for-dev
+  3-1-4-dedup-scan-agent-pipeline: ready-for-dev
+  epic-3-1-retrospective: optional
 
   # Epic 4: Project Management (stories TBD)
   epic-4: backlog

--- a/docs/adversarial-review-story-3-1-1-extract-shared-schemas-constants.md
+++ b/docs/adversarial-review-story-3-1-1-extract-shared-schemas-constants.md
@@ -1,0 +1,160 @@
+# Adversarial Review: Story 3.1.1 — Extract Shared Schemas & Constants
+
+**Date:** 2026-02-23  
+**Artifact:** `_bmad-output/implementation-artifacts/3-1-1-extract-shared-schemas-constants.md`  
+**Scope:** Story 3.1.1 acceptance criteria, tasks, technical requirements, alignment with existing handlers and shared packages, and test impact.
+
+---
+
+## Summary
+
+The story is well-scoped for a refactor-only change (no behavioral changes) and correctly targets the four by-saveId handlers plus the saves create handler for extractions. The review finds **no critical blockers** but **several high-impact gaps**: the exact `saveIdPathSchema` definition is not specified (risk of inconsistent validation or messages), test mocks must explicitly add `requireEventBus` or handler tests will break, and the post-extraction handler usage of `requireEventBus()` (module-level capture and use of `busName`/`ebClient`) is not spelled out. **Medium** items include placement of the rate-limit constant in `db/saves`, optional schema unit test, and build-order dependency.
+
+---
+
+## Epic 3 Intent & Story Role
+
+- **Story role:** Pure DRY refactor (NFR-M1). No new behavior, no API or error-shape changes. Correctly depends on nothing and touches only shared packages and the five saves handlers.
+- **Handlers affected:** The artifact correctly identifies: `saves-get`, `saves-update`, `saves-delete`, `saves-restore` for path schema + (where applicable) rate limit + EventBridge; `saves` (create) for rate limit + EventBridge only. `saves-get` does not use rate limit or EventBridge — only the path schema — which matches the codebase.
+
+---
+
+## High
+
+### H1: Exact `saveIdPathSchema` definition is not specified
+
+**Artifact (Task 1.1):** “Add `saveIdPathSchema` to `backend/shared/validation/src/schemas.ts` alongside existing …”
+
+**Gap:** The artifact does not specify the schema body. In the codebase, all four handlers currently use:
+
+```ts
+const saveIdPathSchema = z.object({
+  saveId: z
+    .string()
+    .regex(/^[0-9A-Z]{26}$/, "saveId must be a 26-character ULID"),
+});
+```
+
+If an implementer uses a different regex (e.g. UUID), different message, or adds/removes constraints, validation behavior or 400 messages will change and AC4 (no behavioral changes) will be violated.
+
+**Recommendation:** In Task 1.1, add the exact definition:
+
+```ts
+export const saveIdPathSchema = z.object({
+  saveId: z
+    .string()
+    .regex(/^[0-9A-Z]{26}$/, "saveId must be a 26-character ULID"),
+});
+```
+
+State that the shared schema must match the current handler definitions exactly (26-char ULID, same message) so that behavior and error messages remain identical.
+
+---
+
+### H2: Test mocks must add `requireEventBus` or handler tests will fail
+
+**Artifact (Previous Story Intelligence):** “Event mock in tests may need updating if `requireEventBus` changes the import surface.”
+
+**Reality:** Handlers will call `requireEventBus()` at **module scope**. In tests, `vi.mock("@ai-learning-hub/events", ...)` replaces the events package. If the mock does not export `requireEventBus`, the handler will either call the real `requireEventBus()` (which reads `process.env.EVENT_BUS_NAME` and `getDefaultClient()`) or, if the mock returns an object without `requireEventBus`, the handler will throw when it tries to call it at load time.
+
+**Evidence:** Current saves handler test mocks (e.g. `backend/functions/saves/handler.test.ts`) mock `getDefaultClient` and set `process.env.EVENT_BUS_NAME = "test-event-bus"`. After extraction, the handler will call `requireEventBus()` at module scope; that call must be satisfied by the mock.
+
+**Recommendation:** In Task 3.2 or Testing Requirements, add an explicit step: “In each of the four handler test files that mock `@ai-learning-hub/events` (saves, saves-update, saves-delete, saves-restore), add `requireEventBus` to the mock, e.g. `requireEventBus: () => ({ busName: 'test-event-bus', ebClient: {} })`, so that module-level `requireEventBus()` succeeds and tests do not fail on load or get wrong EventBridge behavior.”
+
+---
+
+### H3: Handler usage of `requireEventBus()` result is not spelled out
+
+**Artifact (Task 3.1):** Defines `requireEventBus()` returning `{ busName, ebClient }`. Task 3.2 says “call `requireEventBus()` instead of inline boilerplate” and remove the inline blocks.
+
+**Gap:** Current handlers use at module scope: `const EVENT_BUS_NAME = ...`, guard, and `const ebClient = getDefaultEBClient()`. In the handler body they use `const busName = EVENT_BUS_NAME ?? ""` and call `emitEvent(ebClient, busName, entry, logger)`. After extraction, the handler must:
+
+1. Call `requireEventBus()` once at module scope and store the result.
+2. Use that result’s `busName` and `ebClient` wherever `emitEvent` is called (and avoid re-reading env or calling `getDefaultClient` for EventBridge).
+
+If the story does not state this, an implementer might call `requireEventBus()` inside the handler function on every request (wasteful) or keep a separate `getDefaultClient` call for EventBridge (duplication).
+
+**Recommendation:** In Task 3.2 or Dev Notes, add: “At module scope, set `const eventBus = requireEventBus();`. In the handler body, use `eventBus.ebClient` and `eventBus.busName` for all `emitEvent(...)` calls. Do not call `requireEventBus()` inside the handler or retain a separate EventBridge client getter.”
+
+---
+
+## Medium
+
+### M1: Rate limit constant in `db/saves.ts` — package boundary
+
+**Artifact (Task 2.1):** Add `SAVES_WRITE_RATE_LIMIT` to `backend/shared/db/src/saves.ts`.
+
+**Observation:** The `db` package is primarily DynamoDB access and table config. Rate limit **state** lives in the users table (and `enforceRateLimit` is in `db`), but the **constant** (operation name, limit, window) is policy for the “saves” write domain. Putting it in `saves.ts` is defensible (co-located with saves table config) but blurs “data access” with “product policy.”
+
+**Recommendation:** One sentence in Dev Notes: “`SAVES_WRITE_RATE_LIMIT` is placed in `saves.ts` to keep saves-domain policy with saves config. If more operation-specific rate limit constants are added later, consider a dedicated `rate-limits.ts` (or similar) in the db package to avoid scattering policy across multiple domain files.”
+
+---
+
+### M2: Optional unit test for `saveIdPathSchema`
+
+**Artifact (Testing Requirements):** “No new tests required … If a test breaks, the extraction is wrong.”
+
+**Gap:** The validation package has unit tests for other schemas (e.g. `createSaveSchema`, `updateSaveSchema` in `save-schemas.test.ts`). Adding a short test for `saveIdPathSchema` (valid 26-char ULID passes; invalid length/format fail with the expected message) would lock in the exact contract and catch accidental changes to the shared schema. The story does not require it, so it’s optional but would improve safety.
+
+**Recommendation:** In Testing Requirements or as an optional subtask: “Optional: add a test in `backend/shared/validation/test/` that asserts `saveIdPathSchema` accepts a 26-character ULID and rejects invalid formats with the message ‘saveId must be a 26-character ULID’. Not required for AC4 but recommended for regression safety.”
+
+---
+
+### M3: Build order and verification
+
+**Artifact:** Task 1 includes “Rebuild validation package” (1.3); Task 4 runs `npm test`, `type-check`, `lint`.
+
+**Observation:** Handlers import from the **compiled** `@ai-learning-hub/validation` output. If Task 2 or 3 is done before the validation package is rebuilt after adding `saveIdPathSchema`, type-check or tests can fail or use an old build. The artifact already warns in Dev Notes that rebuild is required after schema changes; the task order (1.1–1.6 then 2, 3, 4) is correct. No change strictly required; a short reminder in Task 4.1 (“Ensure validation package has been built (Task 1.3) before running tests”) would reduce mistakes.
+
+**Recommendation:** In Task 4.1, add: “Ensure `npm run -w @ai-learning-hub/validation build` has been run (Task 1.3) so handler imports resolve.”
+
+---
+
+## Low / Clarifications
+
+### L1: `requireEventBus()` placement — `index.ts` vs `init.ts`
+
+**Artifact (Task 3.1):** “Add `requireEventBus()` to the events package (e.g. `backend/shared/events/src/index.ts` or a new `init.ts`).”
+
+**Clarification:** If a new `init.ts` is used, it must be exported from `index.ts` so handlers can `import { requireEventBus } from '@ai-learning-hub/events'`. Stating this avoids a partial export and broken imports.
+
+**Recommendation:** One sentence: “If `requireEventBus` is implemented in a new file (e.g. `init.ts`), export it from `backend/shared/events/src/index.ts` so the public API remains `@ai-learning-hub/events`.”
+
+---
+
+### L2: Grep verification and alternate patterns
+
+**Artifact (Task 1.6):** “Verify: `grep -r "const saveIdPathSchema" backend/functions/` returns no matches.”
+
+**Observation:** This correctly ensures no handler **defines** the schema locally. A handler that both imported and re-declared (e.g. `const saveIdPathSchema = sharedSaveIdPathSchema`) would be caught by the grep if it used the same name. The intended state is only imports; the grep is sufficient.
+
+---
+
+### L3: ADR-008 and error shape
+
+**Artifact (Architecture Compliance):** “ADR-008: No changes to error response format.”
+
+**Observation:** This story does not touch error construction or middleware; it only moves schema and config. No change to ADR-008 is expected. No action needed; the table is accurate.
+
+---
+
+## Positive Notes
+
+- **Behavioral equivalence** is clearly stated (Dev Notes, AC4), and “fix the extraction, not the test” is the right rule.
+- **Validation rebuild** is explicitly called out from prior story intelligence.
+- **EventBridge helper** is specified to run at module scope (cold start), matching current behavior.
+- **Rate limit** use of `as const` and spread with `identifier: userId` matches existing `enforceRateLimit(client, USERS_TABLE_CONFIG.tableName, { ... }, logger)` usage in the codebase.
+- **File list** and touched paths match the actual handlers and shared modules that contain the duplicated code.
+
+---
+
+## Checklist for Implementation
+
+Before implementation, resolve or document:
+
+- [ ] **H1:** Add exact `saveIdPathSchema` definition to Task 1.1.
+- [ ] **H2:** Add explicit step to update events mock in all four handler test files to include `requireEventBus`.
+- [ ] **H3:** Document module-level `const eventBus = requireEventBus();` and use of `eventBus.busName` / `eventBus.ebClient` in handler body.
+- [ ] **M2 (optional):** Consider adding a validation package unit test for `saveIdPathSchema`.
+- [ ] **M3:** Optional reminder in Task 4.1 to run validation build before tests.
+- [ ] **L1:** If using `init.ts`, state that `requireEventBus` must be exported from events `index.ts`.

--- a/docs/adversarial-review-story-3-1-2-shared-test-utilities.md
+++ b/docs/adversarial-review-story-3-1-2-shared-test-utilities.md
@@ -1,0 +1,164 @@
+# Adversarial Review: Story 3.1.2 — Shared Test Utilities for Saves Domain
+
+**Date:** 2026-02-23  
+**Artifact:** `_bmad-output/implementation-artifacts/3-1-2-shared-test-utilities.md`  
+**Scope:** Story 3.1.2 acceptance criteria, tasks, mock design, proof-of-concept migration, and alignment with existing test-utils and Vitest constraints.
+
+---
+
+## Summary
+
+The story is well-scoped and correctly depends on 3.1.1. The review finds **one high-impact inconsistency** (factory defaults vs. existing saves-get assertions), **several medium-impact gaps** (mockDbModule missing getItem/updateItem in default, vi.mock hoisting and \_mockEmitEvent ergonomics, no explicit test for the utilities), and **low/clarification** items (requireEventBus, getDefaultClient implementation, assertADR008 adoption scope) that could cause migration failures or confusion during 3.1.3.
+
+---
+
+## Epic 3 Intent & Dependencies
+
+- **Epic 3 / Story 3.1:** Story 3.1.2 fits the “extract shared test utilities” goal and correctly depends on `3-1-1-extract-shared-schemas-constants`. No conflict with epic intent.
+- **Build-on-3.1.1:** Dev Notes and Previous Story Intelligence correctly reference Story 3.1.1 (saveIdPathSchema, SAVES_WRITE_RATE_LIMIT, requireEventBus). requireEventBus is not present in the current events package; the artifact’s “consider adding requireEventBus mock” is forward-looking and appropriate.
+
+---
+
+## High
+
+### H1: createTestSaveItem defaults break proof-of-concept migration (AC1, AC6)
+
+**Artifact (Task 1.1)** defines `createTestSaveItem` with:
+
+- `url: \`https://example.com/${saveId}\``
+- `normalizedUrl: \`https://example.com/${saveId}\``
+- `urlHash: \`hash-${saveId}\``
+
+**Current `saves-get/handler.test.ts`** uses a local `createSaveItem` with:
+
+- `url: "https://example.com/article"`
+- `normalizedUrl: "https://example.com/article"`
+- `urlHash: "hash123"`
+
+and asserts:
+
+```ts
+expect(body.data.url).toBe("https://example.com/article");
+```
+
+**Impact:** If the proof-of-concept migration (Task 5) simply replaces the local factory with `createTestSaveItem()` and `VALID_SAVE_ID`, the test “returns 200 with save data” will fail: the handler will return the new default URL/urlHash and the assertion will not match.
+
+**Recommendation:** Choose one and document it:
+
+1. **Option A (preferred):** Make the shared factory’s **default** shape match the current saves-get test so that the migration is a drop-in replacement with no assertion changes. In Task 1.1, set default `url`, `normalizedUrl`, and `urlHash` to `"https://example.com/article"` and `"hash123"` (or a single constant like `DEFAULT_TEST_URL` / `DEFAULT_TEST_URL_HASH`). Document that “defaults are chosen so that saves-get tests pass without changing assertions.”
+2. **Option B:** Keep the artifact’s parameterized defaults but in Task 5 explicitly require updating the saves-get assertions to the new defaults (e.g. `expect(body.data.url).toBe(\`https://example.com/${VALID_SAVE_ID}\`)`). Then AC1’s “signature supports all variations” is satisfied by overrides (e.g. `createTestSaveItem(VALID_SAVE_ID, { url: "https://example.com/article", urlHash: "hash123" })`), and the PoC migration must include those overrides or updated assertions.
+
+Until this is resolved, AC6 (“all tests still pass”) is at risk when the artifact’s code is implemented as written.
+
+---
+
+### H2: mockDbModule default return omits getItem and updateItem; story does not require passing them
+
+**Artifact (Task 3.1):** `mockDbModule(mockFns)` returns an object with `getDefaultClient`, `SAVES_TABLE_CONFIG`, `USERS_TABLE_CONFIG`, `toPublicSave`, `requireEnv`, `SAVES_WRITE_RATE_LIMIT`, and `...mockFns`. It does **not** include `getItem` or `updateItem` in the default object.
+
+**Reality:** Saves handlers (e.g. saves-get) call `getItem` and `updateItem` from `@ai-learning-hub/db`. If a test does `vi.mock("@ai-learning-hub/db", () => mockDbModule())` with no arguments, the mocked module will have no `getItem` or `updateItem`; handler code will receive `undefined` and crash.
+
+**Impact:** Implementers or future migrations might assume `mockDbModule()` alone is enough. Tests will fail at runtime until callers pass e.g. `mockDbModule({ getItem: mockGetItem, updateItem: mockUpdateItem })`. The artifact’s proof-of-concept (Task 5.2) says “use mockDbModule() for the @ai-learning-hub/db mock” but does not show that mockFns must supply these.
+
+**Recommendation:**
+
+1. In Task 3.1, add a sentence: “Callers must pass at least `getItem` and `updateItem` (and any other used exports) in `mockFns` so the mocked module is complete for handler tests.”
+2. In Task 5.2, show the intended usage explicitly, e.g.: “Use `mockDbModule({ getItem: mockGetItem, updateItem: mockUpdateItem })` (with mocks declared before `vi.mock()` per Dev Notes).”
+3. Optionally, document in Dev Notes that “saves-get and most saves handlers require getItem and updateItem; list handlers may also need queryItems.”
+
+---
+
+## Medium
+
+### M1: mockEventsModule() — asserting emitEvent calls requires \_mockEmitEvent or vi.mocked()
+
+**Artifact (Task 2.1):** Returns `emitEvent: (...args: unknown[]) => mockEmitEvent(...args)` and `_mockEmitEvent: mockEmitEvent` for assertions.
+
+**Gap:** The story does not explain how a test file should assert that `emitEvent` was called. With `vi.mock("@ai-learning-hub/events", () => mockEventsModule())`, the handler imports `emitEvent` from `@ai-learning-hub/events`; that is the wrapper function. To assert on calls, the test must either (1) import the module and use `vi.mocked(module._mockEmitEvent)` (or access `_mockEmitEvent` if re-exported), or (2) use `vi.mocked(emitEvent)` which would mock the wrapper, not the inner mock—so reset/assertions might be confusing.
+
+**Recommendation:** In Dev Notes or Task 2.1, add one line: “Tests that need to assert emitEvent calls should import the events module and assert on the `_mockEmitEvent` property (e.g. `const events = await import('@ai-learning-hub/events'); expect(events._mockEmitEvent).toHaveBeenCalledWith(...)`), or document that the module factory re-exports `_mockEmitEvent` for test use.” If the index does not re-export `_mockEmitEvent`, clarify that it is only available on the mocked module object, not from test-utils.
+
+---
+
+### M2: mockDbModule getDefaultClient implementation is redundant
+
+**Artifact (Task 3.1):**
+
+```ts
+getDefaultClient: () => vi.fn(() => ({}))(),
+```
+
+This creates a mock function that returns `{}`, then immediately invokes it, so `getDefaultClient()` returns `{}`. The same behavior is achieved with `getDefaultClient: () => ({})`. The `vi.fn()` adds no benefit here and may confuse readers.
+
+**Recommendation:** Use `getDefaultClient: () => ({})` in the artifact (and in implementation) unless there is a need to assert on getDefaultClient being called, in which case document that and use e.g. `const mockGetDefaultClient = vi.fn(() => ({})); ... getDefaultClient: mockGetDefaultClient`.
+
+---
+
+### M3: No explicit test file for the new utilities
+
+**Artifact (Testing Requirements):** “The utilities are tested implicitly — the proof-of-concept migration in Task 5 validates they work correctly.”
+
+**Gap:** If a future change breaks `createTestSaveItem` (e.g. a new required field on SaveItem) or `mockDbModule` (e.g. wrong SAVES_TABLE_CONFIG shape), the only signal would be failing handler tests. There is no dedicated test file for test-utils (e.g. `save-factories.test.ts`, `mock-db.test.ts`) that would fail first and localize the break. The existing `mock-wrapper.test.ts` shows the project does unit-test test utilities.
+
+**Recommendation:** Either (1) add a Task 1.3 / 3.3: “Add minimal unit tests for the new utilities (e.g. createTestSaveItem returns valid SaveItem and applies overrides; mockDbModule return shape includes required keys and mockFns override),” or (2) explicitly document the decision: “Utilities are validated only by consumer tests; no dedicated test-utils tests in this story (acceptable given low risk and PoC coverage).” The second keeps the story smaller but leaves refactor risk to 3.1.3.
+
+---
+
+### M4: Vi.mock hoisting and mockDbModule(mockFns) ordering could be clearer
+
+**Artifact (Dev Notes):** Correctly states that mock functions must be declared before `vi.mock()` and that `mockDbModule()` must accept mock functions as parameters if the test needs direct references.
+
+**Gap:** The proof-of-concept Task 5 does not show the required order in the file (e.g. “at top: const mockGetItem = vi.fn(); const mockUpdateItem = vi.fn(); vi.mock('@ai-learning-hub/db', () => mockDbModule({ getItem: mockGetItem, updateItem: mockUpdateItem })); then imports”). A new contributor might put `vi.mock()` after imports and hit hoisting/undefined reference issues.
+
+**Recommendation:** In Task 5.1–5.2 or Dev Notes, add a one-line reminder: “In the migrated file, declare mock functions (e.g. mockGetItem, mockUpdateItem) before any vi.mock() that uses them, then vi.mock(), then imports and tests.”
+
+---
+
+## Low / Clarifications
+
+### L1: requireEventBus — not in codebase yet
+
+**Artifact (Task 2.3, Previous Story Intelligence):** Suggests considering a `requireEventBus` mock if Story 3.1.1 introduced it. `requireEventBus` does not exist in the current events package.
+
+**Recommendation:** Leave as-is. The “consider” and “if Story 3.1.1 introduced it” wording is correct; implementers can add the mock when 3.1.1 adds the export.
+
+---
+
+### L2: assertADR008Error adoption (AC/Task 4.2)
+
+**Artifact (Task 4.2, Dev Notes):** Preserve existing exports including `assertADR008Error`; adoption in more test files is 3.1.3.
+
+**Clarification:** No conflict. Ensuring index.ts exports assertADR008Error is sufficient for this story; no need to use it in the PoC migration unless saves-get already has an ADR-008 test (it has 400/404 tests but not necessarily assertADR008Error).
+
+---
+
+### L3: toPublicSave and deletedAt
+
+**Artifact (Task 3.1):** `toPublicSave` strips `PK`, `SK`, `deletedAt`. `SaveItem` in `@ai-learning-hub/types` includes optional `deletedAt`; `PublicSave` omits it. The mock’s inline `toPublicSave` matches that. No change needed; just confirming alignment.
+
+---
+
+## Architecture Compliance
+
+- **NFR-M1 (DRY):** The story reduces duplication via shared factories and mocks; compliant.
+- **Test patterns:** Matching `mockMiddlewareModule()` (plain object, factory for vi.mock, optional exposure of mocks for assertions) is correct. The artifact’s mock design is consistent with that pattern.
+
+---
+
+## Recommendations Summary
+
+| Priority | Item                                        | Action                                                                                                                 |
+| -------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| High     | H1 Factory defaults vs saves-get assertions | Align factory defaults with current saves-get (Option A) or document overrides/assertion updates in Task 5 (Option B). |
+| High     | H2 mockDbModule missing getItem/updateItem  | Document that callers must pass getItem/updateItem in mockFns; show in Task 5.2.                                       |
+| Medium   | M1 \_mockEmitEvent assertion pattern        | Document how to assert emitEvent calls (e.g. via \_mockEmitEvent on mocked module).                                    |
+| Medium   | M2 getDefaultClient                         | Simplify to `() => ({})` or document if assertable mock is needed.                                                     |
+| Medium   | M3 Unit tests for utilities                 | Add minimal unit tests or document conscious skip.                                                                     |
+| Medium   | M4 vi.mock ordering                         | Add one-line reminder in Task 5 or Dev Notes.                                                                          |
+| Low      | L1–L3                                       | No change or optional clarification.                                                                                   |
+
+---
+
+## Conclusion
+
+The story is implementable and aligns with Epic 3 and existing test-utils patterns. Addressing **H1** (factory defaults) and **H2** (mockDbModule required mockFns) before or during implementation will prevent proof-of-concept migration failures and confusion in Story 3.1.3. The medium items improve clarity and long-term maintainability of the test utilities.

--- a/docs/adversarial-review-story-3-1-3-handler-test-consolidation.md
+++ b/docs/adversarial-review-story-3-1-3-handler-test-consolidation.md
@@ -1,0 +1,146 @@
+# Adversarial Review: Story 3.1.3 — Handler & Test Consolidation
+
+**Date:** 2026-02-23  
+**Artifact:** `_bmad-output/implementation-artifacts/3-1-3-handler-test-consolidation.md`  
+**Scope:** Acceptance criteria, tasks, dev notes, and alignment with codebase and dependencies (3.1.1, 3.1.2).
+
+---
+
+## Summary
+
+The story is well-scoped and mostly implementable as written. The review identifies **one critical dependency/verification mismatch** (AC8 vs 3.1.1), **several high-impact gaps** (test message assertions, mock factory API, and behavioral change disclosure), and **minor risks** (line-number drift, vague “keep local” guidance, and scope creep) that could cause rework or subtle regressions if unaddressed.
+
+---
+
+## Critical
+
+### C1: AC8 verification assumes 3.1.1 is complete; 3.1.3 tasks never remove local `saveIdPathSchema`
+
+**AC8** requires: “No local schema definitions remain in handler files” and verification step 5.4: `grep -r "const saveIdPathSchema" backend/functions/` returns no matches.
+
+**Reality:** Removal of local `saveIdPathSchema` is owned by **Story 3.1.1** (Task 1.4–1.5: update imports and remove local definitions in saves-get, saves-update, saves-delete, saves-restore). Story 3.1.3’s task list does **not** include changing or removing `saveIdPathSchema` in any handler.
+
+**Impact:** If 3.1.1 is not completed before 3.1.3, the 3.1.3 verification step 5.4 will fail, and implementers may (a) incorrectly add “remove saveIdPathSchema” to 3.1.3, or (b) leave 3.1.3 “done” with AC8 failing. If 3.1.1 is done first, AC8 is satisfied by that story; then 3.1.3’s grep is a **cross-check** that nothing re-introduced the local schema.
+
+**Recommendation:** In 3.1.3, clarify AC8 and Task 5.4: “This verification assumes 3.1.1 has already removed local `saveIdPathSchema` from all handlers. If 5.4 finds matches, complete or fix 3.1.1 first; 3.1.3 does not add or remove path schema imports.” Optionally add a precondition: “3.1.1 completed (no local saveIdPathSchema in backend/functions/).”
+
+---
+
+## High
+
+### H1: `assertADR008Error` does not assert error message — NOT_FOUND “Save not found” can regress
+
+**Story (Task 4, AC6):** Migrate tests to use `assertADR008Error` for error assertions.
+
+**Reality:** `backend/test-utils/assert-adr008.ts` has signature `assertADR008Error(response, expectedCode?, expectedStatus?)`. It does **not** accept or assert `expectedMessage`. So a test that only does `assertADR008Error(response, ErrorCode.NOT_FOUND)` will not catch a regression where the API returns `message: "Item not found"` instead of `"Save not found"`.
+
+**Context:** The adversarial review for Story 3.3 called out that 404 responses must use message `"Save not found"` for consistency with ACs. Handlers that catch db helper `AppError(NOT_FOUND, "Item not found")` and rethrow or forward can violate that. Tests that rely solely on `assertADR008Error` will not detect this.
+
+**Recommendation:** Either (a) extend `assertADR008Error` with an optional `expectedMessage?: string` and document it in 3.1.2/3.1.3, or (b) in 3.1.3 Task 4, require that for NOT_FOUND (and any other message-sensitive code), tests add an explicit assertion on `parsed.error.message` (e.g. `expect(parsed.error.message).toBe("Save not found")`) in addition to `assertADR008Error`. Prefer (a) for consistency and reuse.
+
+---
+
+### H2: `mockDbModule()` API and overrides are underspecified for 3.1.3 migration
+
+**Story (Task 4, Dev Notes):** Use `mockDbModule()` and “Approach A — pass mocks in” so tests keep references (e.g. `mockUpdateItem`) for assertions.
+
+**Reality:** Story 3.1.2 defines `mockDbModule(mockFns)` returning a fixed set of keys (`getDefaultClient`, `SAVES_TABLE_CONFIG`, `USERS_TABLE_CONFIG`, `toPublicSave`, `requireEnv`, `SAVES_WRITE_RATE_LIMIT`). It does not show how `mockFns` is merged: are `queryItems`, `updateItem`, `transactWriteItems`, `getItem` etc. part of the default object or only when passed in? If they are only when passed in, every test that uses `queryItems` or `updateItem` must pass them in Approach A. If the default object omits them, the handler under test will receive `undefined` for those imports and crash unless the test provides them.
+
+**Gap:** 3.1.3 does not specify (a) which db functions each of the 6 test files actually mocks (e.g. saves/handler uses queryItems, updateItem, transactWriteItems; saves-update uses updateItem), or (b) that `mockDbModule()` must either provide no-op implementations for all used db functions or document “pass every used function in mockFns”. Without that, migration can lead to “handler gets undefined for queryItems” in CI.
+
+**Recommendation:** In 3.1.3 Dev Notes or Task 4, add a short checklist: “For each test file, list the `@ai-learning-hub/db` functions the handler under test uses; ensure mockDbModule() is called with overrides for each (e.g. mockDbModule({ queryItems: mockQueryItems, updateItem: mockUpdateItem, transactWriteItems: mockTransactWriteItems })).” If 3.1.2’s mockDbModule provides default vi.fn() for all exported db functions, say so in 3.1.2 and reference it here.
+
+---
+
+### H3: Behavioral change (deletedAt stripped from 409) is a breaking API change — not called out as such
+
+**Story (AC2, Dev Notes):** Shared `toPublicSave` strips `deletedAt`; local one in saves/handler does not. The story makes this the “only intentional behavioral change” and states it is correct.
+
+**Reality:** Any client that currently parses the 409 `existingSave` and reads `deletedAt` (e.g. to show “you previously deleted this save”) will see that field disappear. That is a **breaking change** for the public API contract.
+
+**Recommendation:** In the artifact, add one sentence under “Behavioral change” or in a “Breaking change” subsection: “Removing `deletedAt` from the 409 `existingSave` payload is a breaking change for clients that rely on it; document in release notes or API changelog.” No implementation change required, but the story should not be described as “no behavioral changes except AC2” without acknowledging breakage.
+
+---
+
+### H4: “Keep local if create handler’s test factory has unique needs” is too vague
+
+**Story (Task 4.1):** “Import createTestSaveItem from test-utils (or keep local if create handler’s test factory has unique needs).”
+
+**Risk:** Implementers may keep a local factory in saves/handler.test.ts “to be safe” or because they don’t check whether the shared factory supports all needed overrides. That undermines AC6 (each test file uses shared utilities) and leaves duplication in the largest test file.
+
+**Recommendation:** Replace with a concrete rule: “Use createTestSaveItem from test-utils; if a test requires a field or shape not supported by createTestSaveItem(..., overrides), add that override to the shared factory in 3.1.2 (or extend createTestSaveItem signature) and use it here. Only keep a local factory if the team agrees the create handler has a one-off need that does not belong in shared code.” Optionally add a subtask: “4.1.1 Audit saves/handler.test.ts for any createSaveItem usage; map to createTestSaveItem(saveId?, overrides?) and remove local factory.”
+
+---
+
+## Medium
+
+### M1: Line numbers for 409 call sites will drift
+
+**Story (Task 1.5):** “Replace both 409 response construction sites (Layer 1 at ~line 145 and handleTransactionFailure at ~line 276).”
+
+**Reality:** Current codebase has the first 409 block around 151–159 (body with existingSave) and the second around 276–289. Small drift is expected; “~line 276” is still accurate for the second.
+
+**Recommendation:** Prefer “first 409: the block that returns statusCode 409 with existingSave from layer-1 query; second 409: the block that returns 409 with existingSave from activeResult” (or “search for existingSave in body”); de-emphasize line numbers so the story is robust to prior edits.
+
+---
+
+### M2: Response wrapping equivalence depends on `isApiGatewayResult` — edge case not mentioned
+
+**Story (Dev Notes):** “wrapHandler detects when a handler returns a plain object (no statusCode) and auto-wraps.”
+
+**Reality:** The wrapper uses `isApiGatewayResult(result)` (middleware wrapper.ts): true when result is an object with a numeric `statusCode` property. So returning a plain object **without** `statusCode` is auto-wrapped; returning an object that has `statusCode` (e.g. from createSuccessResponse) is passed through. The only theoretical edge case is a handler returning something like `{ statusCode: 200, data: ... }` with a different shape than createSuccessResponse; that’s not in scope for saves-update/saves-restore.
+
+**Recommendation:** Optional one-liner in Dev Notes: “Auto-wrap applies when the handler return value does not have a numeric statusCode (see isApiGatewayResult in wrapper.ts).” No change required if the team is comfortable with the current wording.
+
+---
+
+### M3: Scope creep risk — other handlers still use createSuccessResponse explicitly
+
+**Reality:** Handlers such as invite-codes and api-keys still use `createSuccessResponse` explicitly. The story only standardizes saves-update and saves-restore to the “return plain data, let wrapHandler wrap” pattern.
+
+**Recommendation:** Add a one-sentence scope note under “Story” or “Architecture Compliance”: “Only the saves domain handlers are in scope; invite-codes and api-keys are unchanged.” This avoids future “we did 3.1.3, why does invite-codes still use createSuccessResponse?” confusion.
+
+---
+
+## Low
+
+### L1: Task 2.4 “Verify AppError is imported from @ai-learning-hub/types”
+
+**Reality:** `AppError` and `isAppError` live in `@ai-learning-hub/types` (errors.ts). Handlers already import `AppError` and `ErrorCode` from there. The verification is quick and correct.
+
+**Recommendation:** None; keep as-is.
+
+---
+
+### L2: Quality gates (Task 5) order
+
+**Story (Task 5):** test → type-check → lint, then greps.
+
+**Recommendation:** Running type-check before tests can fail fast on type errors; current order is acceptable. No change required.
+
+---
+
+## Checklist for implementation
+
+- [ ] Confirm 3.1.1 is done (no local saveIdPathSchema) before treating AC8 as passable.
+- [ ] For NOT_FOUND (and other message-sensitive codes), add message assertion or extend assertADR008Error.
+- [ ] For each test file, ensure mockDbModule() provides (or overrides) every db function the handler uses.
+- [ ] Document deletedAt removal from 409 as a breaking change where appropriate.
+- [ ] Use shared createTestSaveItem for saves/handler.test.ts unless an agreed exception exists.
+- [ ] Locate 409 call sites by content (“existingSave”) rather than by line number.
+
+---
+
+## Summary table
+
+| Severity | Id    | Topic                                                                  |
+| -------- | ----- | ---------------------------------------------------------------------- |
+| Critical | C1    | AC8 / 5.4 assumes 3.1.1 removed saveIdPathSchema; 3.1.3 doesn’t do it  |
+| High     | H1    | assertADR008Error doesn’t assert message; “Save not found” can regress |
+| High     | H2    | mockDbModule() merge/override contract underspecified for migration    |
+| High     | H3    | deletedAt stripping is breaking; should be called out                  |
+| High     | H4    | “Keep local if unique needs” too vague; can leave duplication          |
+| Medium   | M1    | Line numbers for 409 drift; prefer semantic description                |
+| Medium   | M2    | Optional note on isApiGatewayResult for auto-wrap                      |
+| Medium   | M3    | Clarify scope: only saves domain; invite-codes/api-keys unchanged      |
+| Low      | L1–L2 | No change                                                              |

--- a/docs/adversarial-review-story-3-1-4-dedup-scan-agent-pipeline.md
+++ b/docs/adversarial-review-story-3-1-4-dedup-scan-agent-pipeline.md
@@ -1,0 +1,188 @@
+# Adversarial Review: Story 3.1.4 — Deduplication Scan Agent & Pipeline Integration
+
+**Date:** 2026-02-23  
+**Artifact:** `_bmad-output/implementation-artifacts/3-1-4-dedup-scan-agent-pipeline.md`  
+**Scope:** Story 3.1.4 acceptance criteria, tasks, protocol design, alignment with existing pipeline (review-loop, agents README, SKILL.md), and operational risks.
+
+---
+
+## Summary
+
+The story is well-scoped and correctly positions the dedup scan as a preventive step before adversarial review. The review finds **one critical gap** (domain derivation when a story touches only shared packages or multiple domains), **several high-impact issues** (Critical severity claim vs static-only analysis, fixer push/commit safety, agent registry and prompt validator updates, findings path vs canonical review path), and **medium/low clarifications** (scanner Bash scope, escalation hard cap, round numbering) that could cause pipeline failures or inconsistent behavior if unaddressed.
+
+---
+
+## Critical
+
+### C1: Domain derivation fails when story touches only shared packages or multiple handler domains
+
+**Artifact (Dev Notes):** Domain is derived by (1) extracting handler directory paths from `touches` (e.g. `backend/functions/saves-update/handler.ts` → `backend/functions/saves-update`), (2) finding common prefix (e.g. `backend/functions/saves`), (3) building glob `backend/functions/saves*/handler.ts`, (4) also including `backend/shared/*/src/**/*.ts`.
+
+**Gaps:**
+
+1. **No handler paths in `touches`:** If a story only touches shared packages (e.g. 3.1.1 extract shared schemas: `backend/shared/validation/...`), step 1 yields no handler directories. Common prefix over an empty set is undefined. The artifact does not define behavior: skip dedup scan, or treat “domain” as only the shared packages touched.
+2. **Multiple domains:** If a story touches both `backend/functions/saves-update/*` and `backend/functions/auth-login/*`, the “common prefix” of `saves-update` and `auth-login` is `backend/functions/`, giving glob `backend/functions/*/handler.ts` (all handlers). The scanner would then compare saves handlers with auth handlers, which may be out of scope and noisy.
+
+**Impact:** Orchestrator could pass invalid or overly broad domain to the scanner, or skip 2.3b with no defined rule, causing inconsistent pipeline behavior.
+
+**Recommendation:**
+
+- In Task 3.3 and Dev Notes, add: **“If `touches` contains no paths under `backend/functions/`, skip the dedup scan loop for this story (proceed directly to 2.4).”**
+- Define **“domain” as one logical group:** e.g. derive a single primary domain from `touches` (e.g. the most specific common prefix that matches at least one handler path). If multiple disjoint handler domains exist (e.g. both `saves*` and `auth*`), either (a) run the dedup loop once per domain with separate findings files, or (b) document “single primary domain only” and derive the primary domain by a stated rule (e.g. first handler path in `touches`, or domain with the most touched files). State the chosen rule in the protocol.
+
+---
+
+## High
+
+### H1: “Critical” severity assumes semantic divergence is detectable without execution
+
+**Artifact (Task 1.4):** **Critical** is defined as “Local copy of shared export with **semantic divergence** (e.g. `toPublicSave` that behaves differently from shared version).”
+
+**Reality:** The scanner has only Read, Glob, Grep, Bash, Write. It cannot run tests or execute code. “Semantic divergence” (different runtime behavior) cannot be reliably detected by static analysis alone; it would require comparing ASTs or heuristics (same name, different implementation), which is best-effort.
+
+**Impact:** Either the scanner will never emit Critical (if it only flags exact duplicates), or it will emit Critical based on heuristics (e.g. same export name, different body) with risk of false positives. The AC and gate (“0 Important+ before proceeding”) treat Critical as MUST-FIX; overclaiming Critical could block the pipeline incorrectly.
+
+**Recommendation:** In Task 1.4 and AC6, either: (a) redefine **Critical** as “Local definition that **shadows** a shared export (same name, potentially different implementation) — fix by using shared export or documenting intentional divergence,” and clarify that “semantic divergence” is inferred only by name/shape, not by execution; or (b) drop Critical for “semantic divergence” and keep only “duplicate that should be shared” under Important, so the gate remains “0 Important+ findings” and Critical is reserved for future tooling that can run tests.
+
+---
+
+### H2: Fixer commit/push safety not stated; fixer could push or commit to wrong branch
+
+**Artifact (Task 2.3):** Fixer must “Stage and commit fixes” and “Report which findings were addressed.”
+
+**Existing pattern (review-loop.md):** The epic-fixer “commits locally but does NOT push”; push happens in Phase 2.5 (Commit & PR).
+
+**Gap:** The artifact does not state that the dedup fixer must **not** push, or that commits must be on the **current story branch**. A fixer with Bash could run `git push` or `git checkout main; git commit`, causing safety violations.
+
+**Recommendation:** In Task 2.3 and in `dedup-scan-loop.md` (Step C / fixer prompt), add explicit rules: “Commit only on the current branch. Do **not** run `git push`. Do not switch branches. Same branch locality as review-loop fixer.” Optionally add to epic-dedup-fixer.md frontmatter or body: “Never push; never change branch.”
+
+---
+
+### H3: New subagent types not registered; prompt-template validator not extended
+
+**Current state:** `.claude/agents/README.md` documents `epic-reviewer` and `epic-fixer` and states that `subagent_type` matches the agent filename (without `.md`). The prompt-template validator (`.claude/hooks/prompt-template-validator.cjs`) references only `epic-reviewer` and `epic-fixer` and validates prompt blocks in `review-loop.md`.
+
+**Gap:** The artifact adds `epic-dedup-scanner` and `epic-dedup-fixer` but does not require:
+
+1. Updating `.claude/agents/README.md` to list the two new subagents (name, file, purpose, tools, spawned by).
+2. Deciding whether `prompt-template-validator.cjs` should validate `dedup-scan-loop.md` (e.g. prompt blocks with `subagent_type: "epic-dedup-scanner"` and `"epic-dedup-fixer"`). If the project later adds such validation, the artifact gives no hook.
+
+**Impact:** Implementers may add the agent files but forget the README, so the agent system doc is out of date. If the validator is later extended to dedup loop, prompt template changes might break without the artifact having specified the contract.
+
+**Recommendation:**
+
+- Add a **Task 5.3 (or 6):** “Update `.claude/agents/README.md`: add rows for `epic-dedup-scanner` and `epic-dedup-fixer` in the Current Subagents table (file, purpose, tools, spawned by).”
+- In Dev Notes or Testing, add: “If the project adds prompt-template validation for `dedup-scan-loop.md`, ensure the prompt blocks under Step A and Step C include the required `subagent_type` and path placeholders; no change to the validator is required for this story unless the team chooses to extend it.”
+
+---
+
+### H4: Findings path convention vs canonical review path
+
+**Artifact (Dev Notes):** “Dedup findings: `.claude/dedup-findings-{story.id}-round-{round}.md`; Review findings: `.claude/review-findings-{story.id}-round-{round}.md`.”
+
+**Existing pipeline:** `review-loop.md` and `docs/how-auto-epic-works.md` use **`docs/progress/story-{id}-review-findings-round-{N}.md`** for reviewer output. Git and docs also reference `docs/progress/` for review findings.
+
+**Impact:** If the orchestrator and reviewer are wired to `docs/progress/...`, then “Review findings” in the artifact is misleading for implementers and could cause confusion when comparing dedup vs review paths. Dedup path (`.claude/...`) is fine as a distinct location; the artifact should not imply that review findings live under `.claude/` unless the project has standardized on that.
+
+**Recommendation:** In the “Findings output path convention” section, state: “Dedup findings: `.claude/dedup-findings-{story.id}-round-{round}.md`. Review findings: use the same path as in `review-loop.md` (currently `docs/progress/story-{story.id}-review-findings-round-{round}.md`). Do not assume review findings are under `.claude/` unless the orchestrator is updated to write them there.” This keeps dedup clearly separate and avoids contradicting the existing review path.
+
+---
+
+## Medium
+
+### M1: Scanner “Bash” tool scope is unspecified
+
+**Artifact (AC1, Task 1.2):** Scanner has tools Read, Glob, Grep, Bash, Write.
+
+**Gap:** Bash could be used to run arbitrary commands (e.g. `npm run type-check`, custom scripts). The methodology says the scanner “reads” handler files and shared packages and “flags” duplicates; it does not say the scanner may run build/test. Unconstrained Bash could allow the scanner to modify state or run dangerous commands.
+
+**Recommendation:** In Task 1.3 or the scanner agent body, add: “Bash is for read-only or analysis-only use (e.g. running grep, or npm run type-check to validate imports). Do not run commands that modify the repo, run tests that mutate state, or push.” Alternatively, restrict to a fixed set of allowed commands if the platform supports it.
+
+---
+
+### M2: Escalation “same as reviewer round 3” — hard cap for override not stated
+
+**Artifact (AC7, Task 3.7):** When dedup scan has Important+ findings after 2 rounds, escalate to human with “same option set as reviewer round 3 escalation (fix manually / accept / override limit).”
+
+**review-loop.md:** Reviewer escalation offers (a) manual fix, (b) accept and mark complete, (c) continue with 1 more round. It also states: **“Hard cap: 5 total review rounds.”**
+
+**Gap:** The dedup loop has max 2 rounds. If the user chooses “override limit,” does the dedup loop get one more round (3 total) or is there a hard cap (e.g. 3 or 4 total)? The artifact says “same option set” but does not state a hard cap for dedup, so implementers might allow unbounded dedup rounds.
+
+**Recommendation:** In Task 3.7 and dedup-scan-loop.md, add: “Same options (a)/(b)/(c) as review-loop. If (c) override: allow one additional dedup round (max 3 total). **Hard cap: 3 dedup rounds** — after that only (a) or (b).” This mirrors the reviewer’s 5-round cap in spirit.
+
+---
+
+### M3: Step numbering 2.3 vs 2.3b and Phase 2 overview
+
+**Artifact (Task 4.4):** “Ensure step numbering is consistent (2.1 → 2.2 → 2.3 → 2.3b → 2.4 → 2.5 → 2.6 → 2.7).”
+
+**Note:** SKILL.md currently lists 2.3 (Mark for Review), then 2.4 (Code Review Loop). Inserting 2.3b is clear. Any automation or docs that parse step numbers (e.g. “step 2.4”) should still resolve correctly. No change required unless the project has parsers that assume integer-only step IDs; then document that 2.3b is a string label, not 2.31.
+
+**Recommendation:** No change; optionally add one line in Dev Notes: “Step 2.3b is a label; downstream logic should treat it as a single step between 2.3 and 2.4.”
+
+---
+
+## Low / Clarifications
+
+### L1: Fixer “appropriate shared package” for helpers
+
+**Artifact (Task 2.3):** For duplicate helpers, “move to appropriate shared package.” Schemas → validation; constants → db or events.
+
+**Clarification:** “Appropriate” for helpers is not defined (e.g. `@ai-learning-hub/db` for DB helpers, or a new shared util package). Minor risk of fixer choosing different locations across runs.
+
+**Recommendation:** In Task 2.3 or epic-dedup-fixer.md, add: “For duplicate helper functions: prefer existing shared packages by domain (e.g. DynamoDB helpers → `@ai-learning-hub/db`, event helpers → `@ai-learning-hub/events`, validation helpers → `@ai-learning-hub/validation`). If no clear home exists, document in the findings and leave for human decision rather than creating a new package in this step.”
+
+---
+
+### L2: Dry-run skips entire dedup loop — no way to test loop logic in dry-run
+
+**Artifact (Task 3.8, 4.2):** In `--dry-run` mode, skip subagent spawning, log dry-run messages, proceed directly to 2.4.
+
+**Implication:** In dry-run, the orchestrator never runs the dedup loop (no scanner, no fixer, no gate). So dry-run cannot be used to verify that the orchestrator correctly derives domain, spawns scanner/fixer, or parses findings.
+
+**Recommendation:** Accept as intentional: dry-run trades fidelity for speed. Optionally add to Dev Notes: “Dry-run does not execute 2.3b; to validate dedup loop integration, run without --dry-run on a branch that has no MUST-FIX findings (e.g. after 3.1.1–3.1.3).”
+
+---
+
+### L3: Shared packages list — logging, middleware
+
+**Artifact (Task 1.3):** Scanner reads “shared package exports (`@ai-learning-hub/validation`, `db`, `events`, `types`).”
+
+**Reality:** Project also has `@ai-learning-hub/logging` and `@ai-learning-hub/middleware`. Handlers might duplicate logger setup or middleware patterns.
+
+**Recommendation:** In Task 1.3, add “`@ai-learning-hub/logging`, `@ai-learning-hub/middleware`” to the list of shared packages to check, so the scanner considers them when flagging “code that exists in shared packages but is defined locally.”
+
+---
+
+## Compliance Check (Artifact vs Pipeline)
+
+| Item                                                   | Status                                      |
+| ------------------------------------------------------ | ------------------------------------------- |
+| NFR-M1 (DRY) — automated enforcement                   | ✅                                          |
+| Reviewer and review-loop unchanged (AC8)               | ✅ (Task 5)                                 |
+| New step between 2.2 and 2.4, gate 0 MUST-FIX          | ✅                                          |
+| Findings format Critical/Important/Minor like reviewer | ✅                                          |
+| Domain derivation from `touches`                       | ⚠️ No handler path / multi-domain rule (C1) |
+| Fixer no-push / same-branch rule                       | ❌ Not stated (H2)                          |
+| Agents README and validator                            | ⚠️ Not in scope (H3)                        |
+| Review findings path vs docs/progress                  | ⚠️ Inconsistent (H4)                        |
+| Critical = semantic divergence                         | ⚠️ Not detectable statically (H1)           |
+
+---
+
+## Recommended Story Edits (Concise)
+
+1. **Domain derivation (C1):** Define behavior when `touches` has no handler paths (skip dedup scan). Define rule for multiple handler domains (single primary domain, or one run per domain with separate findings paths).
+2. **Critical severity (H1):** Redefine Critical as “shadow of shared export (same name, possible divergence)” and clarify that detection is name/shape-based, not execution-based; or drop Critical for semantic divergence and keep gate on Important+ only.
+3. **Fixer safety (H2):** In Task 2.3 and dedup-scan-loop.md, require: commit only on current branch; do not push; do not switch branches.
+4. **Agent registry (H3):** Add task to update `.claude/agents/README.md` with epic-dedup-scanner and epic-dedup-fixer. Note optional future prompt-template validation for dedup-scan-loop.md.
+5. **Findings path (H4):** In “Findings output path convention,” state that review findings path is as in review-loop.md (e.g. `docs/progress/story-{id}-review-findings-round-{N}.md`), not necessarily `.claude/`.
+6. **Scanner Bash (M1):** Restrict Bash to read-only/analysis use; do not modify repo or push.
+7. **Escalation cap (M2):** State hard cap for dedup override (e.g. 3 total rounds), same spirit as review-loop’s 5-round cap.
+8. **Shared packages (L3):** Include `@ai-learning-hub/logging` and `@ai-learning-hub/middleware` in scanner’s shared-package list.
+
+---
+
+## Conclusion
+
+Story 3.1.4 correctly adds a preventive dedup step before adversarial review and keeps the reviewer unchanged. The main risks are **domain derivation edge cases** (no handlers or multiple domains), **overclaiming Critical** without runtime semantics, **fixer commit/push safety** not stated, and **agent docs/path consistency**. Applying the recommended edits will make the pipeline robust and aligned with existing review-loop and agent conventions.

--- a/docs/adversarial-review-story-3-3-update-delete-restore.md
+++ b/docs/adversarial-review-story-3-3-update-delete-restore.md
@@ -1,0 +1,165 @@
+# Adversarial Review: Story 3.3 — Update, Delete & Restore Saves API
+
+**Date:** 2026-02-22  
+**Artifact:** `_bmad-output/implementation-artifacts/3-3-update-delete-restore-api.md`  
+**Scope:** Story 3.3 acceptance criteria, tasks, technical requirements, and alignment with existing codebase.
+
+---
+
+## Summary
+
+The story is well-structured and mostly implementable as written. The review identifies **one critical gap** (404 message consistency), **several high-impact clarifications** (conditional-update flow, event detail union, and CORS/infra wording), and **minor omissions** (tests, rate-limit value, and event backward compatibility) that could cause rework or production inconsistencies if unaddressed.
+
+---
+
+## Critical
+
+### C1: 404 response message will violate ACs if db helper error is allowed to bubble
+
+**AC5, AC6, AC12** require:
+
+```json
+{ "error": { "code": "NOT_FOUND", "message": "Save not found", "requestId" } }
+```
+
+**Current behavior:** `@ai-learning-hub/db`’s `updateItem` throws `AppError(ErrorCode.NOT_FOUND, "Item not found")` on `ConditionalCheckFailedException` (see `backend/shared/db/src/helpers.ts` ~303–304). The middleware forwards the `AppError` message into the response body.
+
+**Impact:** For **PATCH** and for **DELETE/RESTORE** when the handler concludes “missing → 404”, if the handler lets the db helper’s exception propagate, the API will return `message: "Item not found"` instead of `"Save not found"`, failing the ACs.
+
+**Evidence:** `saves-get` explicitly throws `new AppError(ErrorCode.NOT_FOUND, "Save not found")` when the save is missing or soft-deleted (e.g. `backend/functions/saves-get/handler.ts` ~41).
+
+**Recommendation:** In the story, add an explicit requirement: for any path that returns 404 for a save (PATCH/DELETE/RESTORE), the handler **must** throw `new AppError(ErrorCode.NOT_FOUND, "Save not found")`. In particular:
+
+- **PATCH:** On conditional failure (or any “not found” path), catch or avoid propagating the db helper’s NOT_FOUND and instead throw with message `"Save not found"`.
+- **DELETE / RESTORE:** After disambiguating with `getItem`, when returning 404 throw `AppError(ErrorCode.NOT_FOUND, "Save not found")` (not the raw db exception).
+
+---
+
+## High
+
+### H1: Conditional-update + getItem flow is not spelled out; implementers may misuse the helper
+
+**Story text (Task 3.4–3.5, 4.4–4.5):** “Attempt conditional soft delete … On conditional failure: getItem to disambiguate missing vs already deleted.”
+
+**Reality:** The shared `updateItem` **does not** return on condition failure; it throws `AppError(ErrorCode.NOT_FOUND, "Item not found")`. So “on conditional failure” means “in the catch block for that NOT_FOUND.”
+
+**Gap:** The story never says to **catch** the exception from `updateItem`. A developer might assume a new helper that returns a result type, or might call `getItem` before `updateItem` (adding latency and races). The existing **saves create** handler (3.1b) already uses the “try updateItem, catch NOT_FOUND, then use existing context” pattern for restore; here the handler has no prior item, so it must `getItem` in the catch block.
+
+**Recommendation:** In Task 3 and Task 4, add an explicit step, e.g. “Catch `AppError` with `ErrorCode.NOT_FOUND` from the conditional update; in the catch block call `getItem` with the same key. If no item → 404; if item has `deletedAt` (DELETE) or lacks `deletedAt` (RESTORE) → idempotent success (204 / 200).” This makes the intended control flow and use of the existing helper unambiguous.
+
+---
+
+### H2: Event detail type extension will break existing call sites unless done as a discriminated union
+
+**Story (Task 1.1):** Extend `SavesEventDetailType` with `SaveUpdated` and `SaveDeleted` and “extend the detail typing” for the new shapes.
+
+**Current state:** `backend/shared/events/src/events/saves.ts` defines a single `SavesEventDetail` with `userId`, `saveId`, `url`, `normalizedUrl`, `urlHash`, `contentType`. The **saves create** handler emits `SaveRestored` with that shape (including `url` and `contentType`).
+
+**Conflict:** AC2 says `SaveUpdated` detail includes `updatedFields: string[]` and does not require `contentType`. AC4/AC13 say `SaveDeleted`/`SaveRestored` detail includes `userId`, `saveId`, `urlHash`, `normalizedUrl` (no `url`/`contentType`). If the events package is extended by **replacing** the single `SavesEventDetail` with a union, existing `emitEvent<..., SavesEventDetail>(..., detail: { userId, saveId, url, normalizedUrl, urlHash, contentType })` in the saves create handler must still type-check.
+
+**Recommendation:** In Task 1.1, require a **discriminated union** (e.g. by `detailType` or separate interfaces) so that `SaveCreated`/`SaveRestored` keep their current shape (including `url` and `contentType` where used) and `SaveUpdated`/`SaveDeleted` use the slimmer shapes. Explicitly state that existing call sites in `backend/functions/saves/handler.ts` must compile without changing their emit payloads (Task 1.2 should then be a quick verification).
+
+---
+
+### H3: CORS and route wiring wording can be read as “add preflight only to restore”
+
+**Story (Task 5.4, File Structure):** “Wire API Gateway … Add CORS preflight to the `{saveId}` and `restore` resources.”
+
+**Current CDK:** `saveByIdResource` already has `addCorsPreflight(corsOptions)` (Story 3.2). So “add CORS preflight to `{saveId}`” could be interpreted as “ensure it’s there” (no-op) or “add it if missing.” The **restore** sub-resource (`/saves/{saveId}/restore`) is new and **must** get its own `addCorsPreflight` on that new resource object.
+
+**Recommendation:** Clarify: “Ensure `/saves/{saveId}` has CORS preflight (already present from 3.2). **Add** CORS preflight on the **new** `/saves/{saveId}/restore` resource.” This avoids duplicate preflight or missing preflight on restore.
+
+---
+
+### H4: PATCH empty body and “at least one field” are aligned; story should reference schema refinement
+
+**Technical requirements:** “Only fields present in the request body are updated.”
+
+**Reality:** `updateSaveSchema` in `backend/shared/validation/src/schemas.ts` uses `.refine(..., { message: "At least one field must be provided" })`, so an empty body `{}` fails validation and returns 400. The story’s AC9 and testing requirements already cover invalid body and validation errors.
+
+**Recommendation:** One sentence in “Technical Requirements” or “Library Requirements”: “Empty or missing body is rejected by `updateSaveSchema` (at least one of title, userNotes, contentType, tags required).” This ties the “only present fields updated” behavior to the existing schema and avoids a future “allow PATCH with {} to no-op” misinterpretation.
+
+---
+
+## Medium
+
+### M1: Rate limit value for write endpoints is not stated
+
+**Story (Task 2.4, 3.3, 4.3):** “Enforce write rate limit using `enforceRateLimit` (use the same limit as `saves-create` unless Epic 2 docs specify otherwise).”
+
+**Reality:** The saves create handler uses “200 saves per hour” (see `backend/functions/saves/handler.ts`). The story defers to “same as saves-create” but does not state the value in the artifact.
+
+**Recommendation:** In Developer Context or Technical Requirements, state explicitly: “Write rate limit: same as saves-create (e.g. 200 saves per hour per user for create; use the same operation bucket or an equivalent for update/delete/restore so that a user cannot bypass the intent by mixing operations.” If the product decision is to share one bucket across all save writes, say so to avoid each handler using a different key and effectively multiplying the limit.
+
+---
+
+### M2: DELETE “best-effort” for already-deleted and timestamp behavior
+
+**Story (Technical Requirements):** “If item exists but already deleted → return 204 **without** changing timestamps (best-effort).”
+
+**Implementation:** The flow is conditional update (fails when `deletedAt` exists) → catch → getItem → if `deletedAt` set, return 204 **without** calling update. So timestamps are not changed. “Best-effort” might be read as “we might sometimes update timestamps”; the actual behavior is “we never update when already deleted.”
+
+**Recommendation:** Replace “best-effort” with: “Do not perform any write when the save is already soft-deleted; return 204 with no timestamp change.” This matches the described flow and avoids ambiguity.
+
+---
+
+### M3: Test list does not call out “wrong user” explicitly
+
+**Testing Requirements** cover 404 for “missing save” and (for PATCH) “soft-deleted save,” and 404 for “missing save” for RESTORE. AC5/AC6/AC12 also require 404 when the save exists but belongs to **another user** (per-user isolation).
+
+**Reality:** Because keys are `USER#<userId>`, a request with a valid `saveId` that belongs to another user will result in getItem/updateItem returning nothing or condition failure, and the handler should return 404. That is “not found” from the client’s perspective, but tests should lock in that **wrong user → 404**, not 403 or 200.
+
+**Recommendation:** In the “Required test scenarios” for PATCH, DELETE, and RESTORE, add: “404 when save exists but belongs to another user (wrong PK).” This keeps NFR-S4 and per-user isolation clearly validated by tests.
+
+---
+
+## Low / Clarifications
+
+### L1: `returnValues` for DELETE
+
+**Story:** DELETE returns 204 No Content. The shared `updateItem` defaults to `ReturnValues: "ALL_NEW"`. For DELETE, the handler does not need the updated item. Either pass `returnValues: "NONE"` to avoid reading attributes back, or leave default and ignore the return; both are correct. Stating “use returnValues: 'NONE' for DELETE” would make the intent explicit and slightly reduce read capacity.
+
+### L2: Event payload backward compatibility for `SaveRestored`
+
+**Current 3.1b:** `SaveRestored` is emitted with `url` and `contentType` in the detail. AC13 only requires `userId`, `saveId`, `urlHash`, `normalizedUrl`. Keeping `url` and `contentType` in `SaveRestored` (and in the type union) preserves backward compatibility for existing consumers; the story can note “existing SaveRestored payload remains valid; new fields must include at least …” so that 3.3’s restore handler does not drop fields that 3.1b already emits.
+
+### L3: Architecture enforcement tests (T2/T4) and new routes
+
+The adversarial architecture review (2026-02-20) found that route-completeness and lambda-route-wiring tests do not verify that the **correct** Lambda is wired to each route (F1, F3). Adding three new routes and three new Lambdas will increase the risk of wiring the wrong handler to a method. Task 7.2 says “Ensure architecture enforcement tests still pass”; the story does not require adding a test that asserts “PATCH /saves/{saveId} is integrated with savesUpdateFunction.” Consider a follow-up story or tech-debt item to strengthen T2/T4 so that new routes like these are covered by handler-ref → integration checks.
+
+---
+
+## Compliance Check (Story vs Codebase)
+
+| Item                                                                | Status                                   |
+| ------------------------------------------------------------------- | ---------------------------------------- |
+| `updateSaveSchema` exists and allows partial fields + at least one  | ✅                                       |
+| `updateItem` supports conditionExpression and returnValues          | ✅                                       |
+| `updateItem` throws NOT_FOUND on condition failure                  | ✅ (must be caught for DELETE/RESTORE)   |
+| `toPublicSave` strips PK, SK, deletedAt                             | ✅ (`backend/shared/db/src/saves.ts`)    |
+| `validatePathParams` + ULID schema used in saves-get                | ✅                                       |
+| `enforceRateLimit` in @ai-learning-hub/db                           | ✅                                       |
+| `emitEvent` fire-and-forget, SAVES_EVENT_SOURCE                     | ✅                                       |
+| SAVES_TABLE_CONFIG, requireEnv pattern                              | ✅                                       |
+| HandlerRef and ROUTE_REGISTRY extendible                            | ✅                                       |
+| SavesEventDetailType currently has SaveCreated \| SaveRestored only | ✅ (Story adds SaveUpdated, SaveDeleted) |
+
+---
+
+## Recommended Story Edits (concise)
+
+1. **ACs / Technical requirements:** Require that any 404 for a save returns `message: "Save not found"` and that handlers throw `AppError(ErrorCode.NOT_FOUND, "Save not found")` (do not let db “Item not found” propagate).
+2. **Task 3 (DELETE):** Add step: catch `AppError(ErrorCode.NOT_FOUND)` from conditional update; in catch, call `getItem`; if null → 404 with “Save not found”; if item has `deletedAt` → 204.
+3. **Task 4 (RESTORE):** Same pattern: catch NOT_FOUND, getItem, null → 404, no `deletedAt` → 200 with current save.
+4. **Task 1.1 (events):** Specify that detail types are a discriminated union; existing SaveCreated/SaveRestored payloads unchanged and still valid.
+5. **Task 5.4 / File structure:** Clarify CORS: ensure preflight on existing `{saveId}`; add preflight on new `restore` resource only.
+6. **Technical requirements:** State that empty PATCH body is invalid per `updateSaveSchema` (at least one field required).
+7. **Rate limit:** State the limit (e.g. same as saves-create, 200/hour) and whether update/delete/restore share the same bucket.
+8. **Testing:** Add “404 when save belongs to another user” for PATCH, DELETE, and RESTORE.
+9. **DELETE wording:** Replace “best-effort” with “Do not perform any write when already deleted.”
+
+---
+
+## Conclusion
+
+Story 3.3 is implementable with the current shared packages and patterns. The main risks are **AC-violating 404 messages** if the db helper’s NOT_FOUND is not replaced with “Save not found,” **confusion on conditional-update + getItem** (DELETE/RESTORE), and **event type breakage** if the new detail types are not introduced as a backward-compatible union. Applying the recommended edits and the test addition for “wrong user → 404” will reduce rework and keep behavior and tests aligned with the ACs and NFRs.

--- a/docs/adversarial-review-story-3-4-save-filtering-sorting.md
+++ b/docs/adversarial-review-story-3-4-save-filtering-sorting.md
@@ -1,0 +1,181 @@
+# Adversarial Review: Story 3.4 — Save Filtering & Sorting
+
+**Date:** 2026-02-23  
+**Artifact:** `_bmad-output/implementation-artifacts/3-4-save-filtering-sorting.md`  
+**Scope:** Story 3.4 acceptance criteria, tasks, technical requirements, alignment with Epic 3 intent, Epic 2/3.2 foundation, and project standards.
+
+---
+
+## Summary
+
+The story is well-scoped and builds correctly on Story 3.2’s list/get API and in-memory strategy. The review finds **one critical conflict** with the Epic 3 plan (nextToken behavior), **several high-impact gaps** (validation error message vs AC9, default order semantics, ADR-008 test requirement), and **medium/low clarifications** (missing linkedProjectCount handling, schema placement, optional truncated) that could cause rework or inconsistent behavior if unaddressed.
+
+---
+
+## Epic 3 Intent & Build-on-Epic-2 Check
+
+- **Epic 3 intent:** Story 3.4 delivers FR12 (filter by type), FR13 (filter by linkage), FR14 (search title/source), FR19 (sort by date/title/last accessed). The artifact’s ACs and Technical Requirements align with the epic and with `docs/progress/epic-3-stories-and-plan.md` Story 3.4.
+- **Builds on 3.2:** Correctly depends on `3-2-list-get-saves-api`; reuses `queryAllItems`, same ceiling (1000), same `GET /saves` handler; no new routes or Lambdas. In-memory filter/sort after fetch matches the epic’s “extends Story 3.2’s in-memory strategy.”
+- **Epic 2 / project standards:** Same auth (JWT or API key via existing middleware), same ADR-008 error shape, same route registry and CDK pattern (no infra change for 3.4). GET /saves remains read-only; no rate-limit change (consistent with 3.2). Architecture compliance table correctly references ADR-001, ADR-008, ADR-014, NFR-P2.
+
+---
+
+## Critical
+
+### C1: nextToken behavior contradicts Epic 3 plan (ignore vs 400)
+
+**Epic 3 source** (`docs/progress/epic-3-stories-and-plan.md`, Story 3.4 Technical Notes):
+
+> If `nextToken` references a save not present in the current filtered/sorted result set (e.g., client changed filters between paginated requests), the server **MUST ignore the token and return results from the beginning** (equivalent to no `nextToken`).
+
+**Artifact** (Task 2.4, Developer Context):
+
+> If nextToken resolves to an item not in the current filtered/sorted set, **treat as invalid and return 400** "nextToken is invalid or has expired — restart pagination" (defensive per epic plan).
+
+**Conflict:** The epic explicitly requires **ignore token and return from page 1**. The artifact requires **400 and “restart pagination”**. They are different behaviors: one is silent reset, the other is an error.
+
+**Impact:** Implementers following the artifact will violate the epic’s AC/technical note. Frontends that rely on “ignore and reset” (e.g. retry without nextToken) would instead receive 400 and need different handling.
+
+**Recommendation:** Align the artifact with the epic. Either:
+
+1. **Preferred:** Change Task 2.4 and Developer Context to: “If nextToken resolves to a saveId not in the current filtered/sorted list, **ignore nextToken** and return the first page (same as omitting nextToken). Do not return 400.” Update AC9/AC10 wording if any implied “invalid nextToken → 400” applies only to malformed/stale tokens (e.g. unparseable or pointing to a save that no longer exists in the **unfiltered** set), and document that “cursor not in filtered set” is handled by reset.
+2. **Alternative:** If the product decision is to return 400 for “cursor not in filtered set,” update the Epic 3 story and technical note to say so and drop “ignore the token.”
+
+Until this is resolved, the artifact and epic are inconsistent.
+
+---
+
+## High
+
+### H1: AC9 “valid options listed” vs default validation message
+
+**AC9:** Invalid filter or sort value → 400 `{ error: { code: 'VALIDATION_ERROR', message: '...', requestId } }` **with valid options listed**.
+
+**Current behavior:** `@ai-learning-hub/validation`’s `validate()` throws `AppError(ErrorCode.VALIDATION_ERROR, "Validation failed", { errors: details })` where `details` are Zod’s per-field messages. The top-level **message** is the generic `"Validation failed"`. Zod’s enum errors often put valid values in the per-field message (or in `details.errors[].message`), but the main `error.message` in the response does not necessarily “list valid options.”
+
+**Impact:** If clients or docs assume the main `message` lists options, they will not get that. If the story is satisfied by listing options in `error.details.errors`, the artifact should say so explicitly.
+
+**Recommendation:**
+
+1. In Task 1.3 and Technical Requirements, state either: (a) “The 400 response must list valid options **in the error message or in error.details**,” and/or (b) “For enum validation failures (contentType, linkStatus, sort, order), use a custom message that includes the valid values (e.g. `contentType must be one of: article, video, podcast, ...`) so that AC9 is satisfied in `error.message`.”
+2. In Task 3.1, add an explicit test: “Invalid contentType/linkStatus/sort returns 400; response body (message or details) includes the list of valid options.”
+
+---
+
+### H2: Default `order` when only `sort` is provided is underspecified
+
+**Artifact:** “Defaults: sort=createdAt, order=desc for date sorts and order=asc for title.”
+
+**Gap:** When the client sends `sort=title` but omits `order`, the default must be `asc`. When the client sends `sort=createdAt` and omits `order`, the default must be `desc`. Zod’s `.default()` is per-field and cannot express “default order depending on sort.” The artifact does not say where this conditional default is applied (schema refinement, transform, or handler logic).
+
+**Recommendation:** In Task 1.1 or Dev Notes, add: “Apply default for `order` in the handler after parsing: if `order` is undefined, set order to `'desc'` when sort is `createdAt` or `lastAccessedAt`, and to `'asc'` when sort is `title`.” Optionally add a schema refinement that sets order from sort when order is missing, and document it so tests can assert the default behavior.
+
+---
+
+### H3: ADR-008 error path tests not explicitly required
+
+**Project standard (Story 2.1-D5, AC12):** Every handler test file in `backend/functions/**` must include at least one error path test using `assertADR008Error`.
+
+**Artifact (Task 3.1):** Requires tests for “invalid contentType/linkStatus/sort → 400 with valid options” but does not mention `assertADR008Error` or “ADR-008 body shape.”
+
+**Impact:** Implementers might add 400 tests that only assert status and message and omit the shared ADR-008 assertion, weakening consistency with other handlers.
+
+**Recommendation:** In Task 3.1 or Testing Requirements, add: “For all 400 validation error paths, use `assertADR008Error(result, ErrorCode.VALIDATION_ERROR, 400)` from `backend/test-utils` so that ADR-008 compliance is asserted.”
+
+---
+
+## Medium
+
+### M1: Missing `linkedProjectCount` for old or partial items
+
+**Artifact:** linkStatus filter uses `linkedProjectCount > 0` (linked) and `linkedProjectCount === 0` (unlinked). Save type has `linkedProjectCount: number` (no `?`).
+
+**Reality:** Older items or partial writes might lack the attribute; in JS/TS that becomes `undefined`. Using `item.linkedProjectCount === 0` would treat missing as “not 0” and exclude the item from `linkStatus=unlinked`.
+
+**Recommendation:** In Task 2.2 or Dev Notes, state: “Treat missing `linkedProjectCount` as 0: use `(item.linkedProjectCount ?? 0) > 0` for linked and `(item.linkedProjectCount ?? 0) === 0` for unlinked.”
+
+---
+
+### M2: Schema location: handler-inline vs shared package
+
+**Artifact:** “Optional: new schema in `backend/shared/validation/src/schemas.ts` (e.g. `listSavesQuerySchema`) and export from index.”
+
+**Current 3.2:** `saves-list/handler.ts` defines `listQuerySchema` inline (limit, nextToken only). The artifact leaves open whether 3.4 extends that inline schema or adds a shared `listSavesQuerySchema`.
+
+**Impact:** If the list query schema stays handler-inline, other callers (e.g. future BFF or tests) cannot reuse it. If it moves to validation, the handler must be updated to import it and the artifact should say “add” not “optional.”
+
+**Recommendation:** Decide and document: “Use a single list query schema (either extend the inline schema in the handler with the new params, or add `listSavesQuerySchema` in `@ai-learning-hub/validation` and use it in the handler). If added to validation, export from the package index and reference it in File Structure Requirements.”
+
+---
+
+### M3: `truncated` optional and omission when false
+
+**Artifact:** Response shape “`truncated?: boolean`” and “`truncated: true` only when … capped at 1000.”
+
+**Clarification:** When the user has ≤1000 saves (or the filtered set is from a truncated fetch but we still don’t hit ceiling), the artifact implies we may omit `truncated` or set it to false. Story 3.2’s TODO says “expose truncated in response” when truncated; it does not require sending `truncated: false` when not truncated.
+
+**Recommendation:** One sentence in Technical Requirements or Dev Notes: “Include `truncated` in the response only when `truncated === true` (i.e. `...(truncated && { truncated: true })`); omit when not truncated so clients can treat absence as false.” This matches “truncated: true only when…” and keeps the contract clear.
+
+---
+
+## Low / Clarifications
+
+### L1: Search on empty or missing `title`
+
+**AC4:** “title or url contains” (case-insensitive). Save has `title?: string` and `url: string`.
+
+**Recommendation:** In Task 2.2, explicitly state: “For search, match when the search string is included in `(item.title ?? '')` or `item.url` (case-insensitive).” This avoids ambiguity for missing title.
+
+---
+
+### L2: Sort stability for ties
+
+**Artifact:** Sort by createdAt, lastAccessedAt, or title; null/empty lastAccessedAt or title “sort to bottom.”
+
+**Clarification:** For ties (e.g. same createdAt), the artifact does not require a secondary sort. Determinism helps pagination and testing.
+
+**Recommendation:** Optional: “For tie-breaking when sort key values are equal, use saveId (e.g. ascending) so order is deterministic.” Can be deferred if not required by AC.
+
+---
+
+### L3: Test “nextToken invalid or not in filtered set”
+
+**Artifact (Task 3.1):** “nextToken invalid or not in filtered set → 400.”
+
+**Conflict with C1:** If the artifact is updated to “ignore nextToken when cursor not in filtered set” (per epic), this test should become: “nextToken that decodes to a valid ULID but whose saveId is not in the current filtered/sorted list → first page returned (no 400).” Only **malformed** nextToken (unparseable or invalid ULID) would still yield 400. Task 3.1 should be updated to match the chosen nextToken behavior.
+
+---
+
+## Compliance Check (Artifact vs Standards)
+
+| Item                                                             | Status               |
+| ---------------------------------------------------------------- | -------------------- |
+| Epic 3 FR12, FR13, FR14, FR19 covered by ACs                     | ✅                   |
+| Builds on 3.2 only; no new routes/Lambdas                        | ✅                   |
+| ADR-001 (keys), ADR-008 (errors), ADR-014 (API-first) referenced | ✅                   |
+| NFR-P2 (warm &lt; 1s) acknowledged                               | ✅                   |
+| Same GET /saves, queryAllItems, ceiling 1000                     | ✅                   |
+| contentTypeSchema (validation) for filter                        | ✅                   |
+| Save entity: linkedProjectCount, lastAccessedAt, title, url      | ✅                   |
+| nextToken semantics vs epic plan                                 | ❌ Conflict (C1)     |
+| AC9 “valid options listed” vs default validation message         | ⚠️ Unclear (H1)      |
+| assertADR008Error in handler tests                               | ⚠️ Not required (H3) |
+
+---
+
+## Recommended Story Edits (Concise)
+
+1. **nextToken (C1):** Align with epic: either require “ignore nextToken when cursor not in filtered set and return first page” and update Task 2.4 and Developer Context, or change the epic to “return 400” and document the decision. Update Task 3.1/L3 accordingly.
+2. **AC9 (H1):** Require that 400 for invalid enum params list valid options in `error.message` or in `error.details`, and add a test that asserts the response body contains valid options.
+3. **Default order (H2):** Document that the handler sets default `order` from `sort` when `order` is omitted (desc for date sorts, asc for title).
+4. **Tests (H3):** Require `assertADR008Error(result, ErrorCode.VALIDATION_ERROR, 400)` for validation error paths in saves-list handler tests.
+5. **linkedProjectCount (M1):** Use `(item.linkedProjectCount ?? 0)` for linkStatus filter.
+6. **Schema (M2):** Decide inline vs shared `listSavesQuerySchema` and state it in the artifact.
+7. **truncated (M3):** State that `truncated` is included only when true.
+8. **Search (L1):** Use `(item.title ?? '')` for search on title.
+
+---
+
+## Conclusion
+
+Story 3.4’s scope, dependency on 3.2, and use of project standards (ADRs, shared packages, GET-only extension) are sound. The main fix is **resolving the nextToken conflict with the Epic 3 plan** (ignore vs 400). Addressing AC9 messaging, default order semantics, ADR-008 test requirement, and the medium/low items will keep implementation and tests aligned with the epic and with existing project conventions.

--- a/docs/progress/epic-3-1-stories-and-plan.md
+++ b/docs/progress/epic-3-1-stories-and-plan.md
@@ -1,0 +1,238 @@
+# Epic 3.1: Tech Debt — Saves Domain DRY Consolidation
+
+**Date:** 2026-02-23
+**Source:** Post-implementation audit of Epic 3 stories 3.1a–3.4 (6 handlers, 6 test files, 3 shared packages)
+**NFRs:** NFR-M1 (Maintainability), NFR-R7 (Reliability — toPublicSave divergence)
+
+---
+
+## Epic Goal
+
+Eliminate cross-handler code duplication introduced during Epic 3 implementation, extract shared utilities, standardize test scaffolding, and introduce a pipeline-level deduplication scan agent that prevents future duplication before code reaches the adversarial reviewer.
+
+**User Outcome:** Codebase is DRY across all saves handlers. Future stories automatically get flagged for duplication before review. Developer velocity improves through shared test factories and mock helpers.
+
+---
+
+## Audit Findings That Motivate This Epic
+
+| #   | Finding                                                                                                 | Occurrences  | Risk                             |
+| --- | ------------------------------------------------------------------------------------------------------- | ------------ | -------------------------------- |
+| 1   | `saveIdPathSchema` defined identically in 4 handlers                                                    | 4 files      | Policy drift                     |
+| 2   | `saves/handler.ts` has local `SAVES_TABLE_CONFIG`, `toPublicSave`, `SaveItem` instead of shared imports | 1 file       | `deletedAt` leak in 409 response |
+| 3   | EventBridge init boilerplate identical in 4 handlers                                                    | 4 files      | Policy drift                     |
+| 4   | Rate limit config object identical in 4 handlers                                                        | 4 files      | Policy drift                     |
+| 5   | `AppError.isAppError()` vs manual `instanceof` check — inconsistent                                     | 3 files      | Code clarity                     |
+| 6   | 409 duplicate response built twice within `saves/handler.ts`                                            | 2 locations  | Internal duplication             |
+| 7   | `createSaveItem` test factory — 5 near-identical copies                                                 | 5 test files | Maintenance burden               |
+| 8   | Events mock block identical in 4 test files                                                             | 4 test files | Maintenance burden               |
+| 9   | DB mock blocks with heavy overlap in 6 test files                                                       | 6 test files | Maintenance burden               |
+| 10  | `VALID_SAVE_ID` constant repeated in 4 test files                                                       | 4 test files | Trivial duplication              |
+| 11  | `assertADR008Error` used in only 1 of 6 test files                                                      | 5 test files | Inconsistent error assertions    |
+| 12  | Response wrapping approach inconsistent (3 patterns)                                                    | 6 handlers   | Convention unclear               |
+
+---
+
+## Story Dependency Order
+
+```
+3.1.1 Shared Schemas & Constants  ──►  3.1.2 Test Utilities  ──►  3.1.3 Handler Consolidation
+                                                                          │
+                                                                          ▼
+                                                              3.1.4 Dedup Scan Agent & Pipeline
+```
+
+- **3.1.1** extracts shared code that 3.1.2 and 3.1.3 depend on
+- **3.1.2** creates test utilities that 3.1.3 uses when updating test files
+- **3.1.3** retrofits all handlers and tests to use shared code from 3.1.1 + 3.1.2
+- **3.1.4** adds the pipeline agent (can be done after 3.1.3 proves the patterns work)
+
+---
+
+## Story 3.1.1: Extract Shared Schemas & Constants
+
+**Goal:** Move duplicated schemas, constants, and helpers from individual handlers into shared packages.
+
+### Acceptance Criteria
+
+| #   | Given                                                                                                    | When                                                            | Then                                                                                                                  |
+| --- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| AC1 | `saveIdPathSchema` defined locally in 4 handlers                                                         | Schema extracted to `@ai-learning-hub/validation`               | All 4 handlers import from shared package; no local `saveIdPathSchema` definitions remain                             |
+| AC2 | Rate limit config `{ operation: "saves-write", limit: 200, windowSeconds: 3600 }` repeated in 4 handlers | Config extracted to `@ai-learning-hub/db/saves`                 | All 4 handlers import `SAVES_WRITE_RATE_LIMIT` constant; no inline rate limit config objects remain                   |
+| AC3 | EventBridge init boilerplate repeated in 4 handlers                                                      | Helper `requireEventBus()` created in `@ai-learning-hub/events` | All 4 handlers call `requireEventBus()` instead of inline `process.env.EVENT_BUS_NAME` + guard + `getDefaultClient()` |
+| AC4 | All existing tests pass                                                                                  | After all extractions                                           | `npm test` passes with 0 failures; no behavioral changes                                                              |
+
+### Tasks / Subtasks
+
+- [ ] Task 1: Extract `saveIdPathSchema` (AC: #1)
+  - [ ] 1.1 Add `saveIdPathSchema` to `backend/shared/validation/src/schemas.ts`
+  - [ ] 1.2 Export from `backend/shared/validation/src/index.ts`
+  - [ ] 1.3 Rebuild validation package: `npm run -w @ai-learning-hub/validation build`
+  - [ ] 1.4 Update imports in `saves-get`, `saves-update`, `saves-delete`, `saves-restore` handlers
+  - [ ] 1.5 Remove local `saveIdPathSchema` definitions from all 4 handlers
+- [ ] Task 2: Extract rate limit constant (AC: #2)
+  - [ ] 2.1 Add `SAVES_WRITE_RATE_LIMIT` to `backend/shared/db/src/saves.ts`
+  - [ ] 2.2 Export from `backend/shared/db/src/index.ts`
+  - [ ] 2.3 Update all 4 write handlers to use the constant
+- [ ] Task 3: Extract EventBridge init helper (AC: #3)
+  - [ ] 3.1 Add `requireEventBus()` function to `backend/shared/events/src/index.ts` (or appropriate module)
+  - [ ] 3.2 Update all 4 event-emitting handlers to use `requireEventBus()`
+  - [ ] 3.3 Remove inline `EVENT_BUS_NAME` + guard + `getDefaultEBClient()` boilerplate
+- [ ] Task 4: Verify all tests pass (AC: #4)
+  - [ ] 4.1 Run `npm test` — all tests must pass
+  - [ ] 4.2 Run `npm run type-check` — clean
+
+---
+
+## Story 3.1.2: Shared Test Utilities for Saves Domain
+
+**Goal:** Extract duplicated test factories, mock helpers, and assertion utilities into `backend/test-utils/` so all saves test files share common scaffolding.
+
+### Acceptance Criteria
+
+| #   | Given                                                                  | When                                                               | Then                                                                                                                                                             |
+| --- | ---------------------------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC1 | `createSaveItem` factory defined in 5 test files with minor variations | Factory extracted to `backend/test-utils/save-factories.ts`        | Single `createTestSaveItem(saveId?, overrides?)` function; all 5 test files import it                                                                            |
+| AC2 | Events mock block identical in 4 test files                            | Mock factory extracted to `backend/test-utils/mock-events.ts`      | `mockEventsModule()` function (matching `mockMiddlewareModule()` pattern); all 4 test files use it                                                               |
+| AC3 | DB mock blocks with heavy overlap across 6 test files                  | Composable mock factory created in `backend/test-utils/mock-db.ts` | `mockDbModule(mockFns)` function providing `SAVES_TABLE_CONFIG`, `USERS_TABLE_CONFIG`, `toPublicSave`, `requireEnv`, `getDefaultClient` with override capability |
+| AC4 | `VALID_SAVE_ID` constant defined in 4 test files                       | Constant extracted to `backend/test-utils/save-factories.ts`       | Single export; all 4 test files import it                                                                                                                        |
+| AC5 | `assertADR008Error` used in only 1 of 6 test files                     | All error assertion sites updated                                  | All 6 test files use `assertADR008Error` for error response validation where applicable                                                                          |
+| AC6 | All existing tests pass                                                | After all extractions                                              | `npm test` passes with 0 failures; no behavioral changes                                                                                                         |
+
+### Tasks / Subtasks
+
+- [ ] Task 1: Create `backend/test-utils/save-factories.ts` (AC: #1, #4)
+  - [ ] 1.1 Implement `createTestSaveItem(saveId?, overrides?)` with sensible defaults
+  - [ ] 1.2 Export `VALID_SAVE_ID` constant
+  - [ ] 1.3 Export from `backend/test-utils/index.ts`
+- [ ] Task 2: Create `backend/test-utils/mock-events.ts` (AC: #2)
+  - [ ] 2.1 Implement `mockEventsModule()` returning mock `emitEvent`, `getDefaultClient`, `SAVES_EVENT_SOURCE`
+  - [ ] 2.2 Export from `backend/test-utils/index.ts`
+- [ ] Task 3: Create `backend/test-utils/mock-db.ts` (AC: #3)
+  - [ ] 3.1 Implement `mockDbModule(mockFns)` with standard table configs, `toPublicSave`, `requireEnv`
+  - [ ] 3.2 Export from `backend/test-utils/index.ts`
+- [ ] Task 4: Verify test infrastructure works (AC: #6)
+  - [ ] 4.1 Update one test file (e.g., `saves-get`) as proof-of-concept
+  - [ ] 4.2 Run tests to confirm no regressions
+
+---
+
+## Story 3.1.3: Handler & Test Consolidation
+
+**Goal:** Retrofit all 6 saves handlers and their test files to use shared code from stories 3.1.1 and 3.1.2. Fix the `saves/handler.ts` divergence and standardize patterns.
+
+### Acceptance Criteria
+
+| #   | Given                                                                                         | When                                           | Then                                                                                                                                                      |
+| --- | --------------------------------------------------------------------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC1 | `saves/handler.ts` defines local `SAVES_TABLE_CONFIG`, `SaveItem`, `toPublicSave`             | Handler retrofitted to use shared packages     | Imports `SAVES_TABLE_CONFIG`, `toPublicSave` from `@ai-learning-hub/db`; imports `SaveItem` from `@ai-learning-hub/types`; no local definitions remain    |
+| AC2 | Local `toPublicSave` in `saves/handler.ts` does not strip `deletedAt`                         | Shared `toPublicSave` used everywhere          | `deletedAt` is stripped from all API responses including 409 `existingSave`                                                                               |
+| AC3 | 409 duplicate response built twice within `saves/handler.ts`                                  | Extracted to local helper                      | Single `createDuplicateResponse(existingSave, requestId)` function; both call sites use it                                                                |
+| AC4 | `AppError.isAppError()` not used consistently                                                 | All handlers use `AppError.isAppError()`       | No manual `instanceof Error && "code" in error` checks remain in any saves handler                                                                        |
+| AC5 | `saves-update` and `saves-restore` use unnecessary explicit `createSuccessResponse()` for 200 | Standardized to auto-wrap pattern              | Both handlers return plain data objects for 200 responses (like `saves-get` and `saves-list`); `createSuccessResponse` only used for non-200 status codes |
+| AC6 | All 6 test files have duplicated factory/mock/assertion code                                  | All test files use shared utilities from 3.1.2 | Each test file imports `createTestSaveItem`, `mockEventsModule`, `mockDbModule`, `VALID_SAVE_ID`, `assertADR008Error` from `backend/test-utils/`          |
+| AC7 | All existing tests pass                                                                       | After all changes                              | `npm test` passes with 0 failures; no behavioral changes                                                                                                  |
+| AC8 | No local schema definitions remain                                                            | After cleanup                                  | `grep -r "saveIdPathSchema" backend/functions/` returns only import statements, no `const saveIdPathSchema` or `z.object` definitions                     |
+
+### Tasks / Subtasks
+
+- [ ] Task 1: Retrofit `saves/handler.ts` (AC: #1, #2, #3)
+  - [ ] 1.1 Replace local `SAVES_TABLE_CONFIG` with import from `@ai-learning-hub/db`
+  - [ ] 1.2 Replace local `SaveItem` interface with import from `@ai-learning-hub/types`
+  - [ ] 1.3 Replace local `toPublicSave` with import from `@ai-learning-hub/db`
+  - [ ] 1.4 Extract 409 response into `createDuplicateResponse()` local helper
+  - [ ] 1.5 Verify `deletedAt` is stripped in all response paths
+- [ ] Task 2: Standardize `AppError` usage (AC: #4)
+  - [ ] 2.1 Update `saves-update/handler.ts` to use `AppError.isAppError()`
+  - [ ] 2.2 Update `saves-delete/handler.ts` to use `AppError.isAppError()`
+  - [ ] 2.3 Update `saves-restore/handler.ts` to use `AppError.isAppError()`
+- [ ] Task 3: Standardize response wrapping (AC: #5)
+  - [ ] 3.1 Update `saves-update/handler.ts` to return plain data object for 200
+  - [ ] 3.2 Update `saves-restore/handler.ts` to return plain data object for 200
+- [ ] Task 4: Update all 6 test files to use shared utilities (AC: #6)
+  - [ ] 4.1 Update `saves/handler.test.ts`
+  - [ ] 4.2 Update `saves-get/handler.test.ts`
+  - [ ] 4.3 Update `saves-list/handler.test.ts`
+  - [ ] 4.4 Update `saves-update/handler.test.ts`
+  - [ ] 4.5 Update `saves-delete/handler.test.ts`
+  - [ ] 4.6 Update `saves-restore/handler.test.ts`
+- [ ] Task 5: Verify everything (AC: #7, #8)
+  - [ ] 5.1 Run `npm test` — all tests pass
+  - [ ] 5.2 Run `npm run type-check` — clean
+  - [ ] 5.3 Run `grep -r "saveIdPathSchema" backend/functions/` — only import statements
+  - [ ] 5.4 Run `grep -r "const SAVES_TABLE_CONFIG" backend/functions/` — no matches
+
+---
+
+## Story 3.1.4: Deduplication Scan Agent & Pipeline Integration
+
+**Goal:** Create a new `epic-dedup-scanner` agent that runs BEFORE the adversarial reviewer in the orchestrator pipeline. The scanner reads all handlers in the same domain (not just the branch diff) to detect cross-handler duplication. It has its own 2-round fix loop and must pass (0 findings at Important+) before the code proceeds to the reviewer.
+
+### Acceptance Criteria
+
+| #   | Given                                    | When                                                                                       | Then                                                                                                                                                                                                                                                                      |
+| --- | ---------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC1 | New agent definition created             | `.claude/agents/epic-dedup-scanner.md` exists                                              | Agent has read-only tools (Read, Glob, Grep, Bash, Write), fresh context, scoped to cross-handler duplication detection                                                                                                                                                   |
+| AC2 | New fixer agent created                  | `.claude/agents/epic-dedup-fixer.md` exists                                                | Agent has full edit tools, guided by dedup findings document                                                                                                                                                                                                              |
+| AC3 | Orchestrator pipeline updated            | Step 2.3b "Dedup Scan Loop" added between quality gates (2.2) and adversarial review (2.4) | Dedup scan runs with max 2 rounds; gate requires 0 Important+ findings before proceeding to reviewer                                                                                                                                                                      |
+| AC4 | Supporting protocol doc created          | `.claude/skills/epic-orchestrator/dedup-scan-loop.md` exists                               | Documents the 2-round loop, scanner prompt template, fixer prompt template, gate criteria, and dry-run behavior                                                                                                                                                           |
+| AC5 | Scanner checks for specific patterns     | When scanner runs                                                                          | It reads ALL handler files in the same domain directory (e.g., all `backend/functions/saves-*`), not just the branch diff, and flags: duplicate schema definitions, duplicate constants, duplicate helper functions, code that should use existing shared package exports |
+| AC6 | Scanner output follows structured format | When scanner writes findings                                                               | Output uses `Critical/Important/Minor` format matching the reviewer's findings format so the orchestrator can parse it identically                                                                                                                                        |
+| AC7 | Pipeline gate enforced                   | When dedup scan has Important+ findings after 2 rounds                                     | Orchestrator escalates to human (same pattern as reviewer round 3 escalation)                                                                                                                                                                                             |
+| AC8 | Reviewer remains unchanged               | After pipeline integration                                                                 | `epic-reviewer.md` agent definition is not modified; reviewer continues to operate on branch diff with fresh context                                                                                                                                                      |
+
+### Tasks / Subtasks
+
+- [ ] Task 1: Create `epic-dedup-scanner` agent (AC: #1, #5, #6)
+  - [ ] 1.1 Create `.claude/agents/epic-dedup-scanner.md` with agent definition
+  - [ ] 1.2 Define scanner methodology: read all same-domain handlers, compare patterns, check shared package usage
+  - [ ] 1.3 Define structured findings output format (matching reviewer format)
+- [ ] Task 2: Create `epic-dedup-fixer` agent (AC: #2)
+  - [ ] 2.1 Create `.claude/agents/epic-dedup-fixer.md` with agent definition
+  - [ ] 2.2 Define fixer methodology: read findings, extract to shared packages, update imports, run tests
+- [ ] Task 3: Create pipeline protocol doc (AC: #4)
+  - [ ] 3.1 Create `.claude/skills/epic-orchestrator/dedup-scan-loop.md`
+  - [ ] 3.2 Document 2-round loop protocol (scan → fix → scan → gate)
+  - [ ] 3.3 Document scanner prompt template with domain discovery
+  - [ ] 3.4 Document fixer prompt template
+  - [ ] 3.5 Document gate criteria and escalation path
+  - [ ] 3.6 Document dry-run behavior
+- [ ] Task 4: Update orchestrator pipeline (AC: #3, #7, #8)
+  - [ ] 4.1 Add Step 2.3b to `.claude/skills/epic-orchestrator/SKILL.md` between existing 2.3 and 2.4
+  - [ ] 4.2 Reference `dedup-scan-loop.md` for full protocol
+  - [ ] 4.3 Define gate: 0 Important+ findings required to proceed to 2.4
+  - [ ] 4.4 Define escalation: same pattern as reviewer round 3 (human chooses fix/accept/override)
+  - [ ] 4.5 Verify `epic-reviewer.md` is NOT modified
+
+### Dev Notes
+
+**Domain discovery logic for the scanner:**
+
+The scanner needs to know which "domain" the current story belongs to, so it can read all sibling handlers. The orchestrator should pass the domain directory pattern based on the story's `touches` field. For example:
+
+- Story touches `backend/functions/saves-update/handler.ts` → domain pattern = `backend/functions/saves*/handler.ts`
+- Story touches `backend/functions/auth/handler.ts` → domain pattern = `backend/functions/auth*/handler.ts`
+
+The scanner then reads ALL files matching the domain pattern, plus the relevant shared packages, to detect duplication.
+
+**Relationship to the reviewer:**
+
+```
+Quality Gates (2.2) → Dedup Scan Loop (2.3b) → Mark for Review (2.3) → Adversarial Review (2.4)
+                       ↕                                                  ↕
+                    epic-dedup-scanner (reads all handlers)           epic-reviewer (reads branch diff)
+                    epic-dedup-fixer (extracts to shared)             epic-fixer (fixes findings)
+                       max 2 rounds                                      max 3 rounds
+```
+
+The dedup scan catches structural/DRY issues. The reviewer catches correctness/security/test issues. Neither overlaps with the other's scope.
+
+---
+
+## Project Context Reference
+
+- Audit source: Cross-handler duplication analysis of Epic 3 (stories 3.1a–3.4)
+- Architecture: `_bmad-output/planning-artifacts/architecture.md`
+- Epic orchestrator: `.claude/skills/epic-orchestrator/SKILL.md`
+- Review loop: `.claude/skills/epic-orchestrator/review-loop.md`
+- Existing agents: `.claude/agents/epic-reviewer.md`, `.claude/agents/epic-fixer.md`

--- a/docs/progress/epic-3-auto-run.md
+++ b/docs/progress/epic-3-auto-run.md
@@ -1,9 +1,9 @@
 ---
 epic_id: Epic-3
 status: in-progress
-scope: ["3.1a", "3.1c", "3.1b", "3.2", "3.3"]
+scope: ["3.1a", "3.1c", "3.1b", "3.2", "3.3", "3.4"]
 started: "2026-02-19T16:50:32Z"
-last_updated: "2026-02-23T13:10:00Z"
+last_updated: "2026-02-23T18:35:00Z"
 stories:
   "3.1a":
     status: done
@@ -51,6 +51,17 @@ stories:
     startedAt: "2026-02-23T02:29:10Z"
     completedAt: "2026-02-23T13:10:00Z"
     duration: "~11h"
+  "3.4":
+    status: done
+    issue: 189
+    pr: 190
+    branch: story-3-4-save-filtering-sorting
+    commit: 19ebc832fbd4c1fb5ea79407abd32727c2074cd7
+    coverage: 100
+    review_rounds: 2
+    startedAt: "2026-02-23T18:00:00Z"
+    completedAt: "2026-02-23T18:35:00Z"
+    duration: "35m"
 ---
 
 <!-- Human-readable display below (generated from frontmatter) -->
@@ -64,6 +75,7 @@ stories:
 | 3.1b  | ✅ Complete | #182 | -        | 1             | 41m      |
 | 3.2   | ✅ Complete | #186 | -        | 1             | ~3.5h    |
 | 3.3   | ✅ Complete | #188 | -        | 2             | ~11h     |
+| 3.4   | ✅ Complete | #190 | 100%     | 2             | 35m      |
 
 ## Activity Log
 
@@ -108,3 +120,12 @@ stories:
 - [09:00] Story 3.3: PR #188 created, CI type-check failure (optional chaining)
 - [09:30] Story 3.3: Fix pushed, CI all green (7/7 checks passed)
 - [10:00] Story 3.3: PR #188 squash-merged to main, story complete
+- [00:00] Story 3.4: Added to scope, Issue #189 created, branch story-3-4-save-filtering-sorting created
+- [00:01] Story 3.4: Implementation starting
+- [00:10] Story 3.4: Implementation complete (handler + schema + 36 tests)
+- [00:12] Story 3.4: Quality gates passed (lint, type-check, 329 tests, CDK synth skipped)
+- [00:15] Story 3.4: Review Round 1 — 0 Critical, 4 Important (test coverage gaps)
+- [00:20] Story 3.4: Round 1 fixes applied (6/8 findings addressed, 40 tests total)
+- [00:25] Story 3.4: Review Round 2 — APPROVE (0 Critical, 0 Important, 3 Minor)
+- [00:28] Story 3.4: PR #190 created, CI all green (14/14 checks passed)
+- [00:35] Story 3.4: Marked done

--- a/docs/progress/epic-3-completion-report.md
+++ b/docs/progress/epic-3-completion-report.md
@@ -2,8 +2,8 @@
 
 **Status:** Partial
 **Duration:** ongoing
-**Stories Completed:** 2/TBD
-**Date:** 2026-02-22
+**Stories Completed:** 6/TBD
+**Date:** 2026-02-23
 
 ## Story Summary
 
@@ -11,13 +11,17 @@
 | ----- | ---------------------------------------------------- | ----------- | ---- | -------- | ------------- | -------------- | -------- |
 | 3.1a  | Save Validation & Content Detection Modules          | ✅ Complete | #156 | -        | -             | -              | 51m      |
 | 3.1c  | EventBridge Shared Package (@ai-learning-hub/events) | ✅ Complete | #177 | 97%      | 2             | 2              | 32m      |
+| 3.1b  | Create Save API                                      | ✅ Complete | #182 | -        | 1             | 7              | 41m      |
+| 3.2   | List & Get Saves API                                 | ✅ Complete | #186 | -        | 1             | 3              | ~3.5h    |
+| 3.3   | Update, Delete & Restore Saves API                   | ✅ Complete | #188 | -        | 2             | 9              | ~11h     |
+| 3.4   | Save Filtering & Sorting                             | ✅ Complete | #190 | 100%     | 2             | 6              | 35m      |
 
 ## Metrics
 
-- **Average story time:** 42m
+- **Average story time:** ~2.8h (excluding outlier 3.3)
 - **Test pass rate:** 100%
-- **Review convergence:** 2 rounds average
-- **Common issue categories:** Missing config wiring (tsconfig path alias), debuggability improvements (error stack traces)
+- **Review convergence:** 1.7 rounds average
+- **Common issue categories:** Test coverage gaps (edge cases), type safety, null/empty handling
 
 ## Blockers
 
@@ -25,6 +29,6 @@ None
 
 ## Next Steps
 
-- [ ] Continue with remaining Epic 3 stories (3.1b, 3.2, etc.)
+- [ ] Review and merge open PRs: #190
 - [ ] Run full integration test suite
 - [ ] Update sprint status


### PR DESCRIPTION
## Summary
- Cross-cutting code audit identified 16 duplication findings across all 6 Epic 3 saves handlers
- Created Epic 3.1 (Tech Debt) with 4 stories in dependency order to address them systematically
- Ran adversarial reviews on all 4 stories and triaged findings (accepted 14, rejected 12)
- Includes Epic 3 story artifacts (3.3, 3.4) and review findings from all code review rounds

## Changes

### Epic 3.1 story artifacts (new)
- `3-1-1-extract-shared-schemas-constants.md` — Extract `saveIdPathSchema`, rate limit, EventBridge helper to shared packages
- `3-1-2-shared-test-utilities.md` — Create `createTestSaveItem`, `mockEventsModule()`, `mockDbModule()` in test-utils
- `3-1-3-handler-test-consolidation.md` — Retrofit all 6 handlers + tests to use shared code
- `3-1-4-dedup-scan-agent-pipeline.md` — New `epic-dedup-scanner` + `epic-dedup-fixer` agents, 2-round loop before reviewer

### Adversarial reviews (new)
- Reviews for all 4 Epic 3.1 stories + Stories 3.3 and 3.4

### Epic 3 wrap-up (updated)
- `sprint-status.yaml` — Stories 3.2–3.4 marked done, Epic 3.1 stories added
- `epic-3-auto-run.md` — Story 3.4 completion recorded
- `epic-3-completion-report.md` — All 6 stories reflected with updated metrics

### Review findings (new)
- Code review findings from Stories 3.1b, 3.2, 3.3, 3.4

## Test plan
- [x] No production code changes — documentation and planning only
- [x] All story artifacts follow established format (YAML frontmatter, Given/When/Then ACs, tasks, dev notes)
- [x] Adversarial review findings triaged and applied to story files

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)