### PR TITLE
feat: add phase runner infrastructure (Story 3.1.5)

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -197,4 +197,7 @@ See `.claude/docs/safety-architecture.md` for the full three-layer defense model
 - `.claude/docs/safety-architecture.md` — Three-layer defense model
 - `.claude/docs/hook-system.md` — Hook System Details
 - `.claude/skills/epic-orchestrator/SKILL.md` — Full orchestrator implementation
+- `.claude/skills/epic-orchestrator/phase-registry.md` — Phase 2 step order, skip conditions, gate criteria
+- `.claude/skills/epic-orchestrator/phase-runner.md` — Execution protocol (dry-run, resume, escalation)
 - `.claude/skills/epic-orchestrator/review-loop.md` — Review loop protocol
+- `.claude/skills/epic-orchestrator/dedup-scan-loop.md` — Dedup scan loop protocol

--- a/.claude/skills/epic-orchestrator/SKILL.md
+++ b/.claude/skills/epic-orchestrator/SKILL.md
@@ -166,6 +166,8 @@ Select runner:
 
 ## Phase 2: Story Implementation Loop
 
+> **Phase order and execution semantics** are defined in `phase-registry.md` (step list, skip conditions, gate criteria) and `phase-runner.md` (execution loop, dry-run, resume) in this directory. The sections below are the canonical prose for each step. Step IDs and order must stay in sync with the registry: 2.1 → 2.2 → 2.3 → 2.3b → 2.4 → 2.5 → 2.6 → 2.7.
+
 For each story in scope (topological order):
 
 ### 2.1 Pre-Implementation

--- a/.claude/skills/epic-orchestrator/phase-registry.md
+++ b/.claude/skills/epic-orchestrator/phase-registry.md
@@ -1,0 +1,90 @@
+# Phase Registry
+
+Single source of truth for Phase 2 (Story Implementation Loop) step order, execution semantics, and gate criteria. Referenced by the orchestrator's SKILL.md and executed via the phase-runner.md protocol.
+
+## Phase 2 Steps
+
+| Step | Name                                | Purpose                                                       | What Runs                                                                                         | Skip Condition                                                         | Gate Criteria                                            |
+| ---- | ----------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------- |
+| 2.1  | Pre-Implementation                  | Check deps, create issue/branch, set status to in-progress    | StoryRunner: `getOrCreateIssue`, `getOrCreateBranch`                                              | —                                                                      | All deps "done" in state file; resources created         |
+| 2.2  | Implementation (Protected by Hooks) | Write tests, implement code, run quality gates                | Invoke `/bmad-bmm-dev-story`; then `npm run lint`, `npm run type-check`, `npm test -- --coverage` | `--dry-run`: skip entirely, log only                                   | All tests pass; lint clean; type-check clean             |
+| 2.3  | Mark for Review                     | Update story status to "review" in state file                 | `updateStoryStatus(story, "review")`                                                              | `--dry-run`: skip entirely (status stays `in-progress`)                | Status updated                                           |
+| 2.3b | Dedup Scan Loop                     | Detect cross-handler duplication before adversarial review    | Spawn `epic-dedup-scanner` per `dedup-scan-loop.md`; spawn `epic-dedup-fixer` if findings present | `story.touches` has no paths under `backend/functions/` OR `--dry-run` | 0 MUST-FIX findings (Critical + Important); max 2 rounds |
+| 2.4  | Code Review Loop                    | Adversarial review of branch changes                          | Spawn `epic-reviewer` per `review-loop.md`; spawn `epic-fixer` if findings present                | `--dry-run`: skip subagent spawning, log only                          | 0 MUST-FIX findings (Critical + Important); max 3 rounds |
+| 2.5  | Commit & PR                         | Push branch, create PR, verify CI                             | `git push`, StoryRunner: `getOrCreatePR`, `gh pr checks --watch`                                  | —                                                                      | CI green; PR created                                     |
+| 2.6  | Finalize Story [HUMAN CHECKPOINT]   | Sync with main, update status to "done", human checkpoint     | `git merge origin/${baseBranch}`, `npm test`, `updateStoryStatus(story, "done")`                  | —                                                                      | Merge clean; tests pass; user approves                   |
+| 2.7  | Integration Checkpoint              | Validate dependent stories still valid after upstream changes | File overlap check, type change detection, test re-run per `integration-checkpoint.md`            | `story.hasDependents === false` (no dependent stories)                 | Green/Yellow → continue; Red → escalate                  |
+
+## Step Details
+
+### 2.1 Pre-Implementation
+
+- **Dependency check:** For each dependency, verify "done" in state file. For dependencies with dependents, verify code reached base branch via `git merge-base --is-ancestor`.
+- **Resource creation:** Idempotent via StoryRunner — `getOrCreateIssue(story, epic)`, `getOrCreateBranch(story)`.
+- **State update:** `updateStoryStatus(story, "in-progress")`, record `startedAt` timestamp.
+- **Failure escalation:** If dependency not met, prompt user (skip / pause / override).
+
+### 2.2 Implementation
+
+Sub-steps executed within this phase (not individually registered — phase-level resume only):
+
+1. **Invoke dev-story skill:** `Skill(skill: "bmad-bmm-dev-story", args: "${storyFilePath}")`
+2. **Quality gate:** `npm run lint`, `npm run type-check`, `npm test -- --coverage`
+3. **AC verification:** Write `.claude/temp/ac-verification.json`, run `node .claude/hooks/ac-verify-validator.cjs`
+4. **Secrets scan:** Check changed files for AWS keys, account IDs, private key material
+5. **Commit verification:** Run `node .claude/hooks/commit-gate.cjs`
+6. **CDK synth gate (conditional):** Run `node .claude/hooks/cdk-synth-gate.cjs` if infra files changed
+
+### 2.3 Mark for Review
+
+- **State update:** `updateStoryStatus(story, "review")`
+- Lightweight step; exists as a discrete phase so the state file reflects the transition.
+
+### 2.3b Dedup Scan Loop
+
+- **Protocol:** See `dedup-scan-loop.md` for the full 2-round protocol.
+- **Scanner:** `epic-dedup-scanner` subagent (fresh context, reads ALL domain handlers).
+- **Fixer:** `epic-dedup-fixer` subagent (implementation context, extracts to shared packages).
+- **Gate:** 0 Critical + Important findings to exit. Max 2 rounds, then escalate.
+- **Findings path:** `.claude/dedup-findings-{story.id}-round-{round}.md`
+
+### 2.4 Code Review Loop
+
+- **Protocol:** See `review-loop.md` for the full 3-round protocol.
+- **Reviewer:** `epic-reviewer` subagent (fresh context, diffs branch vs base).
+- **Fixer:** `epic-fixer` subagent (implementation context, fixes findings).
+- **Gate:** 0 Critical + Important findings to exit. Max 3 rounds, then escalate.
+- **Findings path:** `docs/progress/story-{story.id}-review-findings-round-{round}.md`
+
+### 2.5 Commit & PR
+
+- **Pre-stage validation:** Check for `.env`, `.pem`, `.key` files.
+- **Commit:** `git add -A && git commit` with issue reference.
+- **Push:** `git push -u origin ${branchName}` (standard push, never force).
+- **PR creation:** Idempotent via StoryRunner — `getOrCreatePR(story, epic, issue, coverage)`.
+- **Temp cleanup:** `node .claude/hooks/temp-cleanup.cjs`
+- **CI verification:** `gh pr checks ${pr.number} --watch` — must be green before proceeding.
+
+### 2.6 Finalize Story [HUMAN CHECKPOINT]
+
+- **Sync:** `git fetch origin ${baseBranch} && git merge origin/${baseBranch}` — merge, never rebase.
+- **Test:** Re-run tests after merge.
+- **State update:** `updateStoryStatus(story, "done")`, record `completedAt`, compute `duration`.
+- **Completion report:** Upsert story row in `docs/progress/epic-{id}-completion-report.md`.
+- **User prompt:** "Continue to Story X.Z? (y/n/pause/skip)" — deferred until after 2.7 if story has dependents.
+
+### 2.7 Integration Checkpoint
+
+- **Protocol:** See `integration-checkpoint.md` for validation details.
+- **Checks:** Shared file changes, interface/type changes, test re-run.
+- **Result classification:** Green (all clear), Yellow (warnings), Red (failures → escalate).
+- **User options:** y / n / pause / review-X.Y.
+
+## Sync Contract
+
+Step IDs and names in this registry MUST match the Phase 2 headings in SKILL.md. If either document adds, removes, or reorders a step, update both to maintain consistency.
+
+## Versioning
+
+- **Created:** 2026-02-23 (Story 3.1.5)
+- **Last updated:** 2026-02-23

--- a/.claude/skills/epic-orchestrator/phase-runner.md
+++ b/.claude/skills/epic-orchestrator/phase-runner.md
@@ -1,0 +1,124 @@
+# Phase Runner Protocol
+
+Execution protocol for Phase 2 steps. Describes how the orchestrator reads the phase registry and runs each step with consistent handling for dry-run, resume, skip conditions, and gate criteria.
+
+## Execution Loop
+
+For each story in topological order:
+
+```
+1. Read phase-registry.md to get ordered step list (2.1 → 2.2 → 2.3 → 2.3b → 2.4 → 2.5 → 2.6 → 2.7)
+2. Resolve current story and its state from the state file
+3. Determine starting step (see Resume Semantics below)
+4. For each step from starting step onward:
+   a. Evaluate skip conditions from the registry
+      - If skip condition met → log skip reason, advance to next step
+   b. Execute step (invoke skill / run shell / spawn subagent per registry)
+   c. Evaluate gate criteria
+      - If gate passes → advance to next step
+      - If gate fails → follow escalation semantics for that step
+5. After all steps complete → story is done, move to next story in scope
+```
+
+## Skip Condition Evaluation
+
+Before running a step, the runner checks its skip condition from the registry:
+
+| Step | Skip Condition                                            | Evaluation                                                                                                                          |
+| ---- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| 2.1  | — (never skipped)                                         | Always runs                                                                                                                         |
+| 2.2  | `--dry-run`                                               | If `isDryRun === true`, log `[DRY-RUN] Would invoke /bmad-bmm-dev-story for Story ${story.id}`, skip step, advance to next          |
+| 2.3  | `--dry-run`                                               | If `isDryRun === true`, log `[DRY-RUN] Would set story status to 'review'`, skip step (status stays `in-progress`), advance to next |
+| 2.3b | No `backend/functions/` in `story.touches` OR `--dry-run` | Parse `story.touches`; if no handler paths OR `isDryRun`, log skip reason, advance to next step                                     |
+| 2.4  | `--dry-run`                                               | If `isDryRun === true`, skip subagent spawning, log dry-run message                                                                 |
+| 2.5  | — (never skipped)                                         | Always runs (DryRunStoryRunner handles mock operations internally)                                                                  |
+| 2.6  | — (never skipped)                                         | Always runs                                                                                                                         |
+| 2.7  | `story.hasDependents === false`                           | Computed during dependency analysis (Phase 1.3); skip if current story has no dependent stories                                     |
+
+## Gate Criteria Evaluation
+
+After a step completes, the runner evaluates its gate:
+
+| Step | Gate                                     | On Failure                                                                     |
+| ---- | ---------------------------------------- | ------------------------------------------------------------------------------ |
+| 2.1  | Deps satisfied, resources created        | Prompt user: skip / pause / override                                           |
+| 2.2  | Tests pass, lint clean, type-check clean | Auto-fix (max 2 attempts), then HALT                                           |
+| 2.3  | Status updated                           | N/A (always succeeds)                                                          |
+| 2.3b | 0 MUST-FIX findings                      | Round < 2: spawn fixer, re-scan. Round == 2: escalate per `dedup-scan-loop.md` |
+| 2.4  | 0 MUST-FIX findings                      | Round < 3: spawn fixer, re-review. Round == 3: escalate per `review-loop.md`   |
+| 2.5  | CI green, PR created                     | Fix CI failures, re-push. If PR fails, show manual command                     |
+| 2.6  | Merge clean, tests pass, user approves   | Merge conflicts: auto-resolve or escalate. Test failures: auto-fix or escalate |
+| 2.7  | Green or Yellow result                   | Red: escalate to user. Yellow: show warnings alongside 2.6 prompt              |
+
+## Escalation Semantics
+
+When a gate fails and cannot be auto-resolved, the runner escalates to the user. Escalation behavior is defined per step in the protocol docs:
+
+- **2.1 (Pre-Implementation):** Dependency failure → user chooses skip / pause / override (SKILL.md §2.1)
+- **2.2 (Implementation):** Test/lint failure → auto-fix (max 2), then HALT (SKILL.md §Error Recovery)
+- **2.3b (Dedup Scan Loop):** Max rounds exceeded → user chooses fix / accept / extend (dedup-scan-loop.md §Step B)
+- **2.4 (Code Review Loop):** Max rounds exceeded → user chooses fix / accept / extend (review-loop.md §Step B)
+- **2.5 (Commit & PR):** CI failure → fix and re-push. PR creation failure → manual fallback (SKILL.md §2.5)
+- **2.6 (Finalize Story):** Merge conflict → auto-resolve or escalate. Test failure → auto-fix or escalate (SKILL.md §2.6)
+- **2.7 (Integration Checkpoint):** Red result → show details, user chooses continue / pause / review (integration-checkpoint.md)
+
+The runner advances only when the step completes successfully or the user resolves an escalation. It never silently skips a failed gate.
+
+## Dry-Run Mode
+
+In `--dry-run` mode, the runner skips implementation-heavy steps while still exercising the control flow:
+
+| Step | Dry-Run Behavior                                                                         |
+| ---- | ---------------------------------------------------------------------------------------- |
+| 2.1  | Runs normally with DryRunStoryRunner (mock issue/branch creation)                        |
+| 2.2  | Skipped entirely; log `[DRY-RUN] Would invoke /bmad-bmm-dev-story`                       |
+| 2.3  | Log `[DRY-RUN] Would set story status to 'review'`                                       |
+| 2.3b | Skipped; log `[DRY-RUN] Would spawn epic-dedup-scanner`                                  |
+| 2.4  | Skipped; log `[DRY-RUN] Would spawn epic-reviewer`                                       |
+| 2.5  | Runs with DryRunStoryRunner (mock commit/push/PR)                                        |
+| 2.6  | Runs with DryRunStoryRunner (mock merge/status update). Human checkpoint still triggers. |
+| 2.7  | Runs if `story.hasDependents === true` (validation logic still exercised with mock data) |
+
+## Resume Semantics
+
+The state file (see `state-file.md`) stores story-level status only — there is no per-phase "current step" field. When resuming, the runner infers the starting step from the story status:
+
+| Story Status                         | Starting Step | Rationale                                                    |
+| ------------------------------------ | ------------- | ------------------------------------------------------------ |
+| `pending`                            | 2.1           | Fresh start                                                  |
+| `in-progress` (no branch)            | 2.1           | No recoverable state; restart from beginning                 |
+| `in-progress` (branch exists, no PR) | 2.2           | Branch exists; resume implementation                         |
+| `in-progress` (PR exists)            | 2.5           | Skip to post-commit (implementation already done)            |
+| `review`                             | 2.3           | Re-run from 2.3, which re-runs 2.3b (dedup) and 2.4 (review) |
+| `done`                               | —             | Skip story entirely                                          |
+| `blocked`                            | —             | Prompt user: retry / skip / keep blocked                     |
+| `paused`                             | Varies        | Same logic as `in-progress` — check for branch/PR existence  |
+
+**Convention for `review` status:** The state file cannot distinguish between steps 2.3, 2.3b, and 2.4. The convention is to resume from step 2.3 and re-run the dedup scan (2.3b) and code review (2.4). This ensures no scan/review is skipped on resume, at the cost of potentially re-running a clean scan.
+
+**Future enhancement (out of scope):** Add a `last_completed_phase` field per story in the state file YAML for precise phase-level resume. Example: `"3.1.5": { status: review, last_completed_phase: "2.3b" }` → resume from 2.4.
+
+## Idempotency
+
+All steps that create resources are idempotent via the StoryRunner interface:
+
+- `getOrCreateIssue` — checks for existing issue before creating
+- `getOrCreateBranch` — checks for existing branch before creating
+- `getOrCreatePR` — checks for existing PR before creating
+
+This makes the runner safe to re-run from any step without duplicate resource creation.
+
+## Cross-References
+
+- **Phase 2 steps (canonical prose):** `SKILL.md` §Phase 2
+- **Step order and gate criteria:** `phase-registry.md` (this protocol's companion)
+- **Dedup scan protocol:** `dedup-scan-loop.md`
+- **Code review protocol:** `review-loop.md`
+- **Integration checkpoint protocol:** `integration-checkpoint.md`
+- **State file format and resume:** `state-file.md`
+- **StoryRunner interface:** `story-runner.md`
+
+## Versioning
+
+- **Created:** 2026-02-23 (Story 3.1.5)
+- **Last updated:** 2026-02-23

--- a/_bmad-output/implementation-artifacts/3-1-5-phase-runner-infrastructure.md
+++ b/_bmad-output/implementation-artifacts/3-1-5-phase-runner-infrastructure.md
@@ -1,0 +1,129 @@
+---
+id: "3.1.5"
+title: "Phase Runner Infrastructure"
+status: ready-for-dev
+depends_on:
+  - 3-1-4-dedup-scan-agent-pipeline
+touches:
+  - .claude/skills/epic-orchestrator/phase-registry.md (new)
+  - .claude/skills/epic-orchestrator/SKILL.md
+  - .claude/skills/epic-orchestrator/phase-runner.md (new)
+risk: low
+---
+
+# Story 3.1.5: Phase Runner Infrastructure
+
+Status: review
+
+## Story
+
+As the epic orchestrator,
+I want explicit phase runner infrastructure so that Phase 2 steps (quality gates → dedup scan → review → commit) are defined in one place and can be executed consistently by the orchestrator or future automation,
+so that the pipeline is auditable, resumable, and not only implied by prose in SKILL.md.
+
+## Acceptance Criteria
+
+| #   | Given                                    | When                                                                 | Then                                                                                                                                                  |
+| --- | ---------------------------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC1 | Phase registry document exists           | `.claude/skills/epic-orchestrator/phase-registry.md` exists          | Document lists Phase 2 steps in order (2.1–2.7) with: step id, name, one-line purpose, what runs (invoke/shell/subagent), skip conditions, gate criteria |
+| AC2 | Phase runner protocol exists              | `.claude/skills/epic-orchestrator/phase-runner.md` exists            | Protocol describes how to execute the registry: read registry, run current phase, handle dry-run and resume, advance or escalate                      |
+| AC3 | SKILL.md references phase infrastructure | Phase 2 section in SKILL.md                                          | Phase 2 intro points to phase-registry.md and phase-runner.md as the source of phase order and execution; prose steps remain but cite the registry      |
+| AC4 | No duplicate step definitions             | After story is done                                                  | Phase order and step identities in SKILL.md match phase-registry.md; no conflicting numbering or steps                                                 |
+| AC5 | Dry-run and resume covered                | phase-runner.md is read                                              | Dry-run behavior (skip subagents, log only) and resume behavior (state file, start from first non-done) are documented for each phase that supports it |
+
+## Tasks / Subtasks
+
+- [x] Task 1: Create phase registry (AC: #1, #4)
+  - [x] 1.1 Create `.claude/skills/epic-orchestrator/phase-registry.md`
+  - [x] 1.2 Define Phase 2 step list in order: 2.1 Pre-Implementation, 2.2 Implementation (quality gates, AC verification, secrets scan, commit gate, CDK synth), 2.3 Mark for Review, 2.3b Dedup Scan Loop, 2.4 Code Review Loop, 2.5 Commit & PR, 2.6 Finalize Story, 2.7 Integration Checkpoint
+  - [x] 1.3 For each step: id, name, purpose (one line), what runs (e.g. "Invoke /bmad-bmm-dev-story", "Run npm run lint && npm run type-check && npm test", "Spawn epic-dedup-scanner per dedup-scan-loop.md", "Spawn epic-reviewer per review-loop.md"), skip conditions (e.g. dry-run skips 2.2 impl and subagent spawns), gate criteria (e.g. 0 MUST-FIX to exit dedup/review loops). **For 2.7 Integration Checkpoint:** skip condition = run only when `story.hasDependents === true`; skip when current story has no dependents.
+  - [x] 1.4 Use same step ids and names as SKILL.md so they stay in sync
+
+- [x] Task 2: Create phase runner protocol (AC: #2, #5)
+  - [x] 2.1 Create `.claude/skills/epic-orchestrator/phase-runner.md`
+  - [x] 2.2 Document: read phase-registry.md, resolve current story and state, determine current phase (from state file or start at 2.1)
+  - [x] 2.3 Document execution loop: before running a phase, evaluate skip conditions from the registry (e.g. for 2.7, skip if `!story.hasDependents`); run current phase (invoke skill, run shell, spawn subagent per registry); evaluate gate criteria; advance to next phase or escalate. State that escalation semantics (when to pause and prompt user) are defined per phase in the protocol docs (e.g. review-loop.md, dedup-scan-loop.md); the phase runner advances only when the phase completes or the user resolves an escalation.
+  - [x] 2.4 Document dry-run: skip 2.2, 2.3, 2.3b, and 2.4; proceed directly to 2.5 (handled by DryRunStoryRunner). Optionally log `[DRY-RUN] Would set story status to 'review' (2.3)` for audit.
+  - [x] 2.5 Document resume: load state file; state file has no "current phase" field (story-level status only). For story status `review`, define a single convention (e.g. resume from 2.3 and re-run 2.3b and 2.4 so dedup and review are not skipped). Optionally note: a later story could add `current_phase` (or `last_completed_phase`) per story in the state file for precise phase resume. Cross-reference: state-file.md "resume from implementation phase" = phase 2.2 (Implementation). Idempotency of getOrCreateIssue/Branch/PR.
+
+- [x] Task 3: Update SKILL.md to reference phase infrastructure (AC: #3)
+  - [x] 3.1 In Phase 2 intro (before 2.1), add a short paragraph: phase order and execution semantics are defined in `phase-registry.md` and `phase-runner.md` in this directory; the sections below are the canonical prose for each step
+  - [x] 3.2 Ensure step numbering in SKILL.md matches phase-registry.md (2.1 → 2.2 → 2.3 → 2.3b → 2.4 → 2.5 → 2.6 → 2.7)
+  - [x] 3.3 No removal of existing step content — only add the reference and ensure consistency
+
+- [x] Task 4: Update agent/skill docs if needed (AC: #4)
+  - [x] 4.1 If `.claude/agents/README.md` or epic-orchestrator skill list references Phase 2 steps, add a note that phase order is defined in phase-registry.md
+
+## Dev Notes
+
+- **Intent:** The pipeline (Quality Gates → Dedup Scan → Review → Commit) is currently only described in SKILL.md. This story adds a single source of truth for *what* runs in what order (phase-registry.md) and *how* to run it (phase-runner.md), so the orchestrator (and any future script or MCP) can execute phases consistently. No change to safety invariants or to the behavior of existing steps.
+- **Scope:** Documentation and one new protocol only. No new agents, no new hooks, no new scripts required — unless the team chooses to add an optional small runner script (e.g. `node .claude/skills/epic-orchestrator/run-phase.cjs 2.2`) in a follow-up; that is out of scope for this story.
+- **Resume:** State file already exists (state-file.md) but stores only story-level status (no phase field). Phase runner protocol must document the resulting ambiguity for status `review` (cannot distinguish 2.3 vs 2.3b vs 2.4) and define a single convention (e.g. resume from 2.3 and re-run 2.3b and 2.4). See Task 2.5.
+- **Relationship to 3.1.4:** Story 3.1.4 added the dedup scan loop (2.3b) and its protocol (dedup-scan-loop.md). **Prerequisite:** 3.1.4 must be done and SKILL.md must already include step 2.3b and reference dedup-scan-loop.md. If 2.3b is missing from SKILL.md at implementation time, add it (and the reference) as part of Task 3; otherwise only add the Phase 2 intro reference and verify numbering. This story does not change the dedup protocol; it only registers 2.3b in the phase registry and documents how the phase runner invokes it.
+- **Registry granularity:** Registry describes phases at step level (2.1–2.7). Sub-steps within 2.2 (e.g. post-AC-verification, post-secrets-scan) are not enumerated; phase-level resume is story-level only unless extended later.
+- **Drift prevention:** Consider a follow-up (out of scope): a small script or lint rule that parses phase-registry.md and SKILL.md Phase 2 headings and fails if step ids or order differ. This story relies on manual validation.
+
+### Project Structure Notes
+
+- All new/modified files live under `.claude/skills/epic-orchestrator/`. No backend/frontend/infra code.
+- Align with existing skill docs: dependency-analysis.md, story-runner.md, state-file.md, review-loop.md, dedup-scan-loop.md use similar structure (purpose, steps, interfaces).
+
+### References
+
+- [Source: .claude/skills/epic-orchestrator/SKILL.md] Phase 2 steps 2.1–2.7
+- [Source: .claude/skills/epic-orchestrator/dedup-scan-loop.md] Step 2.3b protocol
+- [Source: .claude/skills/epic-orchestrator/review-loop.md] Step 2.4 protocol
+- [Source: _bmad-output/implementation-artifacts/3-1-4-dedup-scan-agent-pipeline.md] Pipeline flow diagram and gate criteria
+
+## Architecture Compliance
+
+| ADR / NFR   | How This Story Must Comply                                                                 |
+| ----------- | ------------------------------------------------------------------------------------------- |
+| **Pipeline** | Phase registry and runner docs must match existing SKILL.md step order and semantics        |
+| **Safety**   | No new agents or hooks; documentation only. No change to human checkpoints or merge rules   |
+| **Resume**   | Phase runner protocol must align with state-file.md and existing --resume behavior          |
+
+## Testing Requirements
+
+- **No automated tests:** This story adds markdown documentation under `.claude/skills/epic-orchestrator/`. Validation is manual and structural:
+  - `phase-registry.md` lists all Phase 2 steps in the same order as SKILL.md with consistent ids (2.1, 2.2, 2.3, 2.3b, 2.4, 2.5, 2.6, 2.7).
+  - `phase-runner.md` describes execution loop, dry-run, and resume without contradicting story-runner.md or state-file.md.
+  - Before marking the story complete, implementers must manually diff step ids and order between phase-registry.md and SKILL.md to ensure no conflicting numbering or steps (AC4).
+- **Quality gates:** `npm run lint` and `npm run type-check` unchanged (no production code). Manual review of new/modified skill docs.
+
+## File Structure Requirements
+
+### New
+
+- `.claude/skills/epic-orchestrator/phase-registry.md` — Phase 2 step list with id, name, purpose, what runs, skip conditions, gate criteria
+- `.claude/skills/epic-orchestrator/phase-runner.md` — Protocol for executing phases (read registry, run phase, dry-run, resume)
+
+### Modify
+
+- `.claude/skills/epic-orchestrator/SKILL.md` — Add Phase 2 intro reference to phase-registry.md and phase-runner.md; verify step numbering
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6
+
+### Debug Log References
+
+None — documentation-only story, no debugging needed.
+
+### Completion Notes List
+
+- Created `phase-registry.md` with Phase 2 step table (8 steps: 2.1–2.7) including step ID, name, purpose, what runs, skip conditions, and gate criteria. Step details section expands each step with cross-references to protocol docs.
+- Created `phase-runner.md` with execution loop protocol, skip condition evaluation, gate criteria evaluation, escalation semantics, dry-run mode behavior, resume semantics (with convention for `review` status ambiguity), and idempotency guarantees.
+- Updated `SKILL.md` Phase 2 intro to reference `phase-registry.md` and `phase-runner.md` with sync contract note.
+- Updated `.claude/agents/README.md` Further Reading section with links to both new docs.
+- Verified step numbering consistency: SKILL.md headings (2.1, 2.2, 2.3, 2.3b, 2.4, 2.5, 2.6, 2.7) match phase-registry.md table rows exactly.
+- Quality gates: `npm run lint` (0 errors), `npm run type-check` (clean). No production code changed.
+
+### File List
+
+- `.claude/skills/epic-orchestrator/phase-registry.md` (new)
+- `.claude/skills/epic-orchestrator/phase-runner.md` (new)
+- `.claude/skills/epic-orchestrator/SKILL.md` (modified — added Phase 2 intro reference)
+- `.claude/agents/README.md` (modified — added Further Reading entries)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -100,11 +100,15 @@ development_status:
   epic-3-retrospective: optional
 
   # Epic 3.1: Tech Debt — Saves Domain DRY Consolidation (4 stories)
-  epic-3-1-debt: backlog
-  3-1-1-extract-shared-schemas-constants: ready-for-dev
-  3-1-2-shared-test-utilities: ready-for-dev
-  3-1-3-handler-test-consolidation: ready-for-dev
-  3-1-4-dedup-scan-agent-pipeline: ready-for-dev
+  epic-3-1-debt: in-progress
+  3-1-1-extract-shared-schemas-constants: done # PR #194
+  3-1-2-shared-test-utilities: done # PR #196
+  3-1-3-handler-test-consolidation: done # PR #198
+  3-1-4-dedup-scan-agent-pipeline: done # PR #200
+  3-1-5-phase-runner-infrastructure: in-progress
+  3-1-6-saves-crud-validation: ready-for-dev
+  3-1-7-dedup-filtering-api-key: ready-for-dev
+  3-1-8-eventbridge-observability-infra: ready-for-dev
   epic-3-1-retrospective: optional
 
   # Epic 4: Project Management (stories TBD)

--- a/docs/adversarial-review-story-3-1-5-phase-runner-infrastructure.md
+++ b/docs/adversarial-review-story-3-1-5-phase-runner-infrastructure.md
@@ -1,0 +1,94 @@
+# Story 3.1.5 Code Review Findings - Round 1
+
+**Reviewer:** Agent (Fresh Context)
+**Date:** 2026-02-23
+**Branch:** story-3-1-5-phase-runner-infrastructure
+
+## Critical Issues (Must Fix)
+
+1. **[Uncommitted Work]:** Story 3.1.5 deliverables are NOT committed to the branch
+   - **File:** All new/modified files: `.claude/skills/epic-orchestrator/phase-registry.md` (new, untracked), `.claude/skills/epic-orchestrator/phase-runner.md` (new, untracked), `.claude/skills/epic-orchestrator/SKILL.md` (modified, unstaged), `.claude/agents/README.md` (modified, unstaged)
+   - **Problem:** The branch `story-3-1-5-phase-runner-infrastructure` contains only one commit beyond `main`: `f5c5edf feat: add dedup scan agent & pipeline integration (Story 3.1.4) #199 (#200)`, which is the merged Story 3.1.4 work already present on `main`. The actual Story 3.1.5 deliverables exist only as unstaged modifications and untracked files in the working tree. Running `git diff main...story-3-1-5-phase-runner-infrastructure --stat` shows only Story 3.1.4 files, not Story 3.1.5 files. Running `git show story-3-1-5-phase-runner-infrastructure:.claude/skills/epic-orchestrator/phase-registry.md` returns a fatal error confirming the file does not exist in the branch commit tree.
+   - **Impact:** The story cannot be reviewed via branch diff, cannot be PR'd, and the work would be lost if the working tree were cleaned or the branch were checked out fresh. Any CI checks on this branch see zero story-related changes. This is a blocking issue for the entire PR workflow.
+   - **Fix:** Stage and commit all Story 3.1.5 files to the branch:
+     ```bash
+     git add .claude/skills/epic-orchestrator/phase-registry.md \
+             .claude/skills/epic-orchestrator/phase-runner.md \
+             .claude/skills/epic-orchestrator/SKILL.md \
+             .claude/agents/README.md
+     git commit -m "feat: add phase runner infrastructure (Story 3.1.5)"
+     ```
+
+2. **[Branch Contains Unrelated Work]:** Branch diff against main includes Story 3.1.4 files already merged to main
+   - **File:** `.claude/agents/epic-dedup-fixer.md`, `.claude/agents/epic-dedup-scanner.md`, `.claude/skills/epic-orchestrator/dedup-scan-loop.md`, plus README.md and SKILL.md changes from 3.1.4
+   - **Problem:** The branch's sole commit (`f5c5edf`) is a squashed copy of Story 3.1.4 that was already merged to `main` as commit `f5c5edf`. Running `git diff main...story-3-1-5-phase-runner-infrastructure --stat` shows 5 files changed (440 insertions) -- all from Story 3.1.4. When the Story 3.1.5 work is committed, the PR will show Story 3.1.4 files mixed in alongside Story 3.1.5 files.
+   - **Impact:** Violates the project's "one issue = one PR" rule (CLAUDE.md). The PR would contain changes from two stories. Reviewers would see dedup-scanner/fixer agent files that are unrelated to phase runner infrastructure.
+   - **Fix:** Rebase or recreate the branch from current `main` (which already includes the 3.1.4 merge), then commit only the 3.1.5 files. For example:
+     ```bash
+     git rebase main
+     ```
+     After rebase, the 3.1.4 commit should be elided since it is already in main, leaving a clean branch for 3.1.5 work only.
+
+## Important Issues (Should Fix)
+
+1. **[Name Mismatch: Step 2.2]:** Registry step name does not match SKILL.md heading
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/.claude/skills/epic-orchestrator/phase-registry.md` line 10, `/Users/stephen/Documents/ai-learning-hub/.claude/skills/epic-orchestrator/SKILL.md` line 207
+   - **Problem:** Phase-registry.md lists step 2.2 as "Implementation". SKILL.md heading reads `### 2.2 Implementation (Protected by Hooks)`. The registry's own Sync Contract (line 85) states: "Step IDs and names in this registry MUST match the Phase 2 headings in SKILL.md." The parenthetical "(Protected by Hooks)" is part of the SKILL.md heading but absent from the registry.
+   - **Impact:** Violates AC4 ("Phase order and step identities in SKILL.md match phase-registry.md; no conflicting numbering or steps") and the registry's own sync contract. Any future automated drift-detection tool would flag this.
+   - **Fix:** Either add "(Protected by Hooks)" to the registry Name column for step 2.2, or define a convention that parenthetical qualifiers in SKILL.md headings are display-only and not part of the canonical step name (and document this convention in the Sync Contract section).
+
+2. **[Name Mismatch: Step 2.6]:** Registry step name does not match SKILL.md heading
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/.claude/skills/epic-orchestrator/phase-registry.md` line 15, `/Users/stephen/Documents/ai-learning-hub/.claude/skills/epic-orchestrator/SKILL.md` line 443
+   - **Problem:** Phase-registry.md lists step 2.6 as "Finalize Story". SKILL.md heading reads `### 2.6 Finalize Story [HUMAN CHECKPOINT]`. The `[HUMAN CHECKPOINT]` marker is semantically meaningful -- it signals this step requires user interaction -- and is part of the heading.
+   - **Impact:** Same AC4/sync contract violation as above. Additionally, the human checkpoint nature of this step is important metadata that the registry omits. An implementer reading only the registry would not know this step has a mandatory user interaction.
+   - **Fix:** Add `[HUMAN CHECKPOINT]` to the registry Name column, or add a separate column/flag to the registry table indicating which steps are human checkpoints (which would also benefit step 2.1 in some dependency-failure scenarios).
+
+3. **[Internal Contradiction: Dry-Run Skip Logic]:** phase-runner.md Skip Condition table contradicts Dry-Run Mode table
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/.claude/skills/epic-orchestrator/phase-runner.md` lines 30-33 (Skip Condition table) vs lines 71-80 (Dry-Run Mode table)
+   - **Problem:** In the Skip Condition Evaluation table, step 2.2 says on dry-run: "skip to 2.5". This implies steps 2.3, 2.3b, and 2.4 are never reached. However, the Dry-Run Mode table on lines 73-77 documents specific dry-run behavior for steps 2.3 (log message), 2.3b (skipped with log), and 2.4 (skipped with log), which implies these steps ARE visited and individually evaluated. If the runner jumps from 2.2 directly to 2.5, the 2.3/2.3b/2.4 dry-run behaviors are dead documentation. The story's own Task 2.4 description says "skip 2.2, 2.3, 2.3b, and 2.4; proceed directly to 2.5" which implies each step is individually skipped (visited but not executed), aligning with the Dry-Run Mode table, NOT with the "skip to 2.5" jump.
+   - **Impact:** An implementer following the Skip Condition Evaluation table would jump from 2.2 to 2.5 and never emit the 2.3 dry-run log. An implementer following the Dry-Run Mode table would visit each step and log individually. The two authoritative tables in the same document give contradictory instructions.
+   - **Fix:** In the Skip Condition Evaluation table, change step 2.2's evaluation from "skip to 2.5" to "skip step, advance to next" (same pattern as other steps). Each subsequent step (2.3, 2.3b, 2.4) then evaluates its own dry-run skip condition per the Dry-Run Mode table. This makes the two tables consistent.
+
+4. **[Missing Dry-Run Skip in Registry: Step 2.3b]:** Phase-registry.md omits `--dry-run` as a skip condition for 2.3b
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/.claude/skills/epic-orchestrator/phase-registry.md` line 12
+   - **Problem:** The registry lists the skip condition for 2.3b as only: "`story.touches` has no paths under `backend/functions/`". It does not mention `--dry-run`. However, SKILL.md (line 360) explicitly says: "In `--dry-run` mode: Skip subagent spawning, log dry-run messages, proceed directly to 2.4." The phase-runner.md Dry-Run Mode table (line 76) says 2.3b is "Skipped" in dry-run. And `dedup-scan-loop.md` (line 160) documents dry-run skip behavior. The registry -- which claims to be the single source of truth for skip conditions -- is incomplete for this step.
+   - **Impact:** An implementer reading only the registry (as designed) would not skip 2.3b in dry-run mode when the story touches handler files. This is a functional gap, not just a documentation style issue.
+   - **Fix:** Add `--dry-run` as an additional skip condition for step 2.3b. The skip condition should read: "`story.touches` has no paths under `backend/functions/` OR `--dry-run`". This matches the pattern used by steps 2.2, 2.3, and 2.4.
+
+5. **[Missing Dry-Run Skip in Registry: Step 2.3]:** Phase-registry.md omits `--dry-run` as a skip condition for 2.3
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/.claude/skills/epic-orchestrator/phase-registry.md` line 11
+   - **Problem:** Similar to the 2.3b issue: the registry lists the skip condition for 2.3 as `--dry-run: log [DRY-RUN] Would set status to 'review'`, which describes the behavior but calls it a skip condition. Meanwhile, the Dry-Run Mode table in phase-runner.md (line 75) says step 2.3 logs the message but does not say "skipped". The registry entry for 2.3 is actually more of a "behavior modification" than a true skip. The inconsistency is whether 2.3 is skipped (no status update) or runs with a log-only mode. SKILL.md (Phase 2.2 dry-run gate) says "proceed directly to Phase 2.5", implying 2.3 is skipped entirely.
+   - **Impact:** Ambiguity about whether the `review` status is written to the state file during dry-run. If 2.3 runs and writes the status, the state file shows `review` for a story that was never actually implemented. If 2.3 is skipped, the state file stays at `in-progress` (set by 2.1).
+   - **Fix:** Clarify in the registry whether 2.3 is fully skipped in dry-run (no status write) or runs in log-only mode (logs but still writes status). The most consistent interpretation matching SKILL.md's "proceed directly to 2.5" is that 2.3 is fully skipped, but the registry currently shows a log message, suggesting partial execution. Align all three sources (SKILL.md, registry, phase-runner.md).
+
+## Minor Issues (Nice to Have)
+
+1. **[Missing dedup-scan-loop.md in README Further Reading]:** README.md adds links to new docs but omits dedup-scan-loop.md
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/.claude/agents/README.md` lines 200-202
+   - **Problem:** The Further Reading section adds `phase-registry.md`, `phase-runner.md`, and `review-loop.md` but omits `dedup-scan-loop.md`. The body of README.md references `dedup-scan-loop.md` at line 52, but the curated Further Reading list omits it.
+   - **Impact:** Minor discoverability issue. The Further Reading list is incomplete as a quick-reference.
+   - **Fix:** Add `- .claude/skills/epic-orchestrator/dedup-scan-loop.md -- Dedup scan loop protocol` to the Further Reading section.
+
+2. **[Versioning Section Inconsistency]:** New docs have Versioning sections that other skill docs lack
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/.claude/skills/epic-orchestrator/phase-registry.md` lines 88-90, `/Users/stephen/Documents/ai-learning-hub/.claude/skills/epic-orchestrator/phase-runner.md` lines 122-124
+   - **Problem:** Both new documents include a "Versioning" section (Created/Last updated). No other skill doc in the directory (`review-loop.md`, `state-file.md`, `story-runner.md`, `dependency-analysis.md`, `integration-checkpoint.md`, `dedup-scan-loop.md`) has this section. This introduces an inconsistent convention.
+   - **Impact:** Very low. Cosmetic inconsistency. No functional impact.
+   - **Fix:** Either remove the Versioning sections to match existing docs, or add them to all other skill docs in a follow-up for consistency. Not blocking.
+
+3. **[Resume Table: "paused" status mapping is vague]:** phase-runner.md Resume Semantics table has thin coverage of `paused`
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/.claude/skills/epic-orchestrator/phase-runner.md` line 95
+   - **Problem:** The resume table says `paused` status maps to "Varies -- Same logic as `in-progress` -- check for branch/PR existence". The state-file.md resume matrix has three rows for `paused` (PR exists, Branch exists, No PR/branch) with distinct actions. The phase-runner.md table collapses these into one row with a vague description.
+   - **Impact:** Low. An implementer would need to consult state-file.md anyway for the full matrix. But the phase-runner.md table claims to be the resume reference for the phase runner, so brevity here may cause confusion.
+   - **Fix:** Either expand the `paused` row into multiple sub-rows (matching state-file.md), or add a note: "See state-file.md Resume Semantics for the full reconciliation matrix for paused stories."
+
+## Summary
+
+- **Total findings:** 10
+- **Critical:** 2
+- **Important:** 5
+- **Minor:** 3
+- **Recommendation:** FIX REQUIRED
+
+**Assessment of delivered content quality:** Setting aside the two Critical git/branch issues, the actual documentation content is strong. The `phase-registry.md` provides a clear, well-structured single-source-of-truth table with step details, cross-references, and a sync contract. The `phase-runner.md` thoroughly covers the execution loop, skip conditions, gate criteria, escalation semantics, dry-run, resume, and idempotency. The SKILL.md Phase 2 intro paragraph and README.md Further Reading additions are appropriate and well-placed. The main content issues are consistency gaps: name mismatches between the registry and SKILL.md headings (violating the documents' own sync contract), an internal contradiction in the dry-run skip logic tables, and missing `--dry-run` skip conditions for steps 2.3b in the registry.
+
+The two Critical issues are strictly about the git workflow -- the work must be committed to the branch and the branch must be cleaned of unrelated Story 3.1.4 content before a PR can proceed. These are process issues, not content quality issues.

--- a/docs/progress/epic-3.1-auto-run.md
+++ b/docs/progress/epic-3.1-auto-run.md
@@ -1,9 +1,9 @@
 ---
 epic_id: Epic-3.1
-status: done
-scope: ["3.1.1", "3.1.2", "3.1.3"]
+status: in-progress
+scope: ["3.1.1", "3.1.2", "3.1.3", "3.1.5", "3.1.7", "3.1.6"]
 started: "2026-02-23T00:00:00Z"
-last_updated: "2026-02-23T18:02:00Z"
+last_updated: "2026-02-23T22:00:00Z"
 stories:
   "3.1.1":
     {
@@ -42,17 +42,23 @@ stories:
       reviewRounds: 1,
       reviewResult: APPROVE,
     }
+  "3.1.5": { status: pending }
+  "3.1.7": { status: pending }
+  "3.1.6": { status: pending }
 ---
 
 <!-- Human-readable display below (generated from frontmatter) -->
 
 # Epic 3.1 Auto-Run Progress
 
-| Story | Status | PR   | Review Rounds | Result  |
-| ----- | ------ | ---- | ------------- | ------- |
-| 3.1.1 | Done   | #194 | 1             | APPROVE |
-| 3.1.2 | Done   | #196 | 1             | APPROVE |
-| 3.1.3 | Done   | #198 | 1             | APPROVE |
+| Story | Status      | PR   | Review Rounds | Result  | Duration |
+| ----- | ----------- | ---- | ------------- | ------- | -------- |
+| 3.1.1 | ✅ Complete | #194 | 1             | APPROVE | -        |
+| 3.1.2 | ✅ Complete | #196 | 1             | APPROVE | 55m      |
+| 3.1.3 | ✅ Complete | #198 | 1             | APPROVE | -        |
+| 3.1.5 | ⏳ Pending  | -    | -             | -       | -        |
+| 3.1.7 | ⏳ Pending  | -    | -             | -       | -        |
+| 3.1.6 | ⏳ Pending  | -    | -             | -       | -        |
 
 ## Activity Log
 
@@ -69,3 +75,5 @@ stories:
 - [21:52] Story 3.1.3: All quality gates passed, review approved (Round 1), PR #198 ready
 - [21:52] Story 3.1.3 complete (3/3 stories done in this scope)
 - [21:52] Epic 3.1 auto-run complete — all 3 stories done
+- [22:00] Epic 3.1 auto-run resumed — adding Stories 3.1.5, 3.1.7, 3.1.6 to scope
+- [22:00] External deps verified: 3.1.4 (PR #200 merged), 3.4 (PR #190 merged)


### PR DESCRIPTION
## Summary

- Create `phase-registry.md` — single source of truth for Phase 2 step order, skip conditions, and gate criteria
- Create `phase-runner.md` — execution protocol covering dry-run mode, resume semantics, skip/gate evaluation, and escalation
- Update `SKILL.md` Phase 2 intro with cross-references to new docs
- Update `README.md` Further Reading with links to new orchestrator docs

## Changes

| File | Change |
|------|--------|
| `.claude/skills/epic-orchestrator/phase-registry.md` | New — step registry table with sync contract |
| `.claude/skills/epic-orchestrator/phase-runner.md` | New — execution loop, dry-run, resume, idempotency |
| `.claude/skills/epic-orchestrator/SKILL.md` | Added Phase 2 intro paragraph |
| `.claude/agents/README.md` | Added Further Reading links (phase-registry, phase-runner, dedup-scan-loop) |

## Review

Adversarial review Round 1 completed. All Important findings fixed:
- Step names synced with SKILL.md headings (2.2, 2.6)
- Dry-run skip logic contradiction resolved (2.2 "skip to 2.5" → "skip step, advance to next")
- Missing `--dry-run` skip added for step 2.3b
- Step 2.3 dry-run behavior clarified (fully skipped, status stays `in-progress`)
- dedup-scan-loop.md added to README Further Reading

## Test plan

- [x] `npm run lint` — passes (0 errors)
- [x] `npm run type-check` — passes
- [x] Step numbering verified consistent between SKILL.md and phase-registry.md
- [x] No automated tests required (documentation-only story)

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)