### PR TITLE
fix: stabilize smoke tests and resolve barrel import env var issue

### DIFF
--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -306,6 +306,19 @@ This document provides the complete epic and story breakdown for ai-learning-hub
 | FR82-FR85 | Epic 1 | Agentic tool risk & human intervention (risk classification, approval gates, escalation) |
 | FR86-FR88 | Epic 1 | Agentic prompt engineering (7-layer structure, CoT, evaluation tests) |
 | FR89-FR91 | Epic 1 | Agentic model & subagent optimization (model selection, subagent library, context management) |
+| FR92-FR93 | Epic 3.2 | Command/query separation (CQRS-lite) |
+| FR94-FR95 | Epic 3.2 + 4/8 | State machine enforcement (middleware in 3.2; per-entity states in 4, 8) |
+| FR96-FR97 | Epic 3.2 | Idempotency-by-default (middleware + concurrency) |
+| FR98-FR99 | Epic 9 | Operation resources (async pipeline status) |
+| FR100-FR101 | Epic 3.2 | Consistent error contract + field-level validation |
+| FR102 | Epic 3.2 | Event history infrastructure |
+| FR103-FR104 | Epic 3.2 | Agent identity + context metadata pass-through |
+| FR105 | Epic 3.2 | Cursor-based pagination |
+| FR106 | Epic 3.2 | Batch operations endpoint |
+| FR107 | Epic 3.2 | Health & readiness endpoints |
+| FR108 | Epic 9 | Enrichment change detection |
+| FR109 | Epic 10 | admin:content:review-flagged CLI |
+| FR110-FR112 | Epic 10 | Analytics endpoints, cohort data, persona reports |
 
 ---
 
@@ -363,6 +376,7 @@ Per ADRs:
 | **1. Foundation** | Nothing works without infrastructure. Custom scaffold required (ADR-011/012). Shared libraries prevent duplication. Agentic instructions keep agents on rails. | Must be first — everything depends on it |
 | **2. Auth** | Users can't do anything without accounts. API keys enable iOS Shortcut and agent access. | Must follow Foundation — needs tables, Clerk integration |
 | **3. Saves** | Core value prop: save URLs fast. Maya's primary journey. Mobile capture is the hook. | First user-facing value. Proves the platform works. |
+| **3.2 Agent-Native API** | Cross-cutting agent-native patterns (idempotency, concurrency, error contract, events, CQRS). Building middleware before Epics 4-11 means all future domains inherit patterns for free. | After Saves — retrofits 2+3, gates 4+ |
 | **4. Projects** | Organization layer. Marcus's need. No value without saves existing first. | Builds on Saves — projects organize saves |
 | **5. Linking** | The "save-to-build" philosophy. Connects resources to projects. Core differentiator. | Requires both Saves and Projects to exist |
 | **6. Notes/Workspace** | Deep work capability. Marcus's "living notebook." Desktop-focused. | Builds on Projects — notes belong to projects |
@@ -379,6 +393,7 @@ The flow follows the **user value chain**:
 1. **Foundation** → Platform exists
 2. **Auth** → Users exist
 3. **Saves** → Content enters the system (capture)
+3.2. **Agent-Native API** → API becomes agent-safe (middleware + retrofit)
 4. **Projects** → Content gets organized (structure)
 5. **Linking** → Content connects to outcomes (purpose)
 6. **Notes** → Thinking is captured (depth)
@@ -417,6 +432,17 @@ flowchart TB
         S1["Save CRUD API"]
         S2["iOS Shortcut"]
         S3["Filtering/Sorting"]
+    end
+
+    subgraph AgentNative["Epic 3.2: Agent-Native API Foundation"]
+        AN1["3.2.1-6 Shared Middleware<br/>(idempotency, concurrency,<br/>error contract, events,<br/>agent identity, pagination,<br/>scoped keys)"]
+        AN2["3.2.7 Saves Retrofit"]
+        AN3["3.2.8 Auth Retrofit"]
+        AN4["3.2.9 Health/Batch"]
+
+        AN1 --> AN2
+        AN1 --> AN3
+        AN1 --> AN4
     end
 
     subgraph Projects["Epic 4: Projects"]
@@ -464,7 +490,8 @@ flowchart TB
     %% Core Dependencies
     Foundation --> Auth
     Auth --> Saves
-    Saves --> Projects
+    Saves --> AgentNative
+    AgentNative --> Projects
     Projects --> Linking
     Linking --> Notes
     Notes --> Search
@@ -486,11 +513,13 @@ flowchart TB
     %% Styling
     classDef foundation fill:#e8f5e9,stroke:#2e7d32
     classDef userValue fill:#e3f2fd,stroke:#1565c0
+    classDef agentNative fill:#fce4ec,stroke:#c62828
     classDef intelligence fill:#fff3e0,stroke:#ef6c00
     classDef ops fill:#f3e5f5,stroke:#7b1fa2
 
     class Foundation foundation
     class Auth,Saves,Projects,Linking,Notes,Search,Tutorials userValue
+    class AgentNative agentNative
     class Pipelines intelligence
     class Admin,Onboarding ops
 ```
@@ -574,8 +603,52 @@ flowchart TB
 | 3.1.2 | Shared test utilities (save-factories, mock-events, mock-db, assertADR008Error) in backend/test-utils/ |
 | 3.1.3 | Handler & test consolidation — retrofit all 6 saves handlers to shared code; fix saves/handler.ts toPublicSave/deletedAt |
 | 3.1.4 | Dedup scan agent & pipeline — epic-dedup-scanner + epic-dedup-fixer, 2-round loop between quality gates and reviewer |
+| 3.1.5 | Phase runner infrastructure — phase-registry.md + phase-runner.md defining Phase 2 order and execution for orchestrator/automation |
 
 **NFRs covered:** NFR-M1 (Maintainability), NFR-R7 (Reliability — toPublicSave divergence)
+
+---
+
+### Epic 3.2: Agent-Native API Foundation
+**Goal:** Build shared agent-native API middleware and retrofit Epics 2 (Auth) and 3 (Saves) so all existing and future endpoints conform to the agent-native API patterns defined in the PRD (FR92-FR107, NFR-AN1-AN7).
+
+**User Outcome:** AI agents can safely retry commands (idempotency), detect concurrent conflicts (optimistic concurrency), understand what went wrong and what to do next (error contract), query entity history (events), and identify themselves (agent identity). All existing saves and auth endpoints conform to the new patterns. Future epics inherit these patterns automatically via shared middleware.
+
+**Why now:** The agent-native patterns are cross-cutting — every entity needs them. Building the middleware layer now (before Epics 4-11) means Projects, Linking, Tutorials, and all future domains get idempotency, concurrency, error contracts, and event history for free. Retrofitting later would mean touching every handler twice.
+
+**Stories:**
+
+| Story | Description | Dependencies |
+|-------|-------------|--------------|
+| 3.2.1 | **Idempotency & optimistic concurrency middleware** — Shared middleware in `@ai-learning-hub/middleware`: Idempotency-Key header extraction, DynamoDB-backed dedup storage with 24-hour TTL, cached result replay on retry. Version field pattern for DynamoDB items, If-Match header validation, 409 conflict response with current version and allowed retry. | None (shared infra) |
+| 3.2.2 | **Consistent error contract & response envelope** — Extend `@ai-learning-hub/middleware` error builder: all errors include `{ code, message, details, current_state, allowed_actions, required_conditions }`. State machine rejections include `current_state` and `allowed_actions`. Field-level validation errors include `{ field, code, message, constraint, allowed_values }`. Wrap all responses in `{ data, meta: { cursor, total, rate_limit }, links: { self, next } }` envelope. | None (shared infra) |
+| 3.2.3 | **Event history infrastructure** — Events storage pattern (DynamoDB events partition per entity, `PK=EVENTS#{entityType}#{entityId}`). Base handler generator for `GET /:entity/:id/events?since=...`. Records state changes, commands executed, actor attribution (`human` \| `agent`), timestamps, and context metadata. 90-day retention policy. | None (shared infra) |
+| 3.2.4 | **Agent identity, context & rate limit transparency** — `X-Agent-ID` header middleware: extract, validate, record `actor_type` (`human` \| `agent`) on all operations. Context metadata pass-through on commands: `{ context: { trigger, source, confidence, upstream_ref } }` flows into event history. Rate limit transparency headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`) on all responses. | None (shared infra) |
+| 3.2.5 | **Cursor-based pagination** — Shared pagination helper in `@ai-learning-hub/db`: opaque cursor encoding/decoding wrapping DynamoDB `LastEvaluatedKey`, `next_cursor` (null if last page). Retrofit all existing list endpoints (saves list, saves filter, saves sort) to use cursor tokens instead of any offset/page patterns. | None (shared infra) |
+| 3.2.6 | **Scoped API key permissions** — Extend API key creation to support 5 permission tiers (`full`, `capture`, `read`, `saves:write`, `projects:write`). Add scope validation middleware that checks operation against granted scopes. Reject with `403 INSUFFICIENT_SCOPE` including `required_scope` and `granted_scopes`. Update key storage schema to persist scopes. | None (shared infra) |
+| 3.2.7 | **Command endpoint pattern & saves domain retrofit** — Establish CQRS-lite command endpoint convention (`POST /:entity/:id:action`). Add command endpoints for saves: `POST /saves/:id:update-metadata`. Split existing mutation endpoints into query (GET, no side effects) and command (POST, requires Idempotency-Key). Apply idempotency (3.2.1), concurrency (3.2.1), error contract (3.2.2), event history (3.2.3), agent identity (3.2.4), cursor pagination (3.2.5), and response envelope (3.2.2) to all saves handlers. | 3.2.1, 3.2.2, 3.2.3, 3.2.4, 3.2.5 |
+| 3.2.8 | **Auth domain retrofit** — Apply response envelope (3.2.2), error contract (3.2.2), agent identity (3.2.4), scoped permissions (3.2.6), and rate limit transparency (3.2.4) to all auth domain handlers. Update API key creation/revocation to use command pattern with idempotency. | 3.2.1, 3.2.2, 3.2.4, 3.2.6 |
+| 3.2.9 | **Health, readiness & batch operations** — `GET /health` returns service availability. `GET /ready` returns readiness including downstream dependency checks (DynamoDB, auth provider). `POST /batch` accepts array of operations with per-operation `Idempotency-Key`, returns per-operation results. Batch is not transactional — partial success reported per-operation. Up to 25 operations per batch. | 3.2.1, 3.2.2 |
+
+**Story Dependency Diagram:**
+
+```
+Track A — Shared Infrastructure (parallelizable):
+3.2.1 Idempotency & Concurrency ─┐
+3.2.2 Error Contract & Envelope ──┤
+3.2.3 Event History ──────────────┼──► 3.2.7 Saves Domain Retrofit
+3.2.4 Agent Identity & Rate Limit ┤           │
+3.2.5 Cursor Pagination ──────────┘           │
+                                              ▼
+3.2.6 Scoped API Keys ────────────────► 3.2.8 Auth Domain Retrofit
+
+3.2.1 + 3.2.2 ────────────────────────► 3.2.9 Health, Readiness & Batch
+```
+
+**FRs covered:** FR92, FR93, FR94 (middleware only — per-entity states in Epics 4, 8), FR95, FR96, FR97, FR100, FR101, FR102, FR103, FR104, FR105, FR106, FR107
+**NFRs covered:** NFR-AN1, NFR-AN2, NFR-AN4, NFR-AN5, NFR-AN6, NFR-AN7
+
+**Note:** FR94-FR95 (state machine enforcement) middleware is built here, but the actual per-entity state definitions and allowed transitions are implemented in their respective epics: projects (Epic 4, FR25), tutorials (Epic 8, FR40). FR98-FR99 (operation resources) remain in Epic 9 (async pipelines). FR108-FR112 remain in Epics 9 and 10.
 
 ---
 

--- a/backend/functions/saves-get/handler.test.ts
+++ b/backend/functions/saves-get/handler.test.ts
@@ -100,6 +100,18 @@ describe("Saves Get Handler — GET /saves/:saveId", () => {
       );
     });
 
+    it("includes lastAccessedAt in response body", async () => {
+      const item = createTestSaveItem(VALID_SAVE_ID, SAVE_OVERRIDES);
+      mockGetItem.mockResolvedValueOnce(item);
+
+      const event = createGetEvent();
+      const result = await handler(event, mockContext);
+
+      const body = JSON.parse(result.body);
+      expect(body.data.lastAccessedAt).toBeDefined();
+      expect(typeof body.data.lastAccessedAt).toBe("string");
+    });
+
     it("returns 200 even when lastAccessedAt update fails", async () => {
       const item = createTestSaveItem(VALID_SAVE_ID, SAVE_OVERRIDES);
       mockGetItem.mockResolvedValueOnce(item);
@@ -112,6 +124,8 @@ describe("Saves Get Handler — GET /saves/:saveId", () => {
       expect(result.statusCode).toBe(200);
       const body = JSON.parse(result.body);
       expect(body.data.saveId).toBe(VALID_SAVE_ID);
+      // lastAccessedAt should be absent when the update fails
+      expect(body.data.lastAccessedAt).toBeUndefined();
     });
   });
 

--- a/backend/functions/saves-get/handler.ts
+++ b/backend/functions/saves-get/handler.ts
@@ -39,6 +39,7 @@ async function savesGetHandler(ctx: HandlerContext) {
   }
 
   // Update lastAccessedAt — awaited but non-throwing (AC4).
+  const now = new Date().toISOString();
   try {
     await updateItem(
       client,
@@ -46,10 +47,12 @@ async function savesGetHandler(ctx: HandlerContext) {
       {
         key: { PK: `USER#${userId}`, SK: `SAVE#${saveId}` },
         updateExpression: "SET lastAccessedAt = :now",
-        expressionAttributeValues: { ":now": new Date().toISOString() },
+        expressionAttributeValues: { ":now": now },
       },
       logger
     );
+    // Reflect the update in the response so callers always see lastAccessedAt
+    item.lastAccessedAt = now;
   } catch (err) {
     logger.error("Failed to update lastAccessedAt (non-fatal)", err as Error, {
       saveId,

--- a/backend/shared/db/src/users.ts
+++ b/backend/shared/db/src/users.ts
@@ -358,6 +358,8 @@ export async function listApiKeys(
         ":skPrefix": "APIKEY#",
       },
       filterExpression: "attribute_not_exists(revokedAt)",
+      consistentRead: true,
+      scanIndexForward: false, // Newest keys first (ULID sort key is time-ordered)
       limit,
       cursor,
     },

--- a/docs/progress/epic-3-1-stories-and-plan.md
+++ b/docs/progress/epic-3-1-stories-and-plan.md
@@ -1,16 +1,16 @@
-# Epic 3.1: Tech Debt — Saves Domain DRY Consolidation
+# Epic 3.1: Tech Debt — Saves Domain DRY Consolidation & Smoke Test Expansion
 
 **Date:** 2026-02-23
 **Source:** Post-implementation audit of Epic 3 stories 3.1a–3.4 (6 handlers, 6 test files, 3 shared packages)
-**NFRs:** NFR-M1 (Maintainability), NFR-R7 (Reliability — toPublicSave divergence)
+**NFRs:** NFR-M1 (Maintainability), NFR-R7 (Reliability — toPublicSave divergence), NFR-O1 (Observability — EventBridge verification)
 
 ---
 
 ## Epic Goal
 
-Eliminate cross-handler code duplication introduced during Epic 3 implementation, extract shared utilities, standardize test scaffolding, and introduce a pipeline-level deduplication scan agent that prevents future duplication before code reaches the adversarial reviewer.
+Eliminate cross-handler code duplication introduced during Epic 3 implementation, extract shared utilities, standardize test scaffolding, introduce a pipeline-level deduplication scan agent that prevents future duplication before code reaches the adversarial reviewer, and expand the smoke test suite to validate the full saves domain infrastructure end-to-end in the deployed AWS environment.
 
-**User Outcome:** Codebase is DRY across all saves handlers. Future stories automatically get flagged for duplication before review. Developer velocity improves through shared test factories and mock helpers.
+**User Outcome:** Codebase is DRY across all saves handlers. Future stories automatically get flagged for duplication before review. Developer velocity improves through shared test factories and mock helpers. Deployments are validated by a phased smoke test suite that proves auth, CRUD, dedup, filtering, API key auth, and EventBridge wiring all work correctly in AWS — catching CDK misconfigurations, missing IAM permissions, and broken env vars before users hit them.
 
 ---
 
@@ -31,25 +31,63 @@ Eliminate cross-handler code duplication introduced during Epic 3 implementation
 | 11  | `assertADR008Error` used in only 1 of 6 test files                                                      | 5 test files | Inconsistent error assertions    |
 | 12  | Response wrapping approach inconsistent (3 patterns)                                                    | 6 handlers   | Convention unclear               |
 
+## Smoke Test Gap Analysis
+
+The existing smoke test (PR #173) validates Epic 2/2.1 infrastructure — the auth chain, user profiles, route connectivity, and rate limiting (14 scenarios, AC1–AC14). The only Epic 3 coverage is AC9/AC10 (route-connectivity), which proves CDK wiring exists but not that the Lambdas actually work. None of the following are functionally validated: saves DynamoDB table operations, TransactWriteItems, GSI queries, EventBridge PutEvents, content type detection, filtering/sorting, or API key auth against saves routes.
+
 ---
 
 ## Story Dependency Order
 
 ```
+Track A — Code Consolidation:
 3.1.1 Shared Schemas & Constants  ──►  3.1.2 Test Utilities  ──►  3.1.3 Handler Consolidation
                                                                           │
                                                                           ▼
                                                               3.1.4 Dedup Scan Agent & Pipeline
+
+Track B — Smoke Test Expansion (independent of Track A):
+3.1.5 Phase Runner Infra  ──►  3.1.6 Saves CRUD & Validation  ──►  3.1.7 Saves Dedup, Filtering & API Key
+                                       │
+3.1.8 EventBridge Observability  ──────┴──►  3.1.9 EventBridge Verification
 ```
 
-- **3.1.1** extracts shared code that 3.1.2 and 3.1.3 depend on
-- **3.1.2** creates test utilities that 3.1.3 uses when updating test files
+### Track A — Code Consolidation
+
+- **3.1.1** extracts shared code that 3.1.2 and 3.1.3 depend on ✅ Done (#194)
+- **3.1.2** creates test utilities that 3.1.3 uses when updating test files ✅ Done (#196)
 - **3.1.3** retrofits all handlers and tests to use shared code from 3.1.1 + 3.1.2
 - **3.1.4** adds the pipeline agent (can be done after 3.1.3 proves the patterns work)
+
+### Track B — Smoke Test Expansion
+
+- **3.1.5** refactors the smoke test runner to support phased execution and CLI flags
+- **3.1.6** adds saves CRUD lifecycle and validation error scenarios (highest-value addition)
+- **3.1.7** adds dedup detection, filtering/sorting, and API key + saves cross-auth scenarios
+- **3.1.8** adds EventBridge observability infra (CDK rule + CloudWatch log group target on event bus)
+- **3.1.9** adds EventBridge verification scenario that queries CloudWatch logs after creating a save
+
+Tracks A and B can be worked **in parallel** — they have no shared dependencies.
+
+### Phase Mapping
+
+The smoke test phases (runtime concept) map to stories as follows:
+
+| Phase | Name               | Scenarios | Story              |
+| ----- | ------------------ | --------- | ------------------ |
+| 1     | `infra-auth`       | AC1–AC14  | Existing (PR #173) |
+| 2     | `saves-crud`       | SC1–SC8   | 3.1.6              |
+| 3     | `saves-dedup`      | SD1–SD2   | 3.1.7              |
+| 4     | `saves-validation` | SV1–SV4   | 3.1.6              |
+| 5     | `saves-filtering`  | SF1–SF3   | 3.1.7              |
+| 6     | `saves-apikey`     | SA1       | 3.1.7              |
+| 7     | `eventbridge`      | EB1–EB3   | 3.1.9              |
 
 ---
 
 ## Story 3.1.1: Extract Shared Schemas & Constants
+
+**Status:** ✅ Done (PR #194)
 
 **Goal:** Move duplicated schemas, constants, and helpers from individual handlers into shared packages.
 
@@ -64,27 +102,16 @@ Eliminate cross-handler code duplication introduced during Epic 3 implementation
 
 ### Tasks / Subtasks
 
-- [ ] Task 1: Extract `saveIdPathSchema` (AC: #1)
-  - [ ] 1.1 Add `saveIdPathSchema` to `backend/shared/validation/src/schemas.ts`
-  - [ ] 1.2 Export from `backend/shared/validation/src/index.ts`
-  - [ ] 1.3 Rebuild validation package: `npm run -w @ai-learning-hub/validation build`
-  - [ ] 1.4 Update imports in `saves-get`, `saves-update`, `saves-delete`, `saves-restore` handlers
-  - [ ] 1.5 Remove local `saveIdPathSchema` definitions from all 4 handlers
-- [ ] Task 2: Extract rate limit constant (AC: #2)
-  - [ ] 2.1 Add `SAVES_WRITE_RATE_LIMIT` to `backend/shared/db/src/saves.ts`
-  - [ ] 2.2 Export from `backend/shared/db/src/index.ts`
-  - [ ] 2.3 Update all 4 write handlers to use the constant
-- [ ] Task 3: Extract EventBridge init helper (AC: #3)
-  - [ ] 3.1 Add `requireEventBus()` function to `backend/shared/events/src/index.ts` (or appropriate module)
-  - [ ] 3.2 Update all 4 event-emitting handlers to use `requireEventBus()`
-  - [ ] 3.3 Remove inline `EVENT_BUS_NAME` + guard + `getDefaultEBClient()` boilerplate
-- [ ] Task 4: Verify all tests pass (AC: #4)
-  - [ ] 4.1 Run `npm test` — all tests must pass
-  - [ ] 4.2 Run `npm run type-check` — clean
+- [x] Task 1: Extract `saveIdPathSchema` (AC: #1)
+- [x] Task 2: Extract rate limit constant (AC: #2)
+- [x] Task 3: Extract EventBridge init helper (AC: #3)
+- [x] Task 4: Verify all tests pass (AC: #4)
 
 ---
 
 ## Story 3.1.2: Shared Test Utilities for Saves Domain
+
+**Status:** ✅ Done (PR #196)
 
 **Goal:** Extract duplicated test factories, mock helpers, and assertion utilities into `backend/test-utils/` so all saves test files share common scaffolding.
 
@@ -101,23 +128,16 @@ Eliminate cross-handler code duplication introduced during Epic 3 implementation
 
 ### Tasks / Subtasks
 
-- [ ] Task 1: Create `backend/test-utils/save-factories.ts` (AC: #1, #4)
-  - [ ] 1.1 Implement `createTestSaveItem(saveId?, overrides?)` with sensible defaults
-  - [ ] 1.2 Export `VALID_SAVE_ID` constant
-  - [ ] 1.3 Export from `backend/test-utils/index.ts`
-- [ ] Task 2: Create `backend/test-utils/mock-events.ts` (AC: #2)
-  - [ ] 2.1 Implement `mockEventsModule()` returning mock `emitEvent`, `getDefaultClient`, `SAVES_EVENT_SOURCE`
-  - [ ] 2.2 Export from `backend/test-utils/index.ts`
-- [ ] Task 3: Create `backend/test-utils/mock-db.ts` (AC: #3)
-  - [ ] 3.1 Implement `mockDbModule(mockFns)` with standard table configs, `toPublicSave`, `requireEnv`
-  - [ ] 3.2 Export from `backend/test-utils/index.ts`
-- [ ] Task 4: Verify test infrastructure works (AC: #6)
-  - [ ] 4.1 Update one test file (e.g., `saves-get`) as proof-of-concept
-  - [ ] 4.2 Run tests to confirm no regressions
+- [x] Task 1: Create `backend/test-utils/save-factories.ts` (AC: #1, #4)
+- [x] Task 2: Create `backend/test-utils/mock-events.ts` (AC: #2)
+- [x] Task 3: Create `backend/test-utils/mock-db.ts` (AC: #3)
+- [x] Task 4: Verify test infrastructure works (AC: #6)
 
 ---
 
 ## Story 3.1.3: Handler & Test Consolidation
+
+**Status:** In Progress
 
 **Goal:** Retrofit all 6 saves handlers and their test files to use shared code from stories 3.1.1 and 3.1.2. Fix the `saves/handler.ts` divergence and standardize patterns.
 
@@ -165,6 +185,8 @@ Eliminate cross-handler code duplication introduced during Epic 3 implementation
 ---
 
 ## Story 3.1.4: Deduplication Scan Agent & Pipeline Integration
+
+**Status:** Pending (depends on 3.1.3)
 
 **Goal:** Create a new `epic-dedup-scanner` agent that runs BEFORE the adversarial reviewer in the orchestrator pipeline. The scanner reads all handlers in the same domain (not just the branch diff) to detect cross-handler duplication. It has its own 2-round fix loop and must pass (0 findings at Important+) before the code proceeds to the reviewer.
 
@@ -229,10 +251,352 @@ The dedup scan catches structural/DRY issues. The reviewer catches correctness/s
 
 ---
 
+## Story 3.1.5: Smoke Test Phase Runner Infrastructure
+
+**Status:** Pending
+
+**Goal:** Refactor the smoke test runner (`scripts/smoke-test/`) to support phased execution with CLI flags. The existing 14 scenarios (AC1–AC14) become Phase 1 (`infra-auth`). New phases are registered but empty — subsequent stories fill them in.
+
+### Acceptance Criteria
+
+| #   | Given                                                            | When                                                 | Then                                                                                                                                                                       |
+| --- | ---------------------------------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC1 | Smoke test runner (`run.ts`) executes all scenarios sequentially | Runner refactored to support phase grouping          | Each scenario belongs to a named phase; phases execute in numeric order; existing scenarios assigned to Phase 1 (`infra-auth`)                                             |
+| AC2 | No way to run a subset of scenarios                              | `--phase` flag added to CLI                          | `npm run smoke-test -- --phase=2` runs only Phase 2; `npm run smoke-test -- --phase=1,4` runs Phases 1 and 4; phases execute in numeric order regardless of argument order |
+| AC3 | No way to run up to a specific phase                             | `--up-to` flag added to CLI                          | `npm run smoke-test -- --up-to=3` runs Phases 1, 2, 3 in order; respects the natural dependency chain                                                                      |
+| AC4 | No default — must explicitly request phases                      | Runner invoked with no flags                         | All registered phases execute in order (full suite); behavior is identical to current runner for existing scenarios                                                        |
+| AC5 | Phase execution provides clear output                            | Any phase combination runs                           | Console output shows phase name/number header before each phase's scenarios; summary at end shows pass/fail/skip counts per phase                                          |
+| AC6 | Phase metadata is extensible                                     | New phase registered                                 | A phase is defined by `{ number, name, scenarios[], dependsOn?: number[] }`; adding a new phase requires only adding an entry to the registry and a scenario file          |
+| AC7 | Phase dependency validation                                      | `--phase=3` requested but Phase 3 depends on Phase 2 | Runner warns that Phase 2 is a dependency of Phase 3 but will NOT be run; does not auto-include (user chose explicitly); warning is informational only                     |
+| AC8 | Existing tests and lint pass                                     | After refactor                                       | `npm run lint` passes; existing smoke test scenarios produce identical results when run with no flags                                                                      |
+
+### Tasks / Subtasks
+
+- [ ] Task 1: Define phase registry type and data structure (AC: #6)
+  - [ ] 1.1 Create `scripts/smoke-test/phases.ts` with `Phase` type: `{ number, name, scenarios, dependsOn? }`
+  - [ ] 1.2 Register Phase 1 (`infra-auth`) containing all existing scenario groups
+  - [ ] 1.3 Register placeholder entries for Phases 2–7 (empty scenario arrays, filled by subsequent stories)
+- [ ] Task 2: Add CLI flag parsing (AC: #2, #3, #4)
+  - [ ] 2.1 Parse `--phase=N` and `--phase=N,M` from `process.argv`
+  - [ ] 2.2 Parse `--up-to=N` from `process.argv`
+  - [ ] 2.3 Default to all phases when no flags provided
+  - [ ] 2.4 Validate that `--phase` and `--up-to` are mutually exclusive
+- [ ] Task 3: Refactor `run.ts` to execute by phase (AC: #1, #5)
+  - [ ] 3.1 Replace flat scenario array with phase-grouped execution loop
+  - [ ] 3.2 Add phase header output (`═══ Phase 1: infra-auth ═══`)
+  - [ ] 3.3 Add per-phase summary in final results table
+  - [ ] 3.4 Preserve existing exit code behavior (non-zero on any failure)
+- [ ] Task 4: Add dependency warnings (AC: #7)
+  - [ ] 4.1 When `--phase` is used, check if requested phases have unmet `dependsOn` phases
+  - [ ] 4.2 Print informational warning (not an error — user may know what they're doing)
+- [ ] Task 5: Verify backward compatibility (AC: #8)
+  - [ ] 5.1 Run `npm run lint` — passes
+  - [ ] 5.2 Run smoke test with no flags — identical output to current runner
+
+### Dev Notes
+
+**Phase registry (initial state after this story):**
+
+| Phase | Name               | Scenarios | dependsOn |
+| ----- | ------------------ | --------- | --------- |
+| 1     | `infra-auth`       | AC1–AC14  | —         |
+| 2     | `saves-crud`       | _(empty)_ | [1]       |
+| 3     | `saves-dedup`      | _(empty)_ | [2]       |
+| 4     | `saves-validation` | _(empty)_ | [1]       |
+| 5     | `saves-filtering`  | _(empty)_ | [2]       |
+| 6     | `saves-apikey`     | _(empty)_ | [1]       |
+| 7     | `eventbridge`      | _(empty)_ | [2]       |
+
+Empty phases are skipped silently during execution (no header printed, no "0/0" in summary).
+
+---
+
+## Story 3.1.6: Saves CRUD & Validation Smoke Scenarios
+
+**Status:** Pending (depends on 3.1.5)
+
+**Goal:** Add the highest-value smoke test scenarios: a full save lifecycle (create → get → list → update → delete → restore) and validation error paths. These prove that DynamoDB table access, IAM permissions, env vars, TransactWriteItems, soft-delete logic, and the ADR-008 error chain all work correctly in the deployed environment.
+
+### Acceptance Criteria
+
+**Phase 2 — Saves CRUD Lifecycle (SC1–SC8):**
+
+| #   | Given                          | When                                                                  | Then                                                                                                                              |
+| --- | ------------------------------ | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| SC1 | Valid JWT auth token available | `POST /saves` with `{ url: "https://example.com/smoke-<timestamp>" }` | 201 response; body has `{ data: { saveId, url, normalizedUrl, urlHash, contentType, tags, ... } }`; `saveId` is a valid ULID      |
+| SC2 | Save created in SC1            | `GET /saves/<saveId>`                                                 | 200 response; body `data.saveId` matches SC1; `data.url` matches submitted URL; `data.lastAccessedAt` is present (updated on GET) |
+| SC3 | Save created in SC1            | `GET /saves`                                                          | 200 response; `items` array contains an entry with matching `saveId`; response has `count` field                                  |
+| SC4 | Save created in SC1            | `PATCH /saves/<saveId>` with `{ title: "Smoke Test Updated" }`        | 200 response; body `data.title` equals `"Smoke Test Updated"`; `data.updatedAt` is later than `data.createdAt`                    |
+| SC5 | Save created in SC1            | `DELETE /saves/<saveId>`                                              | 204 response; empty body                                                                                                          |
+| SC6 | Save deleted in SC5            | `GET /saves/<saveId>`                                                 | 404 response; ADR-008 error shape with code `"NOT_FOUND"`                                                                         |
+| SC7 | Save deleted in SC5            | `POST /saves/<saveId>/restore`                                        | 200 response; body `data.saveId` matches; `data.deletedAt` is absent (stripped by `toPublicSave`)                                 |
+| SC8 | Save restored in SC7           | `GET /saves/<saveId>`                                                 | 200 response; save is accessible again; `data.title` still equals `"Smoke Test Updated"` (persisted through delete/restore cycle) |
+
+**Phase 4 — Saves Validation Errors (SV1–SV4):**
+
+| #   | Given                                              | When                                                                            | Then                                                             |
+| --- | -------------------------------------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| SV1 | Valid auth token available                         | `POST /saves` with `{ url: "not-a-url" }`                                       | 400 response; ADR-008 error shape with code `"VALIDATION_ERROR"` |
+| SV2 | Valid auth token available                         | `GET /saves/not-a-valid-ulid`                                                   | 400 response; ADR-008 error shape with code `"VALIDATION_ERROR"` |
+| SV3 | Valid auth token available                         | `GET /saves/01JNOTREAL000000000000000` (valid ULID format, nonexistent)         | 404 response; ADR-008 error shape with code `"NOT_FOUND"`        |
+| SV4 | Save exists (reuse SC1's save or create a new one) | `PATCH /saves/<saveId>` with `{ url: "https://changed.com" }` (immutable field) | 400 response; ADR-008 error shape with code `"VALIDATION_ERROR"` |
+
+**General:**
+
+| #   | Given                     | When                     | Then                                                                                                                                                     |
+| --- | ------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC1 | All scenarios implemented | Scenarios registered     | Phase 2 (`saves-crud`) contains SC1–SC8; Phase 4 (`saves-validation`) contains SV1–SV4; phase registry updated                                           |
+| AC2 | Test data created         | After scenario execution | All test saves are cleaned up in `finally` blocks (soft-deleted); URLs use unique timestamps to avoid cross-run conflicts                                |
+| AC3 | Existing phases intact    | After adding new phases  | Phase 1 (`infra-auth`) scenarios unchanged; `npm run smoke-test -- --phase=1` produces identical results                                                 |
+| AC4 | Helper utilities needed   | For save response shapes | `assertSaveShape(body)` helper added to `scripts/smoke-test/helpers.ts` validating `{ data: { saveId, url, normalizedUrl, urlHash, contentType, ... } }` |
+
+### Tasks / Subtasks
+
+- [ ] Task 1: Add `assertSaveShape` helper (AC: #4)
+  - [ ] 1.1 Add to `scripts/smoke-test/helpers.ts`
+  - [ ] 1.2 Validate required fields: `saveId`, `url`, `normalizedUrl`, `urlHash`, `contentType`, `tags`, `createdAt`, `updatedAt`
+- [ ] Task 2: Create `scripts/smoke-test/scenarios/saves-crud.ts` (SC1–SC8)
+  - [ ] 2.1 SC1: POST /saves with unique timestamp URL → assert 201 + save shape
+  - [ ] 2.2 SC2: GET /saves/:saveId → assert 200 + matching saveId + lastAccessedAt present
+  - [ ] 2.3 SC3: GET /saves → assert 200 + items contains saveId
+  - [ ] 2.4 SC4: PATCH /saves/:saveId → assert 200 + title updated
+  - [ ] 2.5 SC5: DELETE /saves/:saveId → assert 204
+  - [ ] 2.6 SC6: GET deleted save → assert 404 + ADR-008 NOT_FOUND
+  - [ ] 2.7 SC7: POST /saves/:saveId/restore → assert 200 + no deletedAt
+  - [ ] 2.8 SC8: GET restored save → assert 200 + title persisted
+  - [ ] 2.9 Add cleanup in `finally` block
+- [ ] Task 3: Create `scripts/smoke-test/scenarios/saves-validation.ts` (SV1–SV4)
+  - [ ] 3.1 SV1: POST with invalid URL → assert 400 + VALIDATION_ERROR
+  - [ ] 3.2 SV2: GET with invalid ULID → assert 400 + VALIDATION_ERROR
+  - [ ] 3.3 SV3: GET with nonexistent ULID → assert 404 + NOT_FOUND
+  - [ ] 3.4 SV4: PATCH with immutable field → assert 400 + VALIDATION_ERROR
+- [ ] Task 4: Register scenarios in phase registry (AC: #1)
+  - [ ] 4.1 Import and register saves-crud scenarios as Phase 2
+  - [ ] 4.2 Import and register saves-validation scenarios as Phase 4
+- [ ] Task 5: Verify (AC: #2, #3)
+  - [ ] 5.1 Run `npm run smoke-test -- --phase=1` — identical to current results
+  - [ ] 5.2 Run `npm run smoke-test -- --phase=2` — SC1–SC8 pass against deployed env
+  - [ ] 5.3 Run `npm run smoke-test -- --phase=4` — SV1–SV4 pass against deployed env
+  - [ ] 5.4 Run `npm run lint` — passes
+
+### Dev Notes
+
+**Cleanup strategy:** SC1 creates a save with URL `https://example.com/smoke-test-<Date.now()>`. The `finally` block calls `DELETE /saves/<saveId>` to soft-delete it. Since URLs are timestamped, parallel runs won't conflict. The soft-deleted data remains in DynamoDB but is invisible to the API — no manual table cleanup needed.
+
+**SC1 validates the most infrastructure in a single call:** Lambda execution, DynamoDB TransactWriteItems (save item + user counter update), GSI creation (urlHash-index), EventBridge PutEvents permission, env var resolution (SAVES_TABLE, USERS_TABLE, EVENT_BUS_NAME), Zod schema validation, and the middleware chain (auth + error handling + response wrapping).
+
+---
+
+## Story 3.1.7: Saves Dedup, Filtering & API Key Smoke Scenarios
+
+**Status:** Pending (depends on 3.1.6)
+
+**Goal:** Add second-tier smoke scenarios that validate duplicate detection (including auto-restore on re-save), filtering/sorting query parameters, and the critical API key + saves cross-auth path used by iOS Shortcuts and agents.
+
+### Acceptance Criteria
+
+**Phase 3 — Saves Dedup (SD1–SD2):**
+
+| #   | Given                                                     | When                                | Then                                                                                                                                       |
+| --- | --------------------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| SD1 | A save exists for URL X                                   | `POST /saves` with same URL X       | 409 response; body has `{ error: { code: "DUPLICATE_SAVE" }, existingSave: { saveId, ... } }`; `existingSave` does NOT contain `deletedAt` |
+| SD2 | Save for URL X is soft-deleted (`DELETE /saves/<saveId>`) | `POST /saves` with same URL X again | 200 response (not 201, not 409); save is auto-restored; returned `saveId` matches the original; `deletedAt` is absent                      |
+
+**Phase 5 — Saves Filtering (SF1–SF3):**
+
+| #   | Given                                                                | When                                         | Then                                                                                                  |
+| --- | -------------------------------------------------------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| SF1 | Two saves exist with different content types (e.g., article + video) | `GET /saves?contentType=video`               | 200 response; `items` array contains only saves with `contentType: "video"`; article save is excluded |
+| SF2 | Multiple saves exist with different `createdAt` timestamps           | `GET /saves?sort=createdAt&order=desc`       | 200 response; first item's `createdAt` ≥ second item's `createdAt`                                    |
+| SF3 | A save exists with a unique title (set via PATCH)                    | `GET /saves?search=<unique-title-substring>` | 200 response; `items` array contains the matching save; other saves excluded                          |
+
+**Phase 6 — Saves via API Key (SA1):**
+
+| #   | Given                                                | When                                                                                                         | Then                                                                                                                                    |
+| --- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| SA1 | A valid API key exists (created in Phase 1 or fresh) | `POST /saves` with `x-api-key` header (no JWT) and `{ url: "https://example.com/apikey-smoke-<timestamp>" }` | 201 response; save shape is valid; `userId` in response matches the API key's owner; proves `jwt-or-apikey` auth works for saves routes |
+
+**General:**
+
+| #   | Given                     | When                     | Then                                                                                             |
+| --- | ------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------ |
+| AC1 | All scenarios implemented | Scenarios registered     | Phase 3 contains SD1–SD2; Phase 5 contains SF1–SF3; Phase 6 contains SA1; phase registry updated |
+| AC2 | Test data created         | After scenario execution | All test saves cleaned up in `finally` blocks; URLs use unique timestamps                        |
+| AC3 | Existing phases intact    | After adding new phases  | Phases 1, 2, 4 unchanged; full suite still passes                                                |
+
+### Tasks / Subtasks
+
+- [ ] Task 1: Create `scripts/smoke-test/scenarios/saves-dedup.ts` (SD1–SD2)
+  - [ ] 1.1 SD1: Create save, then POST same URL → assert 409 + DUPLICATE_SAVE + existingSave shape (no deletedAt)
+  - [ ] 1.2 SD2: Delete the save, then POST same URL → assert 200 + auto-restored + same saveId
+  - [ ] 1.3 Add cleanup in `finally` block
+- [ ] Task 2: Create `scripts/smoke-test/scenarios/saves-filtering.ts` (SF1–SF3)
+  - [ ] 2.1 Create 2 test saves with different URLs yielding different content types
+  - [ ] 2.2 SF1: GET /saves?contentType=video → assert only video saves returned
+  - [ ] 2.3 SF2: GET /saves?sort=createdAt&order=desc → assert descending order
+  - [ ] 2.4 SF3: PATCH one save with unique title, then GET /saves?search=<title> → assert match
+  - [ ] 2.5 Add cleanup in `finally` block
+- [ ] Task 3: Create `scripts/smoke-test/scenarios/saves-apikey.ts` (SA1)
+  - [ ] 3.1 SA1: Create or reuse API key, then POST /saves with x-api-key header → assert 201 + valid save shape
+  - [ ] 3.2 Add cleanup in `finally` block
+- [ ] Task 4: Register scenarios in phase registry (AC: #1)
+  - [ ] 4.1 Import and register saves-dedup as Phase 3
+  - [ ] 4.2 Import and register saves-filtering as Phase 5
+  - [ ] 4.3 Import and register saves-apikey as Phase 6
+- [ ] Task 5: Verify (AC: #2, #3)
+  - [ ] 5.1 Run full suite — all phases pass
+  - [ ] 5.2 Run `npm run smoke-test -- --phase=3` — SD1–SD2 pass
+  - [ ] 5.3 Run `npm run smoke-test -- --phase=5` — SF1–SF3 pass
+  - [ ] 5.4 Run `npm run smoke-test -- --phase=6` — SA1 passes
+  - [ ] 5.5 Run `npm run lint` — passes
+
+### Dev Notes
+
+**SD2 is the trickiest scenario.** It validates the auto-restore path in `saves/handler.ts`: when a user re-saves a URL that was previously soft-deleted, the handler detects the existing (deleted) save via GSI, removes `deletedAt`, and returns 200 instead of 409. This exercises TransactWriteItems with a ConditionExpression on the existing item.
+
+**SA1 is critical for the iOS Shortcut / agent capture flow.** The existing API key smoke tests (AC5–AC8) only hit `/users/me`. This scenario proves that `jwt-or-apikey` auth works specifically on saves routes, which resolve `userId` from a different path in the authorizer response.
+
+**SF1 content type detection:** Use a YouTube URL (e.g., `https://youtube.com/watch?v=smoke-test`) to get `contentType: "video"` and a GitHub URL (e.g., `https://github.com/smoke-test`) to get `contentType: "article"`. The content type detection is deterministic based on URL patterns.
+
+---
+
+## Story 3.1.8: EventBridge Observability Infrastructure
+
+**Status:** Pending (no dependencies — can start immediately)
+
+**Goal:** Add a CloudWatch Log Group target to the EventBridge event bus so that all events flowing through the bus are logged. This provides observability into event flow and enables the smoke test (Story 3.1.9) to verify EventBridge wiring by querying CloudWatch Logs. This also validates that CloudWatch logging works in the deployed environment.
+
+### Acceptance Criteria
+
+| #   | Given                                                            | When                                                                | Then                                                                                                                                         |
+| --- | ---------------------------------------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC1 | EventBridge bus `ai-learning-hub-events` has no rules or targets | CDK stack updated with a rule + CloudWatch Log Group target         | New `events.Rule` on the bus matches all events (`{ source: [{ prefix: "ai-learning-hub" }] }`) and targets a CloudWatch Log Group           |
+| AC2 | No explicit CloudWatch Log Group exists for event bus logging    | Log group created by CDK                                            | Log group named `/aws/events/ai-learning-hub-events` exists with retention policy of 14 days (dev) / 90 days (prod based on stage param)     |
+| AC3 | EventBridge needs permission to write to CloudWatch Logs         | CDK grants necessary permissions                                    | The rule target has the correct resource policy allowing `events.amazonaws.com` to create log streams and put log events                     |
+| AC4 | Observability stack exists but only has X-Ray sampling           | EventBridge logging added to events stack (not observability stack) | Changes are in `infra/lib/stacks/core/events.stack.ts` (co-located with the bus); observability stack is not modified                        |
+| AC5 | CDK Nag may flag new resources                                   | `cdk synth` runs                                                    | No new CDK Nag errors; suppressions added with documented reasons if needed                                                                  |
+| AC6 | Infrastructure deploys cleanly                                   | `cdk deploy` runs                                                   | Stack deploys without errors; CloudWatch Log Group visible in AWS Console; creating a save via API produces a log entry in the new log group |
+| AC7 | All existing tests pass                                          | After CDK changes                                                   | `npm test` passes; `npm run lint` passes; no changes to Lambda handler code                                                                  |
+
+### Tasks / Subtasks
+
+- [ ] Task 1: Add CloudWatch Log Group to events stack (AC: #2, #4)
+  - [ ] 1.1 Import `aws-cdk-lib/aws-logs` in `events.stack.ts`
+  - [ ] 1.2 Create `LogGroup` with name `/aws/events/ai-learning-hub-events` and appropriate retention
+  - [ ] 1.3 Export log group name as stack output (`AiLearningHub-EventLogGroupName`)
+- [ ] Task 2: Add EventBridge Rule with Log Group target (AC: #1, #3)
+  - [ ] 2.1 Create `events.Rule` matching `source: [{ prefix: "ai-learning-hub" }]`
+  - [ ] 2.2 Add `CloudWatchLogGroup` target pointing to the log group
+  - [ ] 2.3 CDK handles the resource policy automatically via `targets.CloudWatchLogGroup`
+- [ ] Task 3: Handle CDK Nag (AC: #5)
+  - [ ] 3.1 Run `cdk synth` and check for Nag findings
+  - [ ] 3.2 Add suppressions with documented reasons if needed
+- [ ] Task 4: Verify (AC: #6, #7)
+  - [ ] 4.1 Run `npm test` — passes
+  - [ ] 4.2 Run `npm run lint` — passes
+  - [ ] 4.3 Run `cdk synth` — succeeds without errors
+  - [ ] 4.4 After deploy: create a save via API, check CloudWatch Log Group for matching event entry
+
+### Dev Notes
+
+**Why put this in events.stack.ts, not observability.stack.ts?** The log group is tightly coupled to the event bus — it's a target on a rule attached to the bus. Co-locating keeps the events stack self-contained. The observability stack is for cross-cutting concerns (dashboards, alarms, X-Ray config). If we later add a CloudWatch Dashboard that queries this log group, _that_ would go in the observability stack.
+
+**Retention policy:** 14 days is sufficient for dev/staging (keeps costs low). For production, 90 days provides enough history for incident investigation. Use a stage parameter (passed via CDK context or stack props) to vary retention.
+
+**What gets logged:** Every event on the bus is captured. The event detail includes the full event payload (e.g., `{ userId, saveId, normalizedUrl, urlHash }` for `SaveCreated`). This is intentional — it provides full observability for debugging. Sensitive data considerations: these events contain user IDs and URLs but no PII beyond that.
+
+**No Lambda handler changes.** The existing handlers already call `emitEvent()` fire-and-forget. This story only adds infrastructure to _capture_ those events.
+
+---
+
+## Story 3.1.9: EventBridge Verification Smoke Scenario
+
+**Status:** Pending (depends on 3.1.6 + 3.1.8)
+
+**Goal:** Add a smoke test scenario that verifies EventBridge events are actually being emitted and delivered by querying CloudWatch Logs after creating a save. This validates the full event chain: Lambda → EventBridge PutEvents → Rule → CloudWatch Logs target.
+
+### Acceptance Criteria
+
+**Phase 7 — EventBridge Verification (EB1–EB3):**
+
+| #   | Given                                                                    | When                                                                                                                  | Then                                                                                                                                            |
+| --- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| EB1 | `SMOKE_TEST_EVENT_LOG_GROUP` env var set (or derived from stack outputs) | `POST /saves` with unique URL, then wait 5–10 seconds, then `FilterLogEvents` on `/aws/events/ai-learning-hub-events` | At least one log event found matching the test save's `saveId`; event `detail-type` is `SaveCreated`; event `source` is `ai-learning-hub.saves` |
+| EB2 | Save from EB1 updated via PATCH                                          | Wait 5–10 seconds, then `FilterLogEvents` for `SaveUpdated`                                                           | Log event found with `detail-type: SaveUpdated` and matching `saveId`; `detail.updatedFields` is present                                        |
+| EB3 | Save from EB1 deleted via DELETE                                         | Wait 5–10 seconds, then `FilterLogEvents` for `SaveDeleted`                                                           | Log event found with `detail-type: SaveDeleted` and matching `saveId`                                                                           |
+
+**General:**
+
+| #   | Given                                                           | When                                               | Then                                                                                                                                               |
+| --- | --------------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC1 | Scenario needs AWS SDK to query CloudWatch Logs                 | AWS SDK v3 `@aws-sdk/client-cloudwatch-logs` added | Package added to `scripts/smoke-test/package.json` (or root dev dependency); `FilterLogEventsCommand` used to query log group                      |
+| AC2 | CloudWatch Log Group may not exist (3.1.8 not deployed)         | `SMOKE_TEST_EVENT_LOG_GROUP` not set               | Phase 7 is skipped with `SKIP` status and message: `"EventBridge log group not configured — set SMOKE_TEST_EVENT_LOG_GROUP or deploy Story 3.1.8"` |
+| AC3 | CloudWatch Logs delivery has inherent latency                   | Scenario queries logs                              | Scenario retries `FilterLogEvents` up to 3 times with 5-second intervals (max 15s wait) before failing; first successful match short-circuits      |
+| AC4 | All scenarios implemented                                       | Scenarios registered                               | Phase 7 (`eventbridge`) contains EB1–EB3; phase registry updated                                                                                   |
+| AC5 | Smoke test runner needs AWS credentials for CloudWatch Logs API | Credentials available                              | Scenario uses default credential chain (same as `cdk deploy`); no new IAM users or keys needed; `logs:FilterLogEvents` permission required         |
+| AC6 | Existing phases intact                                          | After adding Phase 7                               | All other phases unchanged; full suite still passes                                                                                                |
+
+### Tasks / Subtasks
+
+- [ ] Task 1: Add AWS SDK dependency (AC: #1)
+  - [ ] 1.1 Add `@aws-sdk/client-cloudwatch-logs` to appropriate package.json
+  - [ ] 1.2 Verify it doesn't conflict with existing dependencies
+- [ ] Task 2: Create CloudWatch Logs query helper
+  - [ ] 2.1 Create `scripts/smoke-test/helpers/cloudwatch.ts` (or add to `helpers.ts`)
+  - [ ] 2.2 Implement `waitForLogEvent(logGroupName, filterPattern, maxRetries, intervalMs)` that retries `FilterLogEvents` (AC: #3)
+  - [ ] 2.3 Return parsed event detail on success, throw on timeout
+- [ ] Task 3: Create `scripts/smoke-test/scenarios/eventbridge-verify.ts` (EB1–EB3)
+  - [ ] 3.1 Check for `SMOKE_TEST_EVENT_LOG_GROUP` env var; skip phase if missing (AC: #2)
+  - [ ] 3.2 EB1: Create save → wait → query for `SaveCreated` with matching saveId
+  - [ ] 3.3 EB2: Update save → wait → query for `SaveUpdated` with matching saveId
+  - [ ] 3.4 EB3: Delete save → wait → query for `SaveDeleted` with matching saveId
+  - [ ] 3.5 Add cleanup in `finally` block
+- [ ] Task 4: Register scenarios in phase registry (AC: #4)
+  - [ ] 4.1 Import and register eventbridge-verify as Phase 7
+- [ ] Task 5: Verify (AC: #5, #6)
+  - [ ] 5.1 Run full suite with `SMOKE_TEST_EVENT_LOG_GROUP` set — all phases pass including Phase 7
+  - [ ] 5.2 Run full suite without `SMOKE_TEST_EVENT_LOG_GROUP` — Phase 7 skipped, all other phases pass
+  - [ ] 5.3 Run `npm run smoke-test -- --phase=7` — EB1–EB3 pass
+  - [ ] 5.4 Run `npm run lint` — passes
+
+### Dev Notes
+
+**Filter pattern for CloudWatch Logs:** Use `filterPattern: '{ $.detail.saveId = "<saveId>" }'` in `FilterLogEventsCommand`. EventBridge delivers events to CloudWatch Logs as JSON with fields: `version`, `id`, `detail-type`, `source`, `account`, `time`, `region`, `resources`, `detail`. The `detail` field contains the event payload.
+
+**Latency:** EventBridge to CloudWatch Logs delivery is typically 1–3 seconds but can spike to 10+ seconds under load. The retry strategy (3 retries × 5 seconds = 15 seconds max) provides adequate headroom. If this proves flaky, increase to 5 retries × 5 seconds.
+
+**Credential requirements:** The smoke test already runs in an environment with AWS credentials (same machine that runs `cdk deploy`). The `FilterLogEvents` API only needs `logs:FilterLogEvents` permission on the specific log group. The default CDK bootstrap role or developer credentials typically have this.
+
+**Why this validates more than "events don't 500":** Without this scenario, EventBridge could silently fail — the handlers fire events fire-and-forget and don't check the PutEvents response. A missing IAM permission, wrong bus name, or bus deletion would be invisible. This scenario proves the full chain works: handler → SDK → EventBridge → Rule → CloudWatch Logs.
+
+---
+
+## Summary: Scenario Inventory
+
+After all Track B stories are complete, the smoke test suite will contain:
+
+| Phase     | Name               | Scenarios | Count  | What it proves                                            |
+| --------- | ------------------ | --------- | ------ | --------------------------------------------------------- |
+| 1         | `infra-auth`       | AC1–AC14  | 14     | JWT/API key auth, route connectivity, CORS, rate limiting |
+| 2         | `saves-crud`       | SC1–SC8   | 8      | Full save lifecycle, DynamoDB CRUD, soft-delete, restore  |
+| 3         | `saves-dedup`      | SD1–SD2   | 2      | Duplicate detection (409), auto-restore on re-save        |
+| 4         | `saves-validation` | SV1–SV4   | 4      | Zod validation, 400/404 error shapes, ADR-008 compliance  |
+| 5         | `saves-filtering`  | SF1–SF3   | 3      | Content type filter, sort order, title/URL search         |
+| 6         | `saves-apikey`     | SA1       | 1      | API key auth on saves routes (iOS/agent path)             |
+| 7         | `eventbridge`      | EB1–EB3   | 3      | EventBridge emit + delivery + CloudWatch Logs capture     |
+| **Total** |                    |           | **35** |                                                           |
+
+---
+
 ## Project Context Reference
 
 - Audit source: Cross-handler duplication analysis of Epic 3 (stories 3.1a–3.4)
+- Smoke test baseline: PR #173 (Epic 2/2.1 validation — 14 scenarios)
 - Architecture: `_bmad-output/planning-artifacts/architecture.md`
 - Epic orchestrator: `.claude/skills/epic-orchestrator/SKILL.md`
 - Review loop: `.claude/skills/epic-orchestrator/review-loop.md`
 - Existing agents: `.claude/agents/epic-reviewer.md`, `.claude/agents/epic-fixer.md`
+- Route registry: `infra/config/route-registry.ts`
+- Events stack: `infra/lib/stacks/core/events.stack.ts`
+- Saves routes stack: `infra/lib/stacks/api/saves-routes.stack.ts`
+- Existing smoke test: `scripts/smoke-test/`

--- a/docs/progress/epic-3.1-auto-run.md
+++ b/docs/progress/epic-3.1-auto-run.md
@@ -3,7 +3,7 @@ epic_id: Epic-3.1
 status: in-progress
 scope: ["3.1.1", "3.1.2", "3.1.3", "3.1.5", "3.1.7", "3.1.6"]
 started: "2026-02-23T00:00:00Z"
-last_updated: "2026-02-23T22:00:00Z"
+last_updated: "2026-02-24T22:30:00Z"
 stories:
   "3.1.1":
     {
@@ -42,9 +42,39 @@ stories:
       reviewRounds: 1,
       reviewResult: APPROVE,
     }
-  "3.1.5": { status: pending }
-  "3.1.7": { status: pending }
-  "3.1.6": { status: pending }
+  "3.1.5":
+    {
+      status: done,
+      issue: 201,
+      pr: 202,
+      branch: story-3-1-5-phase-runner-infrastructure,
+      commit: 4564412,
+      reviewRounds: 1,
+      reviewResult: APPROVE,
+    }
+  "3.1.7":
+    {
+      status: done,
+      issue: 203,
+      pr: 204,
+      branch: story-3-1-7-dedup-filtering-api-key,
+      commit: f42af99,
+      reviewRounds: 1,
+      reviewResult: APPROVE,
+    }
+  "3.1.6":
+    {
+      status: done,
+      issue: 205,
+      pr: 206,
+      branch: story-3-1-6-saves-crud-validation,
+      commit: cc87fcc,
+      startedAt: "2026-02-24T17:30:00Z",
+      completedAt: "2026-02-24T18:33:00Z",
+      duration: "1h 3m",
+      reviewRounds: 3,
+      reviewResult: APPROVE,
+    }
 ---
 
 <!-- Human-readable display below (generated from frontmatter) -->
@@ -56,9 +86,9 @@ stories:
 | 3.1.1 | ✅ Complete | #194 | 1             | APPROVE | -        |
 | 3.1.2 | ✅ Complete | #196 | 1             | APPROVE | 55m      |
 | 3.1.3 | ✅ Complete | #198 | 1             | APPROVE | -        |
-| 3.1.5 | ⏳ Pending  | -    | -             | -       | -        |
-| 3.1.7 | ⏳ Pending  | -    | -             | -       | -        |
-| 3.1.6 | ⏳ Pending  | -    | -             | -       | -        |
+| 3.1.5 | ✅ Complete | #202 | 1             | APPROVE | -        |
+| 3.1.7 | ✅ Complete | #204 | 1             | APPROVE | -        |
+| 3.1.6 | ✅ Complete | #206 | 3             | APPROVE | 1h 3m    |
 
 ## Activity Log
 
@@ -77,3 +107,13 @@ stories:
 - [21:52] Epic 3.1 auto-run complete — all 3 stories done
 - [22:00] Epic 3.1 auto-run resumed — adding Stories 3.1.5, 3.1.7, 3.1.6 to scope
 - [22:00] External deps verified: 3.1.4 (PR #200 merged), 3.4 (PR #190 merged)
+- [24:17:30] Story 3.1.6: Resumed — implementation already complete (uncommitted), running pipeline
+- [24:17:33] Story 3.1.6: AC verification passed, secrets scan clean, committed + pushed
+- [24:17:35] Story 3.1.6: PR #206 created
+- [24:17:38] Story 3.1.6: Review Round 1 — 4 Important findings, fixer addressed all
+- [24:18:08] Story 3.1.6: Review Round 2 — 1 Critical (SV3 25-char ULID), 2 Important, fixer addressed all
+- [24:18:30] Story 3.1.6: Review Round 3 — APPROVE (0 Critical, 0 Important, 1 Minor doc-only)
+- [24:18:33] Story 3.1.6: All CI checks passed, merged with main, tests pass, PR #206 ready
+- [24:18:33] Story 3.1.6 complete (5/6 stories done in scope — 3.1.5 was completed externally via PR #202)
+- [24:22:21] Story 3.1.7: Completed externally — PR #204 merged, issue #203 closed
+- [24:22:30] All stories in scope complete (6/6). Remaining epic stories: 3.1.8, 3.1.9

--- a/docs/progress/epic-3.1-completion-report.md
+++ b/docs/progress/epic-3.1-completion-report.md
@@ -1,25 +1,37 @@
 # Epic 3.1 Completion Report
 
 **Status:** Partial
-**Duration:** ongoing (3.1.1 + 3.1.2 complete, 3.1.3 + 3.1.4 remaining)
-**Stories Completed:** 2/4
-**Date:** 2026-02-23
+**Duration:** ongoing
+**Stories Completed:** 7/9
+**Date:** 2026-02-24
 
 ## Story Summary
 
-| Story | Title                                  | Status  | PR   | Coverage | Review Rounds | Findings Fixed | Duration |
-| ----- | -------------------------------------- | ------- | ---- | -------- | ------------- | -------------- | -------- |
-| 3.1.1 | Extract shared schemas & constants     | Done    | #194 | 97%      | 1             | 0              | ~11h     |
-| 3.1.2 | Shared test utilities for saves domain | Done    | #196 | 97%      | 1             | 0              | 55m      |
-| 3.1.3 | Handler & test consolidation           | Pending | —    | —        | —             | —              | —        |
-| 3.1.4 | Dedup scan agent & pipeline            | Pending | —    | —        | —             | —              | —        |
+### Track A — Code Consolidation
+
+| Story | Title                                  | Status | PR   | Coverage | Review Rounds | Findings Fixed | Duration |
+| ----- | -------------------------------------- | ------ | ---- | -------- | ------------- | -------------- | -------- |
+| 3.1.1 | Extract shared schemas & constants     | Done   | #194 | 97%      | 1             | 0              | ~11h     |
+| 3.1.2 | Shared test utilities for saves domain | Done   | #196 | 97%      | 1             | 0              | 55m      |
+| 3.1.3 | Handler & test consolidation           | Done   | #198 | 97%      | 1             | 0              | ~4h      |
+| 3.1.4 | Dedup scan agent & pipeline            | Done   | #200 | N/A      | 1             | 0              | ~2h      |
+
+### Track B — Smoke Test Expansion
+
+| Story | Title                                    | Status  | PR   | Coverage | Review Rounds | Findings Fixed | Duration |
+| ----- | ---------------------------------------- | ------- | ---- | -------- | ------------- | -------------- | -------- |
+| 3.1.5 | Smoke test phase runner infrastructure   | Done    | #202 | N/A      | 1             | 0              | ~1h      |
+| 3.1.6 | Saves CRUD & validation smoke scenarios  | Done    | #206 | N/A      | 3             | 7              | 1h 3m    |
+| 3.1.7 | Saves dedup, filtering & API key smoke   | Done    | #204 | N/A      | 1             | 0              | -        |
+| 3.1.8 | EventBridge observability infrastructure | Pending | —    | —        | —             | —              | —        |
+| 3.1.9 | EventBridge verification smoke scenario  | Pending | —    | —        | —             | —              | —        |
 
 ## Metrics
 
-- **Average story time:** ~6h (weighted by 3.1.1's longer duration)
+- **Average story time:** ~3h (7 stories)
 - **Test pass rate:** 100%
-- **Review convergence:** 1 round average
-- **Common issue categories:** TypeScript portability (TS2742), type narrowing (`as const` vs mutable)
+- **Review convergence:** 1.3 rounds average (6 stories at 1 round, 1 story at 3 rounds)
+- **Common issue categories:** TypeScript portability (TS2742), type narrowing (`as const` vs mutable), acceptance criteria gaps (ULID format, missing assertions), input validation edge cases (NaN handling)
 
 ## Blockers
 
@@ -27,7 +39,11 @@ None
 
 ## Next Steps
 
-- [ ] Review and merge open PRs: #196
-- [ ] Investigate blocked stories: None
-- [ ] Run full integration test suite
+### Track B (remaining — 2 stories)
+
+- [ ] Complete 3.1.8 (EventBridge observability — no dependencies, can start immediately)
+- [ ] Complete 3.1.9 (EventBridge verification — depends on 3.1.6 + 3.1.8)
+
+### General
+
 - [ ] Update sprint status

--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -42,6 +42,7 @@ const authStack = new AuthStack(app, "AiLearningHubAuth", {
     "Authentication stack for ai-learning-hub (JWT authorizer, API key authorizer, invite validation)",
   usersTable: tablesStack.usersTable,
   inviteCodesTable: tablesStack.inviteCodesTable,
+  savesTable: tablesStack.savesTable,
 });
 authStack.addDependency(tablesStack);
 
@@ -122,6 +123,7 @@ const savesRoutesStack = new SavesRoutesStack(app, "AiLearningHubSavesRoutes", {
   apiKeyAuthorizer: apiGatewayStack.apiKeyAuthorizer,
   savesTable: tablesStack.savesTable,
   usersTable: tablesStack.usersTable,
+  inviteCodesTable: tablesStack.inviteCodesTable,
   eventBus: eventsStack.eventBus,
 });
 savesRoutesStack.addDependency(apiGatewayStack);

--- a/infra/lib/stacks/api/saves-routes.stack.ts
+++ b/infra/lib/stacks/api/saves-routes.stack.ts
@@ -28,6 +28,8 @@ export interface SavesRoutesStackProps extends cdk.StackProps {
   savesTable: dynamodb.Table;
   /** Users DynamoDB table (required for rate limiting) */
   usersTable: dynamodb.Table;
+  /** Invite codes DynamoDB table (required by @ai-learning-hub/db barrel import) */
+  inviteCodesTable: dynamodb.Table;
   /** EventBridge event bus */
   eventBus: events.EventBus;
 }
@@ -49,6 +51,7 @@ export class SavesRoutesStack extends cdk.Stack {
       apiKeyAuthorizer,
       savesTable,
       usersTable,
+      inviteCodesTable,
       eventBus,
     } = props;
 
@@ -93,6 +96,7 @@ export class SavesRoutesStack extends cdk.Stack {
         environment: {
           SAVES_TABLE_NAME: savesTable.tableName,
           USERS_TABLE_NAME: usersTable.tableName,
+          INVITE_CODES_TABLE_NAME: inviteCodesTable.tableName,
           EVENT_BUS_NAME: eventBus.eventBusName,
           NODE_OPTIONS: "--enable-source-maps",
         },
@@ -139,6 +143,8 @@ export class SavesRoutesStack extends cdk.Stack {
         tracing: lambda.Tracing.ACTIVE,
         environment: {
           SAVES_TABLE_NAME: savesTable.tableName,
+          USERS_TABLE_NAME: usersTable.tableName,
+          INVITE_CODES_TABLE_NAME: inviteCodesTable.tableName,
           NODE_OPTIONS: "--enable-source-maps",
         },
         bundling: {
@@ -172,6 +178,8 @@ export class SavesRoutesStack extends cdk.Stack {
         tracing: lambda.Tracing.ACTIVE,
         environment: {
           SAVES_TABLE_NAME: savesTable.tableName,
+          USERS_TABLE_NAME: usersTable.tableName,
+          INVITE_CODES_TABLE_NAME: inviteCodesTable.tableName,
           NODE_OPTIONS: "--enable-source-maps",
         },
         bundling: {
@@ -207,6 +215,7 @@ export class SavesRoutesStack extends cdk.Stack {
         environment: {
           SAVES_TABLE_NAME: savesTable.tableName,
           USERS_TABLE_NAME: usersTable.tableName,
+          INVITE_CODES_TABLE_NAME: inviteCodesTable.tableName,
           EVENT_BUS_NAME: eventBus.eventBusName,
           NODE_OPTIONS: "--enable-source-maps",
         },
@@ -251,6 +260,7 @@ export class SavesRoutesStack extends cdk.Stack {
         environment: {
           SAVES_TABLE_NAME: savesTable.tableName,
           USERS_TABLE_NAME: usersTable.tableName,
+          INVITE_CODES_TABLE_NAME: inviteCodesTable.tableName,
           EVENT_BUS_NAME: eventBus.eventBusName,
           NODE_OPTIONS: "--enable-source-maps",
         },
@@ -295,6 +305,7 @@ export class SavesRoutesStack extends cdk.Stack {
         environment: {
           SAVES_TABLE_NAME: savesTable.tableName,
           USERS_TABLE_NAME: usersTable.tableName,
+          INVITE_CODES_TABLE_NAME: inviteCodesTable.tableName,
           EVENT_BUS_NAME: eventBus.eventBusName,
           NODE_OPTIONS: "--enable-source-maps",
         },

--- a/infra/lib/stacks/auth/auth.stack.ts
+++ b/infra/lib/stacks/auth/auth.stack.ts
@@ -19,6 +19,7 @@ const CLERK_SECRET_KEY_PARAM = "/ai-learning-hub/clerk-secret-key";
 export interface AuthStackProps extends cdk.StackProps {
   usersTable: dynamodb.ITable;
   inviteCodesTable: dynamodb.ITable;
+  savesTable: dynamodb.ITable;
 }
 
 export class AuthStack extends cdk.Stack {
@@ -32,7 +33,7 @@ export class AuthStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: AuthStackProps) {
     super(scope, id, props);
 
-    const { usersTable, inviteCodesTable } = props;
+    const { usersTable, inviteCodesTable, savesTable } = props;
 
     // JWT Authorizer Lambda (ADR-013)
     this.jwtAuthorizerFunction = new lambdaNode.NodejsFunction(
@@ -55,6 +56,7 @@ export class AuthStack extends cdk.Stack {
           CLERK_SECRET_KEY_PARAM: CLERK_SECRET_KEY_PARAM,
           USERS_TABLE_NAME: usersTable.tableName,
           INVITE_CODES_TABLE_NAME: inviteCodesTable.tableName,
+          SAVES_TABLE_NAME: savesTable.tableName,
         },
         bundling: {
           minify: true,
@@ -160,6 +162,7 @@ export class AuthStack extends cdk.Stack {
           CLERK_SECRET_KEY_PARAM: CLERK_SECRET_KEY_PARAM,
           USERS_TABLE_NAME: usersTable.tableName,
           INVITE_CODES_TABLE_NAME: inviteCodesTable.tableName,
+          SAVES_TABLE_NAME: savesTable.tableName,
         },
         bundling: {
           minify: true,
@@ -265,6 +268,7 @@ export class AuthStack extends cdk.Stack {
         environment: {
           USERS_TABLE_NAME: usersTable.tableName,
           INVITE_CODES_TABLE_NAME: inviteCodesTable.tableName,
+          SAVES_TABLE_NAME: savesTable.tableName,
         },
         bundling: {
           minify: true,
@@ -347,6 +351,7 @@ export class AuthStack extends cdk.Stack {
           CLERK_SECRET_KEY_PARAM: CLERK_SECRET_KEY_PARAM,
           INVITE_CODES_TABLE_NAME: inviteCodesTable.tableName,
           USERS_TABLE_NAME: usersTable.tableName,
+          SAVES_TABLE_NAME: savesTable.tableName,
         },
         bundling: {
           minify: true,
@@ -450,6 +455,7 @@ export class AuthStack extends cdk.Stack {
         environment: {
           USERS_TABLE_NAME: usersTable.tableName,
           INVITE_CODES_TABLE_NAME: inviteCodesTable.tableName,
+          SAVES_TABLE_NAME: savesTable.tableName,
         },
         bundling: {
           minify: true,
@@ -531,6 +537,7 @@ export class AuthStack extends cdk.Stack {
         environment: {
           INVITE_CODES_TABLE_NAME: inviteCodesTable.tableName,
           USERS_TABLE_NAME: usersTable.tableName,
+          SAVES_TABLE_NAME: savesTable.tableName,
         },
         bundling: {
           minify: true,

--- a/infra/test/helpers/create-test-api-stacks.ts
+++ b/infra/test/helpers/create-test-api-stacks.ts
@@ -180,6 +180,11 @@ export function createTestApiStacks(): TestApiStacks {
     eventBusName: "arch-test-events",
   });
 
+  const inviteCodesTable = new dynamodb.Table(depsStack, "InviteCodesTable", {
+    partitionKey: { name: "PK", type: dynamodb.AttributeType.STRING },
+    sortKey: { name: "SK", type: dynamodb.AttributeType.STRING },
+  });
+
   const savesRoutesStack = new SavesRoutesStack(app, "ArchTestSavesRoutes", {
     env: awsEnv,
     restApiId: apiGatewayStack.restApi.restApiId,
@@ -187,6 +192,7 @@ export function createTestApiStacks(): TestApiStacks {
     apiKeyAuthorizer: apiGatewayStack.apiKeyAuthorizer,
     savesTable,
     usersTable,
+    inviteCodesTable,
     eventBus,
   });
 

--- a/infra/test/stacks/auth/auth.stack.test.ts
+++ b/infra/test/stacks/auth/auth.stack.test.ts
@@ -29,11 +29,17 @@ describe("AuthStack", () => {
         sortKey: { name: "SK", type: dynamodb.AttributeType.STRING },
       }
     );
+    const savesTable = new dynamodb.Table(tablesStack, "SavesTable", {
+      tableName: "ai-learning-hub-saves",
+      partitionKey: { name: "PK", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "SK", type: dynamodb.AttributeType.STRING },
+    });
 
     const stack = new AuthStack(app, "TestAuthStack", {
       env: awsEnv,
       usersTable,
       inviteCodesTable,
+      savesTable,
     });
     template = Template.fromStack(stack);
   });

--- a/scripts/smoke-test/.env.smoke.example
+++ b/scripts/smoke-test/.env.smoke.example
@@ -1,9 +1,12 @@
 # scripts/smoke-test/.env.smoke.example
 # Copy to .env.smoke (gitignored) and fill in values before running npm run smoke-test
 #
-# Usage:
+# Usage (recommended — auto-auth fetches a fresh JWT automatically):
 #   cp scripts/smoke-test/.env.smoke.example scripts/smoke-test/.env.smoke
 #   # edit .env.smoke with real values
+#   source scripts/smoke-test/.env.smoke && npm run smoke-test -- --auto-auth
+#
+# Usage (manual — you provide the JWT yourself):
 #   source scripts/smoke-test/.env.smoke && npm run smoke-test
 
 # ─── Required ─────────────────────────────────────────────────────────────────
@@ -11,23 +14,40 @@
 # Base URL of the deployed API Gateway stage (no trailing slash)
 # Find in AWS Console → API Gateway → Stages → dev → Invoke URL
 # Or: aws apigateway get-stages --rest-api-id <id> --query 'item[?stageName==`dev`].invokeUrl'
-SMOKE_TEST_API_URL=https://<api-gateway-id>.execute-api.us-east-1.amazonaws.com/dev
+export SMOKE_TEST_API_URL=https://<api-gateway-id>.execute-api.us-east-1.amazonaws.com/dev
 
-# ─── JWT Tokens ───────────────────────────────────────────────────────────────
+# ─── Auto-Auth (recommended) ────────────────────────────────────────────────
+#
+# Use --auto-auth to programmatically fetch a fresh Clerk JWT at startup.
+# No manual token copy-paste needed — just set the user ID and go.
+# Requires valid AWS credentials with ssm:GetParameter access.
+
+# Clerk user ID for the test user (e.g. user_2abc...)
+# Find in Clerk Dashboard → Users, or via: clerk users list
+# The user MUST have publicMetadata.inviteValidated === true
+export SMOKE_TEST_CLERK_USER_ID=user_...
+
+# Optional: Provide the Clerk secret key directly (skips SSM fetch)
+# If not set, auto-auth fetches it from SSM: /ai-learning-hub/clerk-secret-key
+# export CLERK_SECRET_KEY=sk_test_...
+
+# ─── JWT Tokens (manual mode) ───────────────────────────────────────────────
+#
+# Only needed if NOT using --auto-auth.
 
 # Clerk JWT for a regular user in the dev environment
 # Obtain: Sign into the deployed dev frontend → DevTools → Network tab → copy Authorization header value
-# These expire in ~1 hour; regenerate as needed
-SMOKE_TEST_CLERK_JWT=eyJ...
+# These expire in ~60 seconds; use --auto-auth to avoid manual copy-paste
+# export SMOKE_TEST_CLERK_JWT=eyJ...
 
 # Optional: Clerk JWT for an admin user (used for admin-only endpoints if tested)
-# SMOKE_TEST_ADMIN_JWT=eyJ...
+# export SMOKE_TEST_ADMIN_JWT=eyJ...
 
 # Optional: A real Clerk-signed JWT that has NATURALLY EXPIRED (for AC4)
 # MUST be signed by the real Clerk issuer — a fake-secret token produces UNAUTHORIZED
 # (invalid signature), not EXPIRED_TOKEN. See story Dev Notes for how to obtain.
 # If not set, AC4 is automatically skipped with a note (not a failure).
-# SMOKE_TEST_EXPIRED_JWT=eyJ...
+# export SMOKE_TEST_EXPIRED_JWT=eyJ...
 
 # ─── Rate Limiting ────────────────────────────────────────────────────────────
 
@@ -35,11 +55,11 @@ SMOKE_TEST_CLERK_JWT=eyJ...
 # Use a SEPARATE Clerk user from SMOKE_TEST_CLERK_JWT so prior traffic from other
 # scenarios doesn't pre-exhaust the token bucket for this user.
 # If not set, AC14 is automatically skipped with a warning.
-# SMOKE_TEST_RATE_LIMIT_JWT=eyJ...
+# export SMOKE_TEST_RATE_LIMIT_JWT=eyJ...
 
 # ─── Skip List ────────────────────────────────────────────────────────────────
 
 # Optional: Comma-separated AC IDs to skip (AC20)
 # Use when certain scenarios are flaky in a shared dev environment
 # Example: skip rate limiting when bucket state cannot be guaranteed fresh
-# SMOKE_TEST_SKIP=AC14
+# export SMOKE_TEST_SKIP=AC14

--- a/scripts/smoke-test/auto-auth.ts
+++ b/scripts/smoke-test/auto-auth.ts
@@ -1,0 +1,118 @@
+/**
+ * smoke-test/auto-auth.ts
+ * Programmatic JWT generation for smoke tests.
+ *
+ * Uses the Clerk Backend SDK to create a fresh session and obtain
+ * a JWT — eliminating the need to manually copy short-lived tokens.
+ *
+ * Flow:
+ *   1. Fetch CLERK_SECRET_KEY from AWS SSM (cached in env after first fetch)
+ *   2. Create a Clerk Backend client
+ *   3. Find or create an active session for the configured test user
+ *   4. Call getToken() to obtain a fresh JWT
+ *   5. Set process.env.SMOKE_TEST_CLERK_JWT
+ *
+ * Required env vars:
+ *   SMOKE_TEST_CLERK_USER_ID  — Clerk user ID (e.g. "user_2abc...")
+ *
+ * Optional env vars:
+ *   CLERK_SECRET_KEY          — If set, skips SSM fetch (useful for CI)
+ */
+
+import { createClerkClient } from "@clerk/backend";
+import { SSMClient, GetParameterCommand } from "@aws-sdk/client-ssm";
+
+const SSM_PARAM_NAME = "/ai-learning-hub/clerk-secret-key";
+
+/**
+ * Fetch the Clerk secret key from AWS SSM Parameter Store.
+ * Falls back to CLERK_SECRET_KEY env var if already set.
+ */
+async function getClerkSecretKey(): Promise<string> {
+  // Allow direct env var override (useful for CI or local)
+  if (process.env.CLERK_SECRET_KEY) {
+    return process.env.CLERK_SECRET_KEY;
+  }
+
+  console.log(`  ⬇  Fetching Clerk secret key from SSM: ${SSM_PARAM_NAME}`);
+  const ssm = new SSMClient({});
+  const result = await ssm.send(
+    new GetParameterCommand({ Name: SSM_PARAM_NAME, WithDecryption: true })
+  );
+
+  const value = result.Parameter?.Value;
+  if (!value) {
+    throw new Error(
+      `SSM parameter ${SSM_PARAM_NAME} is empty or not found. ` +
+        `Ensure the parameter exists and your AWS credentials have ssm:GetParameter permission.`
+    );
+  }
+
+  // Cache for any subsequent use within this process
+  process.env.CLERK_SECRET_KEY = value;
+  return value;
+}
+
+/**
+ * Programmatically obtain a fresh Clerk JWT for the smoke test user.
+ *
+ * Creates a new session (or reuses an active one) and generates a token.
+ * Sets process.env.SMOKE_TEST_CLERK_JWT so downstream code can use it.
+ *
+ * @returns The JWT string
+ */
+export async function autoFetchJwt(): Promise<string> {
+  const userId = process.env.SMOKE_TEST_CLERK_USER_ID;
+  if (!userId) {
+    throw new Error(
+      "SMOKE_TEST_CLERK_USER_ID is required for --auto-auth. " +
+        "Set it to the Clerk user ID of a dev test user (e.g. user_2abc...)."
+    );
+  }
+
+  console.log("\n🔑 Auto-auth: Fetching fresh JWT...");
+
+  // Step 1: Get the secret key
+  const secretKey = await getClerkSecretKey();
+
+  // Step 2: Create Clerk client
+  const clerk = createClerkClient({ secretKey });
+
+  // Step 3: Find an existing active session, or create one
+  console.log(`  👤 User: ${userId}`);
+
+  let sessionId: string;
+
+  const existingSessions = await clerk.sessions.getSessionList({
+    userId,
+    status: "active",
+  });
+
+  if (existingSessions.data.length > 0) {
+    sessionId = existingSessions.data[0].id;
+    console.log(`  ♻  Reusing active session: ${sessionId}`);
+  } else {
+    console.log("  🆕 No active sessions found — creating a new one...");
+    const newSession = await clerk.sessions.createSession({ userId });
+    sessionId = newSession.id;
+    console.log(`  ✅ Created session: ${sessionId}`);
+  }
+
+  // Step 4: Get a fresh JWT from the session
+  const token = await clerk.sessions.getToken(sessionId);
+  const jwt = token.jwt;
+
+  if (!jwt) {
+    throw new Error(
+      "Clerk returned an empty JWT. Ensure the test user is active and " +
+        "has publicMetadata.inviteValidated === true."
+    );
+  }
+
+  // Step 5: Inject into process env for downstream use
+  process.env.SMOKE_TEST_CLERK_JWT = jwt;
+
+  console.log(`  ✅ JWT obtained (${jwt.length} chars, expires in ~60s)\n`);
+
+  return jwt;
+}

--- a/scripts/smoke-test/run.ts
+++ b/scripts/smoke-test/run.ts
@@ -6,17 +6,36 @@
  * Validates the real Clerk → API Gateway → Lambda → DynamoDB chain.
  * NOT part of the vitest test suite. Run with: npm run smoke-test
  *
- * Required env vars: SMOKE_TEST_API_URL, SMOKE_TEST_CLERK_JWT
- * Optional:         SMOKE_TEST_ADMIN_JWT, SMOKE_TEST_EXPIRED_JWT,
- *                   SMOKE_TEST_RATE_LIMIT_JWT, SMOKE_TEST_SKIP
+ * Required env vars: SMOKE_TEST_API_URL
+ * JWT auth (one of):
+ *   --auto-auth                 Programmatic JWT via Clerk Backend API (recommended)
+ *   SMOKE_TEST_CLERK_JWT        Pre-set JWT token (manual)
+ *
+ * Auto-auth requires:
+ *   SMOKE_TEST_CLERK_USER_ID    Clerk user ID for the test user
+ *   CLERK_SECRET_KEY            (optional — fetched from AWS SSM if not set)
+ *
+ * Optional:  SMOKE_TEST_ADMIN_JWT, SMOKE_TEST_EXPIRED_JWT,
+ *            SMOKE_TEST_RATE_LIMIT_JWT, SMOKE_TEST_SKIP
  * See: scripts/smoke-test/.env.smoke.example
  *
  * Phase support (Story 3.1.6):
- *   npm run smoke-test                    # all phases
- *   npm run smoke-test -- --phase=1       # Phase 1 only (infra-auth)
- *   npm run smoke-test -- --phase=2       # Phase 2 only (saves-crud)
- *   npm run smoke-test -- --up-to=2       # Phases 1 and 2
+ *   npm run smoke-test -- --auto-auth             # all phases, auto JWT
+ *   npm run smoke-test -- --auto-auth --phase=1   # Phase 1 only
+ *   npm run smoke-test -- --auto-auth --phase=2   # Phase 2 only
+ *   npm run smoke-test -- --auto-auth --up-to=2   # Phases 1 and 2
  */
+
+import { getFilteredPhases } from "./phases.js";
+import { ScenarioSkipped } from "./types.js";
+import type { CleanupFn, Result } from "./types.js";
+
+// ─── CLI flags ───────────────────────────────────────────────────────────────
+
+const cliArgs = process.argv.slice(2);
+const useAutoAuth = cliArgs.includes("--auto-auth");
+
+// ─── Startup validation & auto-auth ─────────────────────────────────────────
 
 // AC19: Exit immediately if required env vars are not set
 if (!process.env.SMOKE_TEST_API_URL) {
@@ -25,16 +44,28 @@ if (!process.env.SMOKE_TEST_API_URL) {
   );
   process.exit(1);
 }
+
+if (useAutoAuth) {
+  // Lazy import to avoid pulling in @clerk/backend and @aws-sdk/client-ssm
+  // when not using auto-auth
+  const { autoFetchJwt } = await import("./auto-auth.js");
+  try {
+    await autoFetchJwt();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`\n❌ Auto-auth failed: ${msg}\n`);
+    process.exit(1);
+  }
+}
+
 if (!process.env.SMOKE_TEST_CLERK_JWT) {
   console.error(
-    "SMOKE_TEST_CLERK_JWT is required. See scripts/smoke-test/.env.smoke.example"
+    "SMOKE_TEST_CLERK_JWT is required.\n" +
+      "  Either set it in .env.smoke, or use --auto-auth with SMOKE_TEST_CLERK_USER_ID.\n" +
+      "  See: scripts/smoke-test/.env.smoke.example"
   );
   process.exit(1);
 }
-
-import { getFilteredPhases } from "./phases.js";
-import { ScenarioSkipped } from "./types.js";
-import type { CleanupFn, Result } from "./types.js";
 
 // ─── Cleanup registry ─────────────────────────────────────────────────────────
 
@@ -111,7 +142,7 @@ function printTable(results: Result[]): void {
 
 // ─── Main runner ──────────────────────────────────────────────────────────────
 
-const selectedPhases = getFilteredPhases(process.argv.slice(2));
+const selectedPhases = getFilteredPhases(cliArgs);
 
 // Initialize cleanup registry for each selected phase
 for (const phase of selectedPhases) {

--- a/scripts/smoke-test/scenarios/api-key-auth.ts
+++ b/scripts/smoke-test/scenarios/api-key-auth.ts
@@ -19,29 +19,60 @@ export function initApiKeyCleanup(register: (fn: CleanupFn) => void): void {
   registerCleanupFn = register;
 }
 
+/** Simple sleep helper */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Create an API key with retry-on-429 resilience.
+ * Smoke tests create several keys in rapid succession, which can trip
+ * the rate limiter. Backing off and retrying is the standard approach.
+ */
 async function createKey(
   jwt: string,
   scopes: string[],
   name = "smoke-test-key"
 ): Promise<{ id: string; keyValue: string }> {
-  const res = await getClient().post(
-    "/users/api-keys",
-    { name, scopes },
-    { auth: { type: "jwt", token: jwt } }
-  );
-  assertStatus(res.status, 201, "POST /users/api-keys");
-  const body = res.body as Record<string, unknown>;
-  const data =
-    (body.data as Record<string, unknown> | undefined) ??
-    (body as Record<string, unknown>);
-  // API returns "key" (not "keyValue") as the plaintext API key
-  const keyValue = data.keyValue ?? data.key;
-  if (!data.id || !keyValue) {
-    throw new Error(
-      `API key response missing id or key: ${JSON.stringify(body)}`
+  const maxRetries = 3;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const res = await getClient().post(
+      "/users/api-keys",
+      { name, scopes },
+      { auth: { type: "jwt", token: jwt } }
     );
+
+    if (res.status === 429) {
+      if (attempt === maxRetries) {
+        throw new Error(
+          `POST /users/api-keys still 429 after ${maxRetries} retries — rate limit not clearing`
+        );
+      }
+      const delayMs = 2000 * (attempt + 1); // 2s, 4s, 6s
+      console.log(
+        `    ⏳ Rate limited (429) on key creation, retrying in ${delayMs / 1000}s...`
+      );
+      await sleep(delayMs);
+      continue;
+    }
+
+    assertStatus(res.status, 201, "POST /users/api-keys");
+    const body = res.body as Record<string, unknown>;
+    const data =
+      (body.data as Record<string, unknown> | undefined) ??
+      (body as Record<string, unknown>);
+    // API returns "key" (not "keyValue") as the plaintext API key
+    const keyValue = data.keyValue ?? data.key;
+    if (!data.id || !keyValue) {
+      throw new Error(
+        `API key response missing id or key: ${JSON.stringify(body)}`
+      );
+    }
+    return { id: String(data.id), keyValue: String(keyValue) };
   }
-  return { id: String(data.id), keyValue: String(keyValue) };
+
+  // Unreachable, but TypeScript needs it
+  throw new Error("createKey: unexpected fallthrough");
 }
 
 async function deleteKey(id: string, jwt: string): Promise<number> {
@@ -71,23 +102,39 @@ export const apiKeyScenarios: ScenarioDefinition[] = [
         }
 
         // Step 2: list → new key must appear
-        const listRes = await getClient().get("/users/api-keys", {
-          auth: { type: "jwt", token: jwt },
-        });
-        assertStatus(listRes.status, 200, "GET /users/api-keys");
-        const listBody = listRes.body as Record<string, unknown>;
-        // wrapHandler wraps result → { data: { items: [...], hasMore, nextCursor } }
-        const listData = (listBody.data ?? listBody) as Record<string, unknown>;
-        const items = ((listData as Record<string, unknown>).items ??
-          listData) as unknown[];
-        const found =
-          Array.isArray(items) &&
-          items.some((k) => {
-            const kk = k as Record<string, unknown>;
-            return kk.id === keyId;
+        // DynamoDB GSI is eventually consistent — retry with short delay
+        let found = false;
+        for (let listAttempt = 0; listAttempt < 3; listAttempt++) {
+          if (listAttempt > 0) {
+            console.log(
+              `    ⏳ Key not yet in GSI, retrying in 1s (attempt ${listAttempt + 1}/3)...`
+            );
+            await sleep(1000);
+          }
+          const listRes = await getClient().get("/users/api-keys", {
+            auth: { type: "jwt", token: jwt },
           });
+          assertStatus(listRes.status, 200, "GET /users/api-keys");
+          const listBody = listRes.body as Record<string, unknown>;
+          // wrapHandler wraps result → { data: { items: [...], hasMore, nextCursor } }
+          const listData = (listBody.data ?? listBody) as Record<
+            string,
+            unknown
+          >;
+          const items = ((listData as Record<string, unknown>).items ??
+            listData) as unknown[];
+          found =
+            Array.isArray(items) &&
+            items.some((k) => {
+              const kk = k as Record<string, unknown>;
+              return kk.id === keyId;
+            });
+          if (found) break;
+        }
         if (!found)
-          throw new Error(`Key ${keyId} not found in list after creation`);
+          throw new Error(
+            `Key ${keyId} not found in list after creation (3 retries)`
+          );
 
         // Step 3: delete
         const deleteStatus = await deleteKey(keyId, jwt);


### PR DESCRIPTION
## Summary

- **saves-get handler**: Return `lastAccessedAt` in response body after successful DynamoDB update (fixes SC2 smoke test)
- **listApiKeys query**: Use `consistentRead: true` and `scanIndexForward: false` so newest keys appear first, fixing AC13 pagination issue with orphaned keys
- **Auth stack barrel import fix**: Add `SAVES_TABLE_NAME` to all 6 Auth Lambdas — `@ai-learning-hub/db` barrel import loads `saves.ts` at module init, which calls `requireEnv("SAVES_TABLE_NAME")`
- **Saves routes stack**: Add missing `INVITE_CODES_TABLE_NAME` and `USERS_TABLE_NAME` env vars (same barrel import issue)
- **Smoke test auto-auth**: New `--auto-auth` flag fetches a fresh Clerk JWT via the SDK at startup, eliminating manual token copy-paste
- **Smoke test resilience**: Retry-on-429 with exponential backoff for API key creation, GSI consistency retry loop

## Changes

### Bug Fixes
- `backend/functions/saves-get/handler.ts` — set `item.lastAccessedAt = now` after updateItem so response reflects the update
- `backend/shared/db/src/users.ts` — `listApiKeys` uses consistent reads + descending sort order
- `infra/lib/stacks/auth/auth.stack.ts` — add `SAVES_TABLE_NAME` env var to all Lambdas
- `infra/lib/stacks/api/saves-routes.stack.ts` — add `INVITE_CODES_TABLE_NAME` + `USERS_TABLE_NAME` env vars
- `infra/bin/app.ts` — pass `savesTable` to AuthStack, `inviteCodesTable` to SavesRoutesStack

### New Features
- `scripts/smoke-test/auto-auth.ts` — programmatic Clerk JWT generation via `@clerk/backend` SDK
- `scripts/smoke-test/run.ts` — `--auto-auth` CLI flag support
- `scripts/smoke-test/.env.smoke.example` — updated with auto-auth setup instructions

### Tests
- `backend/functions/saves-get/handler.test.ts` — verify `lastAccessedAt` in response; verify absent when update fails
- `infra/test/stacks/auth/auth.stack.test.ts` — add `savesTable` to test setup
- `infra/test/helpers/create-test-api-stacks.ts` — add `inviteCodesTable` to test helper

### Smoke Test Results
- **24/26 pass** (when rate limit bucket is fresh)
- **2 skipped**: AC4 (no expired JWT configured), AC14 (no dedicated rate limit user)
- **1,606 unit tests**: all passing, 0 regressions

## Test plan

- [x] All 1,606 unit tests pass (`npm test`)
- [x] CDK synth succeeds (infra tests include stack synthesis)
- [x] Smoke tests: 24/26 pass, 2 expected skips
- [ ] Verify saves-get returns `lastAccessedAt` in response (SC2)
- [ ] Verify API key list returns newest keys first (AC13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)