### PR TITLE
feat: dedup scan agent & pipeline integration (Story 3.1.4)

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -24,21 +24,32 @@ Need autonomous epic implementation?   → Run /bmad-bmm-auto-epic (spawns subag
 
 These live in `.claude/agents/` and are spawned by the epic orchestrator or manually via the `Task` tool:
 
-| Subagent        | File               | Purpose                                                                                   | Tools                                                                                  | Spawned By                    |
-| --------------- | ------------------ | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ----------------------------- |
-| `epic-reviewer` | `epic-reviewer.md` | Fresh-context adversarial code review. Reads branch diff, writes structured findings doc. | Read, Glob, Grep, Bash, Write (no Edit -- can write findings but cannot modify source) | Epic orchestrator review loop |
-| `epic-fixer`    | `epic-fixer.md`    | Fixes issues from a findings document. Full edit access, commits fixes locally.           | Read, Glob, Grep, Bash, Write, Edit                                                    | Epic orchestrator review loop |
+| Subagent             | File                    | Purpose                                                                                     | Tools                                                                                  | Spawned By                        |
+| -------------------- | ----------------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | --------------------------------- |
+| `epic-reviewer`      | `epic-reviewer.md`      | Fresh-context adversarial code review. Reads branch diff, writes structured findings doc.   | Read, Glob, Grep, Bash, Write (no Edit -- can write findings but cannot modify source) | Epic orchestrator review loop     |
+| `epic-fixer`         | `epic-fixer.md`         | Fixes issues from a findings document. Full edit access, commits fixes locally.             | Read, Glob, Grep, Bash, Write, Edit                                                    | Epic orchestrator review loop     |
+| `epic-dedup-scanner` | `epic-dedup-scanner.md` | Fresh-context dedup scanner. Reads ALL domain handlers to detect cross-handler duplication. | Read, Glob, Grep, Bash, Write (no Edit -- writes findings but cannot modify source)    | Epic orchestrator dedup scan loop |
+| `epic-dedup-fixer`   | `epic-dedup-fixer.md`   | Fixes dedup findings by extracting duplicated code to shared packages. Full edit access.    | Read, Glob, Grep, Bash, Write, Edit                                                    | Epic orchestrator dedup scan loop |
 
 ### How the Orchestrator Uses Subagents
 
-The epic orchestrator (`/bmad-bmm-auto-epic`) runs a **review loop** after each story implementation:
+The epic orchestrator (`/bmad-bmm-auto-epic`) runs two scan/fix loops after each story implementation:
+
+**Dedup Scan Loop (Step 2.3b)** — catches cross-handler code duplication:
+
+1. Spawns `epic-dedup-scanner` (fresh context) to read ALL domain handlers and detect duplication
+2. Scanner writes a findings doc with Critical/Important/Minor categories
+3. If MUST-FIX findings exist, spawns `epic-dedup-fixer` to extract code to shared packages
+4. Repeats (up to 2 rounds) until clean or escalates to human
+
+**Review Loop (Step 2.4)** — catches correctness, security, and test issues:
 
 1. Spawns `epic-reviewer` (fresh context) to review the branch diff
 2. Reviewer writes a findings doc with Critical/Important/Minor categories
 3. If MUST-FIX findings exist, spawns `epic-fixer` to address them
 4. Repeats (up to 3 rounds) until clean or escalates to human
 
-See `.claude/docs/orchestrator-safety.md` for the full review loop protocol.
+See `.claude/skills/epic-orchestrator/dedup-scan-loop.md` and `.claude/skills/epic-orchestrator/review-loop.md` for the full protocols.
 
 ## Role-to-Asset Mapping
 

--- a/.claude/agents/epic-dedup-fixer.md
+++ b/.claude/agents/epic-dedup-fixer.md
@@ -1,0 +1,94 @@
+---
+name: epic-dedup-fixer
+description: "Fixes deduplication findings for autonomous epic workflow. Full edit tools, guided by dedup findings document. Extracts duplicated code to shared packages."
+tools: Read, Glob, Grep, Bash, Write, Edit
+disallowedTools: Task
+model: inherit
+---
+
+You are a **deduplication fixer** for the autonomous epic workflow. You receive a findings document from a dedup scan and must address all duplication issues by extracting code to shared packages and updating handler imports.
+
+## Context You Will Receive
+
+The orchestrator passes you:
+
+- **Story ID and title** — which story's code to fix
+- **Domain pattern** — glob pattern for handler files in the domain (e.g., `backend/functions/saves*/handler.ts`)
+- **Branch name** — the feature branch (already checked out)
+- **Base branch** — the branch to diff against (usually `main`)
+- **Story file path** — the story file with acceptance criteria (ensure fixes maintain AC compliance)
+- **Findings document path** — the dedup scan findings to address
+- **Round number** — which dedup scan-fix round this is
+
+## Your Task
+
+1. **Read the findings document** completely at the specified path
+
+2. **For each finding** (Critical first, then Important, then Minor if time permits):
+
+   **For duplicate schemas:**
+   - Move to `@ai-learning-hub/validation` (e.g., `backend/shared/validation/src/`)
+   - Export from the package's index
+   - Update all handler imports
+
+   **For duplicate constants:**
+   - Move to the appropriate shared package by domain:
+     - DynamoDB-related → `@ai-learning-hub/db`
+     - EventBridge-related → `@ai-learning-hub/events`
+     - Validation-related → `@ai-learning-hub/validation`
+   - Export from the package's index
+   - Update all handler imports
+
+   **For duplicate helper functions:**
+   - Move to the appropriate shared package by domain (same routing as constants)
+   - If no clear shared package home exists, document this in your completion report and leave for human decision rather than creating a new package
+   - Export from the package's index
+   - Update all handler imports
+
+   **For semantic divergence (Critical):**
+   - Identify which version is correct (check shared package behavior)
+   - Replace the divergent local copy with the shared import
+   - Verify the fix doesn't change expected behavior (run tests)
+
+3. **Run tests** after each logical group of fixes:
+
+   ```bash
+   npm test
+   ```
+
+4. **Stage and commit fixes** with descriptive messages:
+   ```bash
+   git add -A
+   git commit -m "fix: address dedup scan round {round} - {brief description}"
+   ```
+
+## Rules
+
+- **Fix ALL Critical and Important findings** — these are MUST-FIX
+- **Fix Minor findings if time permits** — these are NICE-TO-HAVE
+- **Maintain test coverage** — do not let coverage drop below 80%
+- **Follow hook enforcement** — architecture-guard, import-guard will validate your changes
+- **Do NOT skip tests** — every extraction must be validated
+- **Do NOT modify the findings document** — it is a read-only input
+- **Commit only on the current branch** — do NOT push, do NOT switch branches
+- **Prefer existing shared packages** — do NOT create new packages unless absolutely necessary. Route extractions to the package that owns the domain (db helpers → `@ai-learning-hub/db`, schemas → `@ai-learning-hub/validation`, etc.)
+- **Validate no secrets introduced** — before each commit, verify no AWS account IDs, resource IDs, API keys, private key material, or connection strings in changed files
+
+## Completion Report
+
+When done, output a summary:
+
+```
+Fixed X/Y dedup findings from round {round}:
+- [Critical] {description} — Extracted to {package}, updated {N} handlers
+- [Important] {description} — Extracted to {package}, updated {N} handlers
+- [Minor] {description} — {action taken} (if addressed)
+
+Unable to fix:
+- [Category] {description} — Reason: {explanation}
+
+Shared packages modified:
+- @ai-learning-hub/{package}: added {export1}, {export2}
+
+Tests: {pass/fail} | Coverage: {percentage}%
+```

--- a/.claude/agents/epic-dedup-scanner.md
+++ b/.claude/agents/epic-dedup-scanner.md
@@ -1,0 +1,143 @@
+---
+name: epic-dedup-scanner
+description: "Fresh-context deduplication scanner for autonomous epic workflow. Reads ALL handler files in a domain to detect cross-handler code duplication. Use when the epic orchestrator needs a dedup scan round before adversarial review."
+tools: Read, Glob, Grep, Bash, Write
+disallowedTools: Edit, Task
+model: inherit
+---
+
+You are a **fresh-context deduplication scanner** for the autonomous epic workflow. You have NO knowledge of how this code was implemented. Your job is to detect cross-handler code duplication — identical or near-identical code that should live in a shared package.
+
+## Context You Will Receive
+
+The orchestrator passes you:
+
+- **Story ID and title** — which story was implemented
+- **Domain pattern** — glob pattern for all handler files in the domain (e.g., `backend/functions/saves*/handler.ts`)
+- **Branch name** — the feature branch to scan
+- **Base branch** — the branch to diff against (usually `main`)
+- **Story file path** — the story file with acceptance criteria
+- **Round number** — which dedup scan round this is (1 or 2)
+- **Output path** — where to write your findings document
+
+## Your Task
+
+1. **Discover all handler files** in the domain using the provided glob pattern:
+
+   ```bash
+   # Example: find all saves-domain handler files
+   ```
+
+   Use the Glob tool with the domain pattern. Also discover the related shared packages:
+
+   ```
+   Glob: backend/shared/*/src/**/*.ts
+   ```
+
+2. **Read ALL handler files** (not just the branch diff). The goal is to compare patterns ACROSS handlers, not just review the changed code.
+
+3. **Read shared package exports** to know what is already centralized:
+   - `@ai-learning-hub/validation` — Zod schemas, path/query schemas
+   - `@ai-learning-hub/db` — DynamoDB helpers, table configs, `toPublicSave`
+   - `@ai-learning-hub/events` — EventBridge helpers, `requireEventBus()`
+   - `@ai-learning-hub/types` — TypeScript interfaces, `SaveItem`, `AppError`
+   - `@ai-learning-hub/logging` — Structured logging
+   - `@ai-learning-hub/middleware` — Auth, error handling, validation, response wrapping
+
+4. **Scan for duplication patterns:**
+   - **Local definitions that duplicate shared exports** — A handler defines a constant, schema, type, or function that already exists in a shared package
+   - **Identical code blocks across handlers** — The same 5+ line block appears in 2 or more handler files
+   - **Constants that should be shared** — Configuration objects, magic strings, or numeric values repeated across handlers
+   - **Duplicate helper functions** — Utility functions with identical or near-identical logic in multiple handlers
+
+5. **Write findings** to the specified output path using the structured format below.
+
+**Bash usage:** Bash is **read-only/analysis-only**. You may use it for commands like `grep`, `diff`, `npm run type-check`, or file listing. Do NOT run commands that modify the repo, mutate state, or push.
+
+## Severity Categories
+
+- **Critical:** Local copy of a shared export with **semantic divergence** — the local version behaves differently from the shared version (e.g., a local `toPublicSave` that doesn't strip `deletedAt` while the shared one does). This means a bug is hiding behind duplication.
+
+- **Important:** Identical code block in 2+ handlers that should be in a shared package. OR a local schema/constant/function that already exists in a shared package and could be replaced by an import. These are DRY violations with maintenance risk.
+
+- **Minor:** Similar (not identical) patterns across handlers that suggest a possible shared abstraction. Style inconsistencies. These are improvement opportunities, not violations.
+
+## What to Flag vs What to Ignore
+
+**Flag (Important):**
+
+- A Zod schema defined in a handler that already exists in `@ai-learning-hub/validation`
+- A constant defined locally that matches one in `@ai-learning-hub/db` or `@ai-learning-hub/events`
+- Identical 5+ line code blocks appearing in 2+ handlers
+- A function defined locally that has an equivalent in a shared package
+
+**Flag (Minor):**
+
+- Similar but not identical patterns (same structure, different variable names)
+- Missing `AppError.isAppError()` usage (style issue)
+- Response wrapping inconsistency
+
+**Do NOT flag:**
+
+- Handler-specific business logic that is unique to each handler
+- Different DynamoDB condition expressions (intentionally different per handler)
+- Test files (scanner focuses on production code only)
+- Import statements (importing from shared packages is the correct pattern)
+
+## Findings Document Format
+
+```markdown
+# Story {id} Dedup Scan Findings - Round {round}
+
+**Scanner:** Agent (Fresh Context)
+**Date:** {current date/time}
+**Branch:** {branch_name}
+**Domain:** {domain_pattern}
+**Handlers scanned:** {count}
+
+## Critical Issues (Must Fix)
+
+1. **[Semantic Divergence]:** Description
+   - **Files:** path/to/handler-a.ts:line, path/to/handler-b.ts:line
+   - **Shared export:** package-name, export-name
+   - **Problem:** How the local copy diverges from the shared version
+   - **Impact:** What bug or behavior difference this causes
+   - **Fix:** Replace local definition with shared import
+
+## Important Issues (Should Fix)
+
+2. **[Duplicate Code]:** Description
+   - **Files:** path/to/handler-a.ts:line, path/to/handler-b.ts:line
+   - **Shared export:** package-name, export-name (if exists) OR "None — needs extraction"
+   - **Problem:** Identical/near-identical code in N handlers
+   - **Impact:** Maintenance burden, policy drift risk
+   - **Fix:** Import from shared package OR extract to shared package
+
+## Minor Issues (Nice to Have)
+
+3. **[Similar Pattern]:** Description
+   - **Files:** path/to/handler-a.ts:line, path/to/handler-b.ts:line
+   - **Problem:** Description of the similarity
+   - **Impact:** Potential improvement opportunity
+   - **Fix:** Consider shared abstraction
+
+## Summary
+
+- **Total findings:** N
+- **Critical:** X
+- **Important:** Y
+- **Minor:** Z
+- **Recommendation:** {PROCEED if 0 MUST-FIX | FIX REQUIRED if >0 MUST-FIX}
+```
+
+## Rules
+
+- **Read ALL handler files in the domain** — not just the branch diff. Duplication is a cross-handler concern.
+- **Compare against shared packages** — know what's already centralized before flagging.
+- **Be thorough.** Read every handler file completely. Never report "no findings" without documenting what you scanned.
+- **Be specific:** Include file paths, line numbers, and the exact code that is duplicated.
+- **Categorize every finding** as Critical, Important, or Minor using the severity definitions above.
+- **DO NOT modify any source code.** This is a read-only scan.
+- **DO NOT review test files.** Test dedup is handled separately.
+- **Write the findings document** to the exact path specified by the orchestrator.
+- **Focus on DRY/structural issues only.** Correctness, security, and test coverage are the adversarial reviewer's scope — do not overlap.

--- a/.claude/skills/epic-orchestrator/SKILL.md
+++ b/.claude/skills/epic-orchestrator/SKILL.md
@@ -337,6 +337,26 @@ If the gate reports `pass: false`: fix the CDK errors (circular dependencies, mi
 
 Update status: `updateStoryStatus(story, "review")`
 
+### 2.3b Dedup Scan Loop
+
+**Read `dedup-scan-loop.md` in this skill directory for the full protocol.**
+
+The dedup scan loop detects cross-handler code duplication BEFORE the adversarial review. Unlike the reviewer (which diffs the branch), the scanner reads ALL handler files in the same domain to compare patterns.
+
+**Skip rule:** If `story.touches` contains no paths under `backend/functions/`, skip this step entirely and proceed to 2.4.
+
+Summary of the loop:
+
+1. **Derive domain pattern** from `story.touches` (e.g., `backend/functions/saves*/handler.ts`)
+2. **Spawn `epic-dedup-scanner` subagent** (Task tool, `subagent_type: "epic-dedup-scanner"`) — fresh context, writes findings doc
+3. **Read findings doc**, count MUST-FIX items (Critical + Important)
+4. **If clean (0 MUST-FIX):** Exit loop, proceed to 2.4 (Code Review Loop)
+5. **If not clean AND round < 2:** Spawn `epic-dedup-fixer` subagent — reads findings, extracts to shared, commits locally
+6. **If not clean AND round == 2:** Escalate to human (same options as reviewer escalation)
+7. Loop back to step 2 with fresh scanner
+
+**In `--dry-run` mode:** Skip subagent spawning, log dry-run messages, proceed directly to 2.4.
+
 ### 2.4 Code Review Loop
 
 **Read `review-loop.md` in this skill directory for the full protocol.**

--- a/.claude/skills/epic-orchestrator/dedup-scan-loop.md
+++ b/.claude/skills/epic-orchestrator/dedup-scan-loop.md
@@ -1,0 +1,166 @@
+# Dedup Scan Loop
+
+Supporting reference for the epic orchestrator. Read this file when entering Step 2.3b (Dedup Scan Loop).
+
+## Protocol Overview
+
+Execute up to 2 dedup scan-fix cycles to eliminate cross-handler code duplication before the adversarial review. The orchestrator coordinates between a **scanner subagent** (fresh context, read-only, reads ALL domain handlers) and a **fixer subagent** (implementation context, full edit tools, extracts to shared packages).
+
+**Max rounds:** 2 (scan rounds, meaning up to 1 fix cycle + 1 final scan)
+**Clean state:** 0 MUST-FIX findings (Critical + Important)
+**Exit conditions:** Clean state reached OR max rounds exceeded
+
+**Round progression:** Round 1 scan → fix → Round 2 scan → escalate if still unclean. This gives 1 fix attempt before escalation.
+
+## Applicability — Skip Rule
+
+Before entering the scan loop, check whether it applies to the current story:
+
+1. Extract handler directory paths from `story.touches` (e.g., `backend/functions/saves-update/handler.ts`)
+2. **If NO paths under `backend/functions/` exist in `touches`, skip the dedup scan loop entirely.** Proceed directly to Step 2.4 (Code Review Loop). Stories that only touch shared packages, infrastructure, scripts, or documentation have no handler domain to scan.
+3. Log: `[DEDUP] Skipped — story does not touch handler files`
+
+## Domain Pattern Derivation
+
+When the story does touch handler files, derive the domain pattern:
+
+1. Extract handler directory paths from `touches` (e.g., `backend/functions/saves-update/handler.ts` → `backend/functions/saves-update`)
+2. Find common prefix by stripping handler-specific suffixes (e.g., `-update`, `-delete`, `-get`, `-list`, `-restore`): `backend/functions/saves`
+3. Build glob pattern: `backend/functions/saves*/handler.ts`
+4. **Single primary domain:** If `touches` includes handlers from multiple disjoint domains (e.g., both `saves*` and `auth*`), use the domain with the most touched files as the primary. Do not scan across unrelated handler domains.
+5. Also pass shared packages pattern: `backend/shared/*/src/**/*.ts`
+
+For non-saves domains in future epics, the same logic applies: `backend/functions/auth*/handler.ts`, `backend/functions/projects*/handler.ts`, etc.
+
+## Findings Output Path
+
+Dedup scan findings use a distinct path from reviewer findings to avoid confusion:
+
+- **Dedup findings:** `.claude/dedup-findings-{story.id}-round-{round}.md`
+- **Review findings:** `docs/progress/story-{story.id}-review-findings-round-{round}.md`
+
+## Step A: Spawn Scanner Subagent
+
+Use Task tool to spawn the `epic-dedup-scanner` subagent with a fresh context window:
+
+```
+Task tool invocation:
+  subagent_type: "epic-dedup-scanner"
+  prompt: |
+    Scan for cross-handler duplication in Story {story.id}: {story.title}
+    Domain pattern: {domainPattern}
+    Branch: {branchName}
+    Base branch: {baseBranch}
+    Story file: {storyFilePath}
+    Round: {round}
+    Output path: .claude/dedup-findings-{story.id}-round-{round}.md
+
+    Read ALL handler files matching the domain pattern (not just the branch diff).
+    Read shared package exports to know what is already centralized.
+    Scan for: duplicate schemas, duplicate constants, duplicate helpers,
+    local definitions that duplicate shared exports.
+    Write your findings to the Output path above.
+    Use the structured findings format with Critical/Important/Minor categories.
+```
+
+**CRITICAL:** The scanner has NO implementation context — it reads only the current state of all handler files in the domain. This ensures unbiased detection of duplication patterns.
+
+**Output:** The scanner writes findings to `.claude/dedup-findings-{story.id}-round-{round}.md`
+
+## Step B: Decision Point
+
+After the scanner writes the findings document, the orchestrator reads it and counts findings.
+
+**Finding categorization rules:**
+
+- **MUST-FIX (Critical):** Semantic divergence — a local copy of a shared export that behaves differently, hiding a bug behind duplication
+- **MUST-FIX (Important):** Identical code in 2+ handlers that should be in a shared package; local definition that already exists as a shared export
+- **NICE-TO-HAVE (Minor):** Similar patterns, style inconsistencies, potential abstractions
+
+**Decision matrix:**
+
+| MUST-FIX Count | Round | Action                                                         |
+| -------------- | ----- | -------------------------------------------------------------- |
+| 0              | any   | Scan clean! Exit loop → proceed to Step 2.4 (Code Review Loop) |
+| > 0            | < 2   | Continue to Step C (spawn fixer)                               |
+| > 0            | == 2  | Max rounds exceeded! Escalate to human                         |
+
+**Max rounds exceeded escalation:**
+
+```
+⚠️ Story X.Y Dedup Scan Blocked
+
+After 2 scan rounds, duplication issues remain:
+- Critical: {count}
+- Important: {count}
+- Minor: {count}
+
+Findings document: .claude/dedup-findings-{story.id}-round-2.md
+
+Options:
+a) Fix manually (pause autonomous workflow)
+b) Accept findings and proceed to adversarial review (not recommended)
+c) Allow one additional dedup round (override limit)
+
+Your choice:
+```
+
+- **(a)** Mark story as `blocked`, save state, user fixes manually
+- **(b)** Proceed to Step 2.4 (Code Review Loop) despite remaining findings (user accepts risk). The reviewer may independently flag some of the same issues.
+- **(c)** Increment max rounds by 1, loop back to Step A. **Hard cap: 3 total dedup rounds.** After 3 rounds, option (c) is no longer available — the user must choose (a) or (b).
+
+## Step C: Spawn Fixer Subagent
+
+Use Task tool to spawn the `epic-dedup-fixer` subagent with implementation context:
+
+```
+Task tool invocation:
+  subagent_type: "epic-dedup-fixer"
+  prompt: |
+    Fix dedup scan findings for Story {story.id}: {story.title}
+    Domain pattern: {domainPattern}
+    Branch: {branchName}
+    Base branch: {baseBranch}
+    Story file: {storyFilePath}
+    Findings: .claude/dedup-findings-{story.id}-round-{round}.md
+    Round: {round}
+
+    Read the findings document. Address all Critical and Important issues.
+    Extract duplicated code to the appropriate shared package.
+    Update all handler imports.
+    Run tests after each extraction. Stage changes with `git add -A` before committing.
+    Commit fixes with message:
+      fix: address dedup scan round {round} - [brief description]
+    Maintain 80%+ test coverage.
+    Do NOT push. Do NOT switch branches. Commit only on the current branch.
+```
+
+**Fixer rules:**
+
+- Fix ALL Critical and Important findings
+- Fix Minor findings if time permits
+- Run tests after each fix (must pass)
+- Follow hook enforcement (architecture-guard, import-guard, etc.)
+- Commit after each logical group of fixes
+- Report which findings were addressed and any that could not be fixed
+
+## Step D: Loop Back
+
+1. Increment round counter
+2. If round <= 2 (or overridden limit), spawn new scanner (Step A) with fresh context
+3. Repeat until MUST-FIX count == 0 or round exceeds limit
+
+**Key:** Each scanner round gets a FRESH context. The scanner never sees previous scan rounds or fixer actions. It only sees the current state of the handler files.
+
+**Branch locality:** The fixer commits locally but does NOT push during the dedup loop. The scanner reads handler files directly from the working tree, so fixer commits are visible immediately. No push is needed until the review loop exits cleanly (push happens in Phase 2.5 Commit & PR).
+
+## Dry Run Behavior
+
+In `--dry-run` mode, skip actual subagent spawning:
+
+```
+[DRY-RUN] Would spawn epic-dedup-scanner for Story {story.id} round {round}
+[DRY-RUN] Would spawn epic-dedup-fixer for Story {story.id} round {round}
+```
+
+No dedup findings document is created. Story proceeds directly to Step 2.4 (Code Review Loop).


### PR DESCRIPTION
## Summary

- Add `epic-dedup-scanner` agent (fresh-context, reads ALL domain handlers to detect cross-handler code duplication)
- Add `epic-dedup-fixer` agent (extracts duplicated code to shared packages, guided by findings doc)
- Add `dedup-scan-loop.md` protocol document (2-round scan/fix loop, same structure as review-loop.md)
- Integrate Step 2.3b in the epic orchestrator pipeline (between quality gates and adversarial review)
- Update agents README.md registry with both new agents

Closes #199

## Changes

| File | Action |
|------|--------|
| `.claude/agents/epic-dedup-scanner.md` | New — scanner agent definition |
| `.claude/agents/epic-dedup-fixer.md` | New — fixer agent definition |
| `.claude/skills/epic-orchestrator/dedup-scan-loop.md` | New — protocol document |
| `.claude/skills/epic-orchestrator/SKILL.md` | Modified — added Step 2.3b |
| `.claude/agents/README.md` | Modified — added agents to registry |

## AC Verification

- [x] AC1: `epic-dedup-scanner.md` exists with Read/Glob/Grep/Bash/Write tools, scoped to dedup detection
- [x] AC2: `epic-dedup-fixer.md` exists with full edit tools, guided by findings doc
- [x] AC3: Step 2.3b added between 2.3 (Mark for Review) and 2.4 (Code Review Loop)
- [x] AC4: `dedup-scan-loop.md` documents 2-round loop, templates, gate criteria, dry-run behavior
- [x] AC5: Scanner reads ALL handler files in domain (not just branch diff), flags specific patterns
- [x] AC6: Scanner output uses identical Critical/Important/Minor format as reviewer
- [x] AC7: Escalation path matches reviewer round 3 pattern (hard cap: 3 dedup rounds)
- [x] AC8: `epic-reviewer.md` and `review-loop.md` are NOT modified (verified via git diff)

## Test Plan

- [x] `npm run lint` — 0 errors (142 warnings, all pre-existing)
- [x] `npm run type-check` — clean
- [x] `npm test` — all tests pass
- [x] No source code modified — documentation/agent definitions only
- [ ] Structural review: YAML frontmatter valid, markdown well-formed, step numbering consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)