### PR TITLE
docs: add Epic 3.2 stories 3.2.1, 3.2.2, 3.2.3 #219

### DIFF
--- a/_bmad-output/implementation-artifacts/3-2-1-idempotency-optimistic-concurrency-middleware.md
+++ b/_bmad-output/implementation-artifacts/3-2-1-idempotency-optimistic-concurrency-middleware.md
@@ -1,0 +1,255 @@
+# Story 3.2.1: Idempotency & Optimistic Concurrency Middleware
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a **developer building agent-native API endpoints**,
+I want **shared idempotency and optimistic concurrency middleware in `@ai-learning-hub/middleware` backed by DynamoDB**,
+so that **all command endpoints can be safely retried by AI agents without creating duplicates, and concurrent writes are detected and rejected with actionable error responses**.
+
+## Acceptance Criteria
+
+### Idempotency Middleware (FR96, NFR-AN1, NFR-AN6)
+
+1. **AC1: Idempotency-Key extraction & validation** — Middleware extracts the `Idempotency-Key` header from incoming requests. Returns `400 VALIDATION_ERROR` with message "Idempotency-Key header is required" when the header is missing on a command endpoint that opts into idempotency enforcement. Key must be a non-empty string, 1-256 characters, matching `[a-zA-Z0-9_\-\.]+`. Invalid format returns `400 VALIDATION_ERROR` with message describing the constraint.
+2. **AC2: DynamoDB-backed dedup storage** — Idempotency records are stored in a dedicated DynamoDB table (`idempotency` table) with PK = `IDEMP#{userId}#{idempotencyKey}`. Each record stores the original response body, status code, headers, the operation path, and the actor/key/command fingerprint.
+3. **AC3: Cached result replay (2xx only)** — When a duplicate `Idempotency-Key` is received from the same user for the same operation path, the middleware returns the cached response (same status code, body, and relevant headers) without re-executing the handler. The replayed response includes an `X-Idempotent-Replayed: true` header. **Only responses with 2xx status codes are cached.** Error responses (4xx, 5xx) are NOT cached — the agent can fix the issue and retry with the same key.
+4. **AC4: 24-hour TTL with application-level expiry check** — Idempotency records have a TTL attribute (`expiresAt`) set to 24 hours from creation. DynamoDB TTL is enabled on the table for eventual physical cleanup. **Additionally, the read path checks `expiresAt` at the application level:** if `Date.now() > record.expiresAt`, the record is treated as a cache miss and the handler re-executes. This defense-in-depth approach prevents stale replays during DynamoDB's TTL deletion lag window (which can be up to 48 hours).
+5. **AC5: Operation fingerprint matching** — Idempotency dedup checks match on `(userId, idempotencyKey, operationPath)`. A key reused for a different operation path returns `409 IDEMPOTENCY_KEY_CONFLICT` with message "Idempotency-Key already used for a different operation" and details including `{ boundTo: <original_operation_path> }` (prevents key reuse across different endpoints).
+6. **AC6: Concurrent first-use race condition** — When two requests arrive simultaneously with the same new `Idempotency-Key`, the first to write the idempotency record wins (DynamoDB conditional write). The second request retries reading the now-stored result and replays it. No duplicate execution occurs.
+7. **AC7: wrapHandler integration** — `WrapperOptions` gains a new `idempotent?: boolean` field. When `true`, the idempotency middleware is applied before handler execution. When `false` or unset, the handler executes normally (backward-compatible).
+8. **AC8: Response size guard** — If the handler response body exceeds 350KB (DynamoDB 400KB item size safety margin), the idempotency record stores a tombstone (`{ oversized: true }`) instead of the full response. Subsequent retries with the same key re-execute the handler rather than replaying. A warning is logged: "Idempotency response too large to cache".
+9. **AC9: Fail-open on idempotency table errors** — If the idempotency table is unreachable (DynamoDB error on read or write), the middleware logs a warning and falls through to execute the handler normally (fail-open). Idempotency is best-effort, not a blocking dependency. The response includes an `X-Idempotency-Status: unavailable` header so agents are aware.
+
+### Optimistic Concurrency (FR97, NFR-AN2)
+
+10. **AC10: Version field pattern** — A `withVersion<T>` TypeScript utility type adds a `version: number` field to any entity type. A `INITIAL_VERSION` constant is exported (value: `1`). A `nextVersion(current: number): number` helper increments the version.
+11. **AC11: If-Match header validation** — Middleware extracts the `If-Match` header from incoming requests. When the handler context includes `requireVersion: true` in WrapperOptions, the middleware validates that `If-Match` is present and parses it as a numeric version. The parsed version number is attached to `HandlerContext` as `expectedVersion?: number`. Handlers access it via `ctx.expectedVersion` and pass it to `updateItemWithVersion`. Missing `If-Match` on a version-required endpoint returns `428 PRECONDITION_REQUIRED` with message "If-Match header is required for this operation".
+12. **AC12: 409 Conflict response** — When a DynamoDB conditional write fails due to version mismatch, the middleware (or a helper function) returns a `409 CONFLICT` response with body: `{ error: { code: "VERSION_CONFLICT", message: "Resource has been modified", requestId }, currentVersion: <server_version> }`. The `currentVersion` field enables the agent to re-read and retry.
+13. **AC13: Optimistic concurrency DB helper** — A new `updateItemWithVersion` function in `@ai-learning-hub/db` wraps `updateItem` to automatically add `SET version = :newVersion` and `ConditionExpression: version = :expectedVersion`. Accepts `expectedVersion` parameter and throws a typed `VersionConflictError` on mismatch.
+14. **AC14: Version on create** — A `putItemWithVersion` helper in `@ai-learning-hub/db` automatically sets `version: 1` on new items.
+
+### Infrastructure (CDK)
+
+15. **AC15: Idempotency DynamoDB table** — CDK stack creates a new `idempotency` table: PK = `pk` (string), TTL attribute = `expiresAt`, on-demand billing, encryption at rest enabled, point-in-time recovery enabled. Table name passed to Lambda functions via `IDEMPOTENCY_TABLE_NAME` environment variable.
+16. **AC16: Table cost compliance** — Idempotency table storage overhead remains < 1% of total DynamoDB capacity (NFR-AN6). Each record is ~1KB (response body + metadata). At boutique scale (100 commands/day), this is ~100KB/day, well within limits.
+
+### Type Safety & Error Codes
+
+17. **AC17: New error codes** — `ErrorCode` enum extended with: `VERSION_CONFLICT` (409), `PRECONDITION_REQUIRED` (428), `IDEMPOTENCY_KEY_CONFLICT` (409). All mapped in `ErrorCodeToStatus`.
+18. **AC18: Exported types** — All new types exported from package index files: `IdempotencyRecord`, `VersionedEntity`, `VersionConflictError`, `IdempotencyOptions`, middleware option types.
+
+### Testing
+
+19. **AC19: Unit tests — idempotency** — Tests cover: key extraction, key format validation, missing key rejection, first-use storage, duplicate replay, expired key re-execution, different-operation rejection, concurrent race condition handling, oversized response tombstone, fail-open on table errors. Minimum 90% coverage for new idempotency code.
+20. **AC20: Unit tests — optimistic concurrency** — Tests cover: version field initialization, If-Match extraction, missing If-Match rejection, version match success, version mismatch 409 response, `updateItemWithVersion` conditional write, `putItemWithVersion` initial version, `ctx.expectedVersion` propagation. Minimum 90% coverage for new concurrency code.
+21. **AC21: Integration contract tests** — Test that idempotency + concurrency middleware integrates correctly with the existing `wrapHandler` chain: auth → idempotency check → handler execution → idempotency store → response. Verify backward compatibility (handlers without `idempotent: true` are unaffected).
+
+## Tasks / Subtasks
+
+### Task 1: New Error Codes & Types (AC: #17, #18, #10)
+
+- [ ] 1.1 Add `VERSION_CONFLICT`, `PRECONDITION_REQUIRED`, `IDEMPOTENCY_KEY_CONFLICT` to `ErrorCode` enum in `@ai-learning-hub/types/src/errors.ts`
+- [ ] 1.2 Add status code mappings to `ErrorCodeToStatus` (409, 428, 409)
+- [ ] 1.3 Create `withVersion<T>` utility type, `INITIAL_VERSION` constant, `nextVersion()` helper in `@ai-learning-hub/types/src/entities.ts`
+- [ ] 1.4 Create `IdempotencyRecord` interface in `@ai-learning-hub/types/src/api.ts`
+- [ ] 1.5 Export all new types from package index
+- [ ] 1.6 Write tests for new types and helpers
+
+### Task 2: Idempotency DynamoDB Table (AC: #15, #16)
+
+- [ ] 2.1 Create `idempotency-table.stack.ts` in `infra/lib/stacks/core/` (or extend existing tables stack)
+- [ ] 2.2 Define table: PK = `pk` (string), TTL on `expiresAt`, on-demand billing, encryption, PITR
+- [ ] 2.3 Export table name and add to Lambda environment variable configuration pattern
+- [ ] 2.4 Add `IDEMPOTENCY_TABLE_NAME` to relevant function environment variables in API stacks
+- [ ] 2.5 Verify CDK synth succeeds
+- [ ] 2.6 Update `infra/bin/app.ts` to include the new idempotency table stack in the deployment graph, dependent on the core stack
+
+### Task 3: Idempotency Storage Layer (AC: #2, #4, #5, #6, #8)
+
+- [ ] 3.1 Create `idempotency.ts` in `@ai-learning-hub/db/src/` with table config
+- [ ] 3.2 Implement `storeIdempotencyRecord(client, key, userId, operationPath, response)` — conditional PutItem with `attribute_not_exists(pk)`
+- [ ] 3.3 Implement `getIdempotencyRecord(client, key, userId, operationPath)` — GetItem, returns null if not found OR if `expiresAt < Date.now()` (application-level expiry check, defense-in-depth against DynamoDB TTL lag)
+- [ ] 3.4 Record schema: `{ pk, userId, operationPath, statusCode, responseBody, responseHeaders, createdAt, expiresAt }`
+- [ ] 3.5 Export from `@ai-learning-hub/db` index
+- [ ] 3.6 Write unit tests with mocked DynamoDB client
+
+### Task 4: Optimistic Concurrency DB Helpers (AC: #13, #14)
+
+- [ ] 4.1 Create `VersionConflictError` class extending `AppError` with `currentVersion` field
+- [ ] 4.2 Implement `updateItemWithVersion(client, config, params, expectedVersion, logger)` in `@ai-learning-hub/db/src/helpers.ts` (or new file)
+- [ ] 4.3 Implement `putItemWithVersion(client, config, item, logger)` — auto-sets `version: 1`
+- [ ] 4.4 Export from `@ai-learning-hub/db` index
+- [ ] 4.5 Write unit tests: version match success, version mismatch error, initial version on create
+
+### Task 5: Idempotency Middleware (AC: #1, #3, #7, #8, #9)
+
+- [ ] 5.1 Create `idempotency.ts` in `@ai-learning-hub/middleware/src/`
+- [ ] 5.2 Implement `extractIdempotencyKey(event)` — returns key or throws `VALIDATION_ERROR`
+- [ ] 5.3 Implement idempotency check/store logic as middleware layer within `wrapHandler`
+- [ ] 5.4 Add `idempotent?: boolean` to `WrapperOptions`
+- [ ] 5.5 Wire idempotency middleware into `wrapHandler` flow: after auth, before handler execution
+- [ ] 5.6 Add `X-Idempotent-Replayed: true` header on cached response replay
+- [ ] 5.7 Handle concurrent first-use: catch ConditionalCheckFailed on store → re-read → replay
+- [ ] 5.8 Implement response size guard: if body > 350KB, store tombstone and log warning
+- [ ] 5.9 Implement fail-open: catch idempotency table errors → log warning → execute handler → add `X-Idempotency-Status: unavailable` header
+- [ ] 5.10 Export from `@ai-learning-hub/middleware` index
+- [ ] 5.11 Write unit tests (AC19)
+
+### Task 6: Optimistic Concurrency Middleware (AC: #11, #12)
+
+- [ ] 6.1 Create `concurrency.ts` in `@ai-learning-hub/middleware/src/`
+- [ ] 6.2 Implement `extractIfMatch(event)` — returns version number or throws `PRECONDITION_REQUIRED`
+- [ ] 6.3 Add `requireVersion?: boolean` to `WrapperOptions`
+- [ ] 6.4 Parse `If-Match` header and attach to `HandlerContext` as `expectedVersion`
+- [ ] 6.5 Wire into `wrapHandler`: extract before handler, provide in context
+- [ ] 6.6 Export from `@ai-learning-hub/middleware` index
+- [ ] 6.7 Write unit tests (AC20)
+
+### Task 7: Integration & Contract Tests (AC: #21)
+
+- [ ] 7.1 Integration test: wrapHandler with `idempotent: true` — full middleware chain
+- [ ] 7.2 Integration test: wrapHandler with `requireVersion: true` — full middleware chain
+- [ ] 7.3 Integration test: backward compatibility — existing handlers unaffected
+- [ ] 7.4 Integration test: combined idempotent + requireVersion on same handler
+- [ ] 7.5 Verify all existing middleware tests still pass
+
+## Dev Notes
+
+### Architecture Patterns & Constraints
+
+- **ADR-001 (Multi-Table DynamoDB):** The idempotency store uses a new dedicated table, consistent with separation of concerns. PK pattern: `IDEMP#{userId}#{idempotencyKey}` follows the project's key prefix convention.
+- **ADR-008 (Standardized Error Handling):** All new error responses use the existing `AppError` → `createErrorResponse` pipeline. New error codes (`VERSION_CONFLICT`, `PRECONDITION_REQUIRED`, `IDEMPOTENCY_KEY_CONFLICT`) follow the established `ErrorCode` enum pattern.
+- **ADR-014 (API-First Design):** Idempotency headers (`Idempotency-Key`, `If-Match`, `X-Idempotent-Replayed`) follow HTTP standards for agent consumption.
+- **ADR-015 (Lambda Layers):** New middleware and DB functions are added to existing shared packages and deployed via the shared Lambda Layer.
+- **No Lambda-to-Lambda (ADR-005):** This story is pure middleware/shared code — no inter-service calls.
+
+### Existing Code to Extend
+
+| Package | File | Changes |
+|---------|------|---------|
+| `@ai-learning-hub/types` | `src/errors.ts` | Add 3 new `ErrorCode` values + status mappings |
+| `@ai-learning-hub/types` | `src/entities.ts` | Add `withVersion<T>`, `INITIAL_VERSION`, `nextVersion()` |
+| `@ai-learning-hub/types` | `src/api.ts` | Add `IdempotencyRecord` interface |
+| `@ai-learning-hub/db` | `src/idempotency.ts` (new) | Idempotency table config + CRUD operations |
+| `@ai-learning-hub/db` | `src/helpers.ts` | Add `updateItemWithVersion`, `putItemWithVersion` |
+| `@ai-learning-hub/middleware` | `src/idempotency.ts` (new) | Idempotency middleware logic |
+| `@ai-learning-hub/middleware` | `src/concurrency.ts` (new) | Optimistic concurrency middleware logic |
+| `@ai-learning-hub/middleware` | `src/wrapper.ts` | Wire idempotency + concurrency into `wrapHandler` |
+| `@ai-learning-hub/middleware` | `src/index.ts` | Export new middleware |
+| `infra/lib/stacks/core/` | `idempotency-table.stack.ts` (new) | CDK stack for idempotency table |
+
+### DynamoDB Idempotency Table Design
+
+```
+Table: ai-learning-hub-idempotency
+PK: pk (string) — "IDEMP#{userId}#{idempotencyKey}"
+TTL: expiresAt (number) — Unix epoch seconds, 24h from creation
+
+Attributes:
+  - pk: string
+  - userId: string
+  - operationPath: string (e.g. "POST /saves")
+  - statusCode: number
+  - responseBody: string (JSON stringified)
+  - responseHeaders: Record<string, string> (selected headers to replay)
+  - createdAt: string (ISO 8601)
+  - expiresAt: number (Unix epoch for TTL)
+
+Billing: On-demand (PAY_PER_REQUEST)
+Encryption: AWS-owned key (default)
+PITR: Enabled
+```
+
+### Optimistic Concurrency Pattern
+
+```typescript
+// Entity with version
+interface SaveItemVersioned extends SaveItem {
+  version: number; // starts at 1, incremented on every mutation
+}
+
+// Update with version check
+await updateItemWithVersion(client, SAVES_TABLE_CONFIG, {
+  key: { PK: `USER#${userId}`, SK: `SAVE#${saveId}` },
+  updateExpression: "SET title = :title, updatedAt = :now",
+  expressionAttributeValues: { ":title": newTitle, ":now": now },
+}, expectedVersion, logger);
+// Throws VersionConflictError if version mismatch
+```
+
+### Middleware Chain Order (after this story)
+
+```
+Request → Extract Auth → Check Idempotency Cache → Extract If-Match
+         → Execute Handler → Store Idempotency Result → Return Response
+```
+
+### Testing Standards
+
+- **Framework:** Vitest (already used across all shared packages)
+- **Coverage target:** 90% for new code (above the 80% CI gate)
+- **Test location:** Co-located `test/` directories in each shared package
+- **Mock pattern:** Use `vi.mock()` for DynamoDB client, following `backend/shared/db/test/` patterns
+- **Test factories:** Use existing `backend/test-utils/` mock helpers where applicable
+
+### Scope Boundaries
+
+- **Non-goal: Retrofitting existing entities.** This story does NOT add the `version` field to existing entities (saves, users). The version field pattern and helpers are created here; the actual retrofit to saves is Story 3.2.7 and to auth is Story 3.2.8.
+- **DELETE endpoints:** HTTP DELETE is inherently idempotent. The `idempotent: true` flag is intended for POST command endpoints (state-changing commands). DELETEs do not need idempotency middleware — they should remain naturally idempotent via soft-delete checks.
+- **Fail-open philosophy:** The idempotency middleware is a safety net, not a hard dependency. If the idempotency table is down, handlers execute normally and agents may see duplicate effects — this is the same behavior as before this middleware existed, and is acceptable at boutique scale.
+
+### Key Technical Decisions
+
+1. **Separate idempotency table (not saves table):** Cross-cutting concern used by ALL future domains (projects, links, tutorials). Own table with TTL keeps it clean and doesn't pollute entity tables.
+2. **PK includes userId:** Prevents cross-user idempotency key collisions. User A and User B can use the same key value independently.
+3. **operationPath is intentionally NOT in the PK:** The PK is `(userId, idempotencyKey)` only. The `operationPath` is stored as an attribute and checked at the application layer. This is deliberate: if operationPath were in the PK, reusing a key for a different operation would silently create a separate record instead of being detected and rejected (AC5). The application-layer check ensures cross-operation key reuse is caught.
+4. **Version stored as number (not ETag string):** Simpler to increment and compare. `If-Match` header carries the numeric version as a string.
+5. **Middleware opt-in via WrapperOptions:** Backward-compatible. Existing handlers without `idempotent: true` are completely unaffected.
+6. **VersionConflictError extends AppError:** Integrates with existing error handling pipeline. The `currentVersion` field is included in the response body for agent retry logic.
+
+### Project Structure Notes
+
+- All new code goes into existing shared packages — no new packages created
+- New CDK table stack follows `infra/lib/stacks/core/tables.stack.ts` pattern
+- Environment variable naming follows existing convention: `IDEMPOTENCY_TABLE_NAME`
+- No new npm dependencies required — uses existing `@aws-sdk/lib-dynamodb` and `ulidx`
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/prd.md#Agent-Native API Patterns] — FR96 (idempotency), FR97 (optimistic concurrency)
+- [Source: _bmad-output/planning-artifacts/prd.md#Non-Functional Requirements] — NFR-AN1 (24h window), NFR-AN2 (no distributed locking), NFR-AN6 (<1% storage)
+- [Source: _bmad-output/planning-artifacts/architecture.md#ADR-001] — Multi-table DynamoDB design
+- [Source: _bmad-output/planning-artifacts/architecture.md#ADR-008] — Standardized error handling
+- [Source: _bmad-output/planning-artifacts/architecture.md#ADR-015] — Lambda Layers for shared code
+- [Source: _bmad-output/planning-artifacts/epics.md#Epic 3.2] — Story definition and dependencies
+- [Source: backend/shared/middleware/src/wrapper.ts] — Existing wrapHandler pattern to extend
+- [Source: backend/shared/middleware/src/error-handler.ts] — Existing error response pipeline
+- [Source: backend/shared/types/src/errors.ts] — Existing ErrorCode enum to extend
+- [Source: backend/shared/db/src/helpers.ts] — Existing DynamoDB helpers to extend
+
+### Git Intelligence
+
+Recent work (Epic 3.1) established patterns for:
+- Shared schema extraction to `@ai-learning-hub/*` packages (PR #194)
+- Shared test utilities in `backend/test-utils/` (PR #196)
+- Handler consolidation using shared middleware (PR #198)
+- Phase runner infrastructure for smoke tests (PR #202)
+- API key scope enforcement across endpoints (PR #204)
+
+These patterns should be followed for consistency. The scope enforcement middleware from PR #204 (Story 3.1.7) is particularly relevant as it demonstrates how to add new middleware concerns to the existing handler pipeline.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+{{agent_model_name_version}}
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/3-2-2-consistent-error-contract-response-envelope.md
+++ b/_bmad-output/implementation-artifacts/3-2-2-consistent-error-contract-response-envelope.md
@@ -1,0 +1,353 @@
+# Story 3.2.2: Consistent Error Contract & Response Envelope
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a **developer building agent-native API endpoints**,
+I want **a consistent error contract with actionable context and a standardized response envelope in `@ai-learning-hub/middleware`**,
+so that **all API responses — success and error — follow a single parseable shape, enabling AI agents to understand failures, determine next actions, and navigate paginated data without special-casing per endpoint**.
+
+## Acceptance Criteria
+
+### Enhanced Error Contract (FR100, NFR-AN7)
+
+1. **AC1: Extended error body shape** — All error responses follow the shape: `{ error: { code, message, requestId, details?, currentState?, allowedActions?, requiredConditions? } }`. The three new fields (`currentState`, `allowedActions`, `requiredConditions`) are optional and present only when semantically relevant. The existing `code`, `message`, `requestId` fields remain mandatory. The existing `details` field remains an optional catch-all object. **Naming convention:** camelCase is used to match the existing `requestId` field, even though the PRD uses snake_case. The JSON wire format is camelCase throughout.
+
+2. **AC2: State machine error enrichment** — When an error has `currentState` set (e.g., a future `INVALID_STATE_TRANSITION` error), the response includes `currentState` (string — the entity's current lifecycle state) and `allowedActions` (string array — the transitions valid from that state). This gives agents machine-readable context to choose the correct next action. Example: `{ error: { code: "INVALID_STATE_TRANSITION", message: "Cannot complete a paused project", currentState: "paused", allowedActions: ["resume", "delete"] } }`.
+
+3. **AC3: Error builder helpers** — A new `AppErrorBuilder` in `@ai-learning-hub/types` provides a fluent API: `AppError.build(ErrorCode.FORBIDDEN, "msg").withState("paused", ["resume"]).withConditions(["must resume first"]).create()`. The builder is optional syntactic sugar — direct `new AppError(...)` still works. Builder sets the new fields via the existing `details` mechanism internally, and `toApiError()` promotes them to top-level error fields in the output.
+
+4. **AC4: New error code — INVALID_STATE_TRANSITION** — `ErrorCode` enum extended with `INVALID_STATE_TRANSITION` mapped to HTTP 409. This code is defined now for future use by state machine middleware (Epic 3.2 Story 3.2.7+ and Epics 4, 8). Handlers are not required to use it yet.
+
+5. **AC5: Backward compatibility & field promotion** — Existing error responses that do not set `currentState`, `allowedActions`, or `requiredConditions` remain unchanged. The `toApiError()` method only includes these fields when they have values. When promoted, these fields are **removed from `details`** to avoid duplication (single source of truth). If `details` becomes empty after stripping promoted fields, it is omitted from the response entirely. No existing tests break.
+
+### Field-Level Validation Errors (FR101)
+
+6. **AC6: Enhanced ValidationErrorDetail** — The `ValidationErrorDetail` interface in `@ai-learning-hub/validation` gains two optional fields: `constraint?: string` (human-readable constraint description, e.g., "minimum 1 character") and `allowed_values?: string[]` (list of valid values for enum fields, e.g., `["article", "video", "podcast"]`). Existing `field`, `message`, `code` fields remain.
+
+7. **AC7: Zod error extraction — constraints** — `formatZodErrors` extracts constraint information from Zod error metadata where available: `too_small` errors include minimum value, `too_big` errors include maximum value, `invalid_string` errors include the expected format (e.g., "email", "url", "uuid"), `invalid_enum_value` errors include the allowed options as `allowed_values`. When Zod does not expose constraint info, the `constraint` field is omitted.
+
+8. **AC8: Validation error response shape** — Validation errors use the standard error body with `details` containing a `fields` array: `{ error: { code: "VALIDATION_ERROR", message: "Validation failed", requestId, details: { fields: [{ field, code, message, constraint?, allowed_values? }] } } }`. The key is renamed from `errors` to `fields` to be more explicit and avoid ambiguity with the top-level `error` key. Existing handlers that throw `AppError(VALIDATION_ERROR, msg, { errors: [...] })` are migrated to use `{ fields: [...] }` instead. (The migration is confined to `validate()` in `@ai-learning-hub/validation` — handlers don't construct this manually.)
+
+### Response Envelope (FR100 — success responses)
+
+9. **AC9: Standard envelope shape** — All success responses (2xx) follow: `{ data: T | T[], meta?: { cursor?: string | null, total?: number, rateLimit?: { limit: number, remaining: number, reset: string } }, links?: { self: string, next?: string | null } }`. The `data` field wraps the primary payload. `meta` is included only when at least one sub-field is populated; omitted entirely otherwise. `links` is included only when `self` is provided; omitted entirely otherwise. Empty objects (`meta: {}`, `links: {}`) are never sent. Single-resource GETs typically omit both `meta` and `links`.
+
+10. **AC10: createSuccessResponse enhancement** — The existing `createSuccessResponse` function is updated to use an options object for extensibility. New signature: `createSuccessResponse<T>(data: T, requestId: string, options?: { statusCode?: number, meta?: EnvelopeMeta, links?: ResponseLinks })`. The function builds the envelope, sets `Content-Type` and `X-Request-Id` headers, and returns the API Gateway response. Existing callers passing `(data, requestId)` continue to work (options defaults to `{}`). All existing callers that use the old positional form `(data, requestId, statusCode, meta)` are migrated to the new options form in this story — no overload detection needed since there are only ~5-8 call sites in the codebase.
+
+11. **AC11: ApiResponseMeta type update** — The existing `ApiResponseMeta` interface is replaced with the new `EnvelopeMeta` interface: `{ cursor?: string | null, total?: number, rateLimit?: RateLimitMeta }`. The deprecated `page`, `pageSize`, `nextCursor`, `prevCursor` fields are removed (they are not used by any handler in the codebase — verified via grep). A new `ResponseLinks` interface is added: `{ self: string, next?: string | null }`. A new `RateLimitMeta` interface is added: `{ limit: number, remaining: number, reset: string }`. The `reset` field is an ISO 8601 datetime string (e.g., `"2026-02-25T13:00:00Z"`) per ADR-014.
+
+12. **AC12: 204 No Content exclusion** — `createNoContentResponse` is unchanged. 204 responses have no body and are exempt from the envelope requirement.
+
+13. **AC13: Backward compatibility — success shape** — Existing handlers that return plain objects from `wrapHandler` (auto-wrapped via `createSuccessResponse`) continue to work. They produce `{ data: <object> }` with no `meta` or `links`. All existing callers of `createSuccessResponse` that use the old positional form are migrated to the new options form in Task 4.
+
+### Type Safety & Exports
+
+14. **AC14: New types exported** — All new types exported from `@ai-learning-hub/types` index: `EnvelopeMeta`, `RateLimitMeta`, `ResponseLinks`, `ResponseEnvelope<T>`, `FieldValidationError`. The `AppErrorBuilder` class is NOT exported separately — it is an internal implementation detail, accessible only via `AppError.build()`. This ensures a single canonical path for building enhanced errors.
+
+15. **AC15: Updated type imports** — All new types and the builder are importable from `@ai-learning-hub/types` and `@ai-learning-hub/middleware` (re-exported where used). No new packages created.
+
+### Testing
+
+16. **AC16: Unit tests — error contract** — Tests cover: basic error shape unchanged, error with `currentState` + `allowedActions`, error with `requiredConditions`, `INVALID_STATE_TRANSITION` error code, `AppErrorBuilder` fluent API, backward compatibility (existing AppError calls produce same output). Minimum 90% coverage for new error contract code.
+
+17. **AC17: Unit tests — field-level validation** — Tests cover: Zod `too_small` → constraint extracted, Zod `too_big` → constraint extracted, Zod `invalid_enum_value` → `allowed_values` extracted, Zod `invalid_string` → format constraint extracted, nested field paths, `fields` key in validation error details. Minimum 90% coverage.
+
+18. **AC18: Unit tests — response envelope** — Tests cover: basic `{ data }` envelope, envelope with `meta.cursor` + `meta.total`, envelope with `meta.rateLimit`, envelope with `links.self` + `links.next`, 204 responses unchanged, backward compatibility with existing `createSuccessResponse` callers (both old positional and new options forms). Minimum 90% coverage.
+
+19. **AC19: wrapHandler normalization preserves new fields** — The ADR-008 normalization path in `wrapHandler` (which normalizes 4xx/5xx pass-through responses) preserves `currentState`, `allowedActions`, and `requiredConditions` fields when present in the error body. A handler that returns a raw API Gateway result with these fields does not have them stripped.
+
+20. **AC20: Integration contract tests** — Test that the full middleware chain produces the correct envelope: wrapHandler auto-wraps handler return values in `{ data }`. Verify error responses include all specified fields. Verify existing handler tests still pass without modification (beyond the `errors` → `fields` key rename in validation error assertions).
+
+## Tasks / Subtasks
+
+### Task 1: Enhanced Error Types & Builder (AC: #1, #3, #4, #5, #14)
+
+- [ ] 1.1 Add `INVALID_STATE_TRANSITION` to `ErrorCode` enum in `@ai-learning-hub/types/src/errors.ts`
+- [ ] 1.2 Add status code mapping `INVALID_STATE_TRANSITION → 409` to `ErrorCodeToStatus`
+- [ ] 1.3 Extend `ApiErrorBody` interface with optional fields: `currentState?: string`, `allowedActions?: string[]`, `requiredConditions?: string[]`
+- [ ] 1.4 Update `AppError.toApiError()` to promote `currentState`, `allowedActions`, `requiredConditions` from `details` to top-level error fields when present
+- [ ] 1.5 Create `AppErrorBuilder` class with fluent API: `.withState(currentState, allowedActions)`, `.withConditions(conditions)`, `.withDetails(details)`, `.create()`
+- [ ] 1.6 Add static `AppError.build(code, msg)` factory method that returns an internal `AppErrorBuilder` instance. Do NOT export `AppErrorBuilder` as a standalone class — it is only accessible via `AppError.build()`
+- [ ] 1.7 Write unit tests for new error code, builder, and toApiError promotion
+
+### Task 2: Enhanced Validation Error Formatting (AC: #6, #7, #8)
+
+- [ ] 2.1 Extend `ValidationErrorDetail` interface with `constraint?: string` and `allowed_values?: string[]`
+- [ ] 2.2 Update `formatZodErrors` to extract constraint info from Zod error metadata: `too_small` → `"minimum {minimum}"`, `too_big` → `"maximum {maximum}"`, `invalid_enum_value` → `allowed_values: options`, `invalid_string` → `"expected {validation}"`
+- [ ] 2.3 Update `validate()` to use `{ fields: [...] }` instead of `{ errors: [...] }` in AppError details
+- [ ] 2.4 Update `validateJsonBody`, `validateQueryParams`, `validatePathParams` to use consistent `fields` key
+- [ ] 2.5 Export updated `ValidationErrorDetail` (alias as `FieldValidationError`) from package index
+- [ ] 2.6 Write unit tests for enhanced formatZodErrors (all Zod error types: too_small, too_big, invalid_enum_value, invalid_string, nested fields)
+
+### Task 3: Response Envelope Types (AC: #9, #11, #14)
+
+- [ ] 3.1 Create `EnvelopeMeta` interface in `@ai-learning-hub/types/src/api.ts`: `{ cursor?: string | null, total?: number, rateLimit?: RateLimitMeta }`
+- [ ] 3.2 Create `RateLimitMeta` interface: `{ limit: number, remaining: number, reset: string }`
+- [ ] 3.3 Create `ResponseLinks` interface: `{ self: string, next?: string | null }`
+- [ ] 3.4 Create `ResponseEnvelope<T>` generic type: `{ data: T, meta?: EnvelopeMeta, links?: ResponseLinks }`
+- [ ] 3.5 Remove deprecated `page`, `pageSize`, `nextCursor`, `prevCursor` from `ApiResponseMeta` (replace with `EnvelopeMeta`)
+- [ ] 3.6 Export all new types from `@ai-learning-hub/types` index
+- [ ] 3.7 Write type-level tests verifying generic type compatibility
+
+### Task 4: Middleware Response Envelope Implementation (AC: #10, #12, #13)
+
+- [ ] 4.1 Update `createSuccessResponse` to use options object pattern: `(data, requestId, options?: { statusCode?, meta?, links? })`
+- [ ] 4.2 Migrate all existing callers of `createSuccessResponse` to the new options form:
+  - `backend/functions/saves/handler.ts` — `createSuccessResponse(toPublicSave(saveItem), requestId, 201)` → `createSuccessResponse(toPublicSave(saveItem), requestId, { statusCode: 201 })`
+  - `backend/functions/saves/handler.ts` (restore path) — `createSuccessResponse(..., requestId, 200)` → `createSuccessResponse(..., requestId, { statusCode: 200 })`
+  - Any other callers found via grep for `createSuccessResponse(` across `backend/functions/`
+- [ ] 4.3 Build response body as `{ data, meta?, links? }` — omit `meta` when empty/undefined, omit `links` when empty/undefined (never send `meta: {}` or `links: {}`)
+- [ ] 4.4 Verify `createNoContentResponse` remains unchanged (204, no body)
+- [ ] 4.5 Update `wrapHandler` auto-wrap path: handler results wrapped as `{ data: result }` (existing behavior preserved)
+- [ ] 4.6 Export updated types from `@ai-learning-hub/middleware` index
+- [ ] 4.7 Write unit tests for all envelope scenarios
+
+### Task 5: Enhanced Error Response Formatting (AC: #2, #5, #19)
+
+- [ ] 5.1 Update `createErrorResponse` in `error-handler.ts` to extract `currentState`, `allowedActions`, `requiredConditions` from `AppError.details` and include them as top-level fields in the error body (strip from `details` to avoid duplication)
+- [ ] 5.2 Ensure existing errors without these fields produce identical output (backward compatibility)
+- [ ] 5.3 Update ADR-008 normalization in `wrapHandler` (the 4xx/5xx pass-through path at lines 180-211) to preserve `currentState`, `allowedActions`, `requiredConditions` fields when present in parsed error bodies
+- [ ] 5.4 Write unit tests for enhanced error response formatting and normalization preservation
+
+### Task 6: Validation Error Migration (AC: #8)
+
+Known locations using `{ errors: [...] }` key (exhaustive as of story creation):
+- `backend/shared/validation/src/validator.ts` — `validate()` function (line 36)
+- `backend/shared/validation/test/validator.test.ts` — test assertions checking `details.errors` or `errors` array
+- Any handler integration tests that assert on validation error shape
+
+- [ ] 6.1 Verify the known locations above with a grep for `errors:` near `VALIDATION_ERROR` — confirm no additional locations exist
+- [ ] 6.2 Update `validate()` in `backend/shared/validation/src/validator.ts` to use `{ fields: [...] }` key
+- [ ] 6.3 Update `backend/shared/validation/test/validator.test.ts` assertions from `details.errors` / `errors` to `details.fields` / `fields`
+- [ ] 6.4 Grep for any handler-level tests asserting on `details.errors` and update them
+- [ ] 6.5 Write migration verification test that confirms no response in the test suite uses `details.errors` key
+
+### Task 7: Integration & Contract Tests (AC: #19, #20)
+
+- [ ] 7.1 Integration test: wrapHandler auto-wraps plain object → `{ data: <object> }`
+- [ ] 7.2 Integration test: wrapHandler with explicit `createSuccessResponse` + envelope meta (options object form)
+- [ ] 7.3 Integration test: error response includes `currentState` and `allowedActions` when set
+- [ ] 7.5 Integration test: 4xx pass-through normalization preserves `currentState`, `allowedActions`, `requiredConditions`
+- [ ] 7.6 Integration test: validation error includes `fields` array with constraints
+- [ ] 7.7 Integration test: backward compatibility — existing handler return patterns unchanged
+- [ ] 7.8 Verify all existing middleware and handler tests still pass
+
+## Dev Notes
+
+### Architecture Patterns & Constraints
+
+- **ADR-008 (Standardized Error Handling):** This story extends ADR-008's error contract for agent-native consumption. The base shape `{ error: { code, message, requestId } }` is preserved. New fields are additive (optional), maintaining full backward compatibility.
+- **ADR-014 (API-First Design):** The response envelope and enhanced error contract are driven by API-first philosophy — agents parse one response shape for all endpoints.
+- **ADR-015 (Lambda Layers):** All changes are in shared packages (`@ai-learning-hub/types`, `@ai-learning-hub/middleware`, `@ai-learning-hub/validation`), deployed via Lambda Layer.
+- **No Lambda-to-Lambda (ADR-005):** This story is pure middleware/shared code — no inter-service calls.
+- **FR100:** Error contract: `{ code, message, details, currentState, allowedActions, requiredConditions }` (camelCase in JSON; PRD uses snake_case — project convention is camelCase per existing `requestId`)
+- **FR101:** Field-level validation: `{ field, code, message, constraint, allowed_values }`
+- **NFR-AN7:** 100% of error responses include `code`, `message`; state machine errors include `allowed_actions`
+
+### Existing Code to Extend
+
+| Package | File | Changes |
+|---------|------|---------|
+| `@ai-learning-hub/types` | `src/errors.ts` | Add `INVALID_STATE_TRANSITION` to ErrorCode, extend `ApiErrorBody`, add `AppErrorBuilder` |
+| `@ai-learning-hub/types` | `src/api.ts` | Replace `ApiResponseMeta` with `EnvelopeMeta`, add `RateLimitMeta`, `ResponseLinks`, `ResponseEnvelope<T>` |
+| `@ai-learning-hub/types` | `src/index.ts` | Export new types |
+| `@ai-learning-hub/validation` | `src/validator.ts` | Enhance `ValidationErrorDetail`, update `formatZodErrors` for constraint extraction, rename `errors` → `fields` |
+| `@ai-learning-hub/validation` | `src/index.ts` | Export `FieldValidationError` alias |
+| `@ai-learning-hub/middleware` | `src/error-handler.ts` | Enhance `createErrorResponse` for new fields, update `createSuccessResponse` for envelope |
+| `@ai-learning-hub/middleware` | `src/wrapper.ts` | Ensure auto-wrap path produces correct envelope |
+| `@ai-learning-hub/middleware` | `src/index.ts` | Export new types |
+
+### Current Response Shapes (Before This Story)
+
+**Error response (current):**
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Validation failed",
+    "requestId": "abc-123",
+    "details": {
+      "errors": [{ "field": "url", "message": "Required", "code": "invalid_type" }]
+    }
+  }
+}
+```
+
+**Error response (after this story):**
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Validation failed",
+    "requestId": "abc-123",
+    "details": {
+      "fields": [
+        {
+          "field": "url",
+          "message": "Required",
+          "code": "invalid_type",
+          "constraint": "minimum 1 character"
+        }
+      ]
+    }
+  }
+}
+```
+
+**State machine error (new pattern):**
+```json
+{
+  "error": {
+    "code": "INVALID_STATE_TRANSITION",
+    "message": "Cannot complete a paused project",
+    "requestId": "abc-123",
+    "currentState": "paused",
+    "allowedActions": ["resume", "delete"],
+    "requiredConditions": ["Project must be in 'building' state to complete"]
+  }
+}
+```
+
+**Success response (current):**
+```json
+{
+  "data": { "saveId": "01HX...", "url": "https://..." }
+}
+```
+
+**Success response with envelope (after):**
+```json
+{
+  "data": [{ "saveId": "01HX...", "url": "https://..." }],
+  "meta": {
+    "cursor": "eyJ...",
+    "total": 42,
+    "rateLimit": { "limit": 200, "remaining": 198, "reset": "2026-02-25T13:00:00Z" }
+  },
+  "links": {
+    "self": "/saves?limit=25",
+    "next": "/saves?limit=25&cursor=eyJ..."
+  }
+}
+```
+
+### Breaking Change: `errors` → `fields` Key Rename
+
+The validation error details key changes from `errors` to `fields`. This is a minor breaking change for consumers that parse `details.errors`. The rename is necessary because:
+- `errors` is ambiguous (could be confused with the top-level `error` key)
+- `fields` is more descriptive for field-level validation detail
+- FR101 specifies the field-level detail structure — `fields` aligns with the FR wording
+
+**Migration scope:** The change is isolated to `validate()` in `@ai-learning-hub/validation`. All handlers use `validate()` or `validateJsonBody()` — none construct the details manually. Test assertions checking `details.errors` need updating to `details.fields`.
+
+### AppErrorBuilder Pattern
+
+```typescript
+// Simple error (existing pattern still works)
+throw new AppError(ErrorCode.FORBIDDEN, "Insufficient permissions");
+
+// Enhanced error with state context (new builder)
+throw AppError.build(ErrorCode.INVALID_STATE_TRANSITION, "Cannot complete a paused project")
+  .withState("paused", ["resume", "delete"])
+  .withConditions(["Project must be in 'building' state to complete"])
+  .create();
+
+// Enhanced error with custom details + state
+throw AppError.build(ErrorCode.CONFLICT, "Version conflict")
+  .withDetails({ currentVersion: 5 })
+  .withState("modified", ["re-read", "retry"])
+  .create();
+```
+
+### Relationship to Other 3.2 Stories
+
+- **3.2.1 (Idempotency & Concurrency):** Adds error codes `VERSION_CONFLICT`, `PRECONDITION_REQUIRED`, `IDEMPOTENCY_KEY_CONFLICT`. Those errors benefit from the enhanced contract (e.g., `VERSION_CONFLICT` can include `current_state`). 3.2.2 does NOT depend on 3.2.1 — both are shared infra that can be built in parallel.
+- **3.2.3 (Event History):** No dependency in either direction.
+- **3.2.4 (Agent Identity & Rate Limit):** Rate limit transparency headers (`X-RateLimit-*`) will populate `meta.rate_limit` in the envelope. 3.2.4 can use the envelope types defined here. No hard dependency.
+- **3.2.5 (Cursor Pagination):** Cursor pagination will populate `meta.cursor` and `links.next`. 3.2.5 uses the envelope types defined here. No hard dependency.
+- **3.2.7 (Saves Retrofit):** Will use the envelope, error contract, and builder when retrofitting saves handlers. Depends on this story.
+- **3.2.8 (Auth Retrofit):** Same as 3.2.7 for auth handlers.
+
+### Scope Boundaries
+
+- **Non-goal: Retrofitting existing handlers.** This story creates the infrastructure (types, helpers, middleware). Actual handler retrofits to use the full envelope with `meta` and `links` are in Stories 3.2.7 and 3.2.8.
+- **Non-goal: Rate limit header population.** The `rateLimit` field in `meta` is defined here but populated by Story 3.2.4 (Agent Identity & Rate Limit Transparency).
+- **Non-goal: Cursor pagination implementation.** The `cursor` field in `meta` and `next` in `links` are defined here but populated by Story 3.2.5 (Cursor-Based Pagination).
+- **Non-goal: Domain-specific error payloads.** The saves handler's `DUPLICATE_SAVE` response currently places `existingSave` as a sibling of `error` (e.g., `{ error: {...}, existingSave: {...} }`). Normalizing domain-specific error payloads into `error.details` or the envelope `data` field is deferred to Story 3.2.7 (Saves Retrofit). This story does not change existing handler response construction.
+- **Non-goal: `links` population.** The `links` types are defined here, but populating `links.self` and `links.next` requires request context (path, query params) that is the handler's responsibility. Actual `links` population is deferred to retrofit stories (3.2.7, 3.2.8) which have access to request context.
+- **Goal: The `errors` → `fields` rename IS in scope.** This is a one-time migration that's cleanest to do now, before more handlers are added.
+
+### Testing Standards
+
+- **Framework:** Vitest (already used across all shared packages)
+- **Coverage target:** 90% for new code (above the 80% CI gate)
+- **Test location:** Co-located `test/` directories in each shared package
+- **Mock pattern:** Use `vi.mock()` for any mocked dependencies, following existing patterns
+- **Test factories:** Use existing `backend/test-utils/` mock helpers where applicable
+
+### Key Technical Decisions
+
+1. **camelCase for new error fields:** The PRD specifies `current_state`, `allowed_actions`, `required_conditions` (snake_case), but the existing API uses camelCase throughout (`requestId`, `saveId`, `contentType`). Decision: use camelCase (`currentState`, `allowedActions`, `requiredConditions`) for consistency. The PRD's snake_case is treated as conceptual naming, not wire format.
+2. **Promote fields from `details` in `toApiError()`:** The `currentState`, `allowedActions`, `requiredConditions` are stored internally as `details` properties (keeping `AppError` constructor simple) but are promoted to top-level error body fields in `toApiError()`. This avoids adding constructor parameters while giving a clean API output.
+3. **Static `AppError.build()` factory — single canonical path:** The builder is a static method on `AppError` for discoverability. `AppError.build(code, msg)` returns an internal `AppErrorBuilder` (not exported) that collects state/conditions/details and produces the final `AppError` via `.create()`. This ensures one way to build enhanced errors — no competing imports.
+4. **Options object for `createSuccessResponse` — no overload:** The new signature uses `(data, requestId, options?)` instead of positional parameters. All existing callers (~5-8 call sites) are migrated to the new form in this story. No overload detection is needed — simpler implementation, fewer edge cases.
+5. **`EnvelopeMeta` replaces `ApiResponseMeta`:** The old type had `page`/`pageSize` fields that are incompatible with cursor pagination. Grep confirms no handler uses these fields — safe to remove. A type alias `ApiResponseMeta = EnvelopeMeta` can be kept briefly for transition if needed, but the old-shape fields (`page`, `pageSize`, `nextCursor`, `prevCursor`) must be removed.
+6. **`fields` not `errors` for validation details:** The rename from `errors` to `fields` is deliberate — `errors` is confusing inside an `error` wrapper. FR101 says "field-level detail" so `fields` is the natural key.
+7. **No CDK changes required:** This story is entirely shared library code. No new DynamoDB tables, no new Lambda functions, no infrastructure changes.
+
+### Project Structure Notes
+
+- All changes go into existing shared packages — no new packages created
+- No new npm dependencies required
+- No CDK stack changes
+- File changes are confined to `backend/shared/types/`, `backend/shared/validation/`, and `backend/shared/middleware/`
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/prd.md#Error Contract] — FR100 (consistent error contract), FR101 (field-level validation)
+- [Source: _bmad-output/planning-artifacts/prd.md#Non-Functional Requirements] — NFR-AN7 (100% error responses include code, message; state machine errors include allowed_actions)
+- [Source: _bmad-output/planning-artifacts/architecture.md#ADR-008] — Standardized error handling baseline
+- [Source: _bmad-output/planning-artifacts/architecture.md#ADR-014] — API-first design, consistent response shapes
+- [Source: _bmad-output/planning-artifacts/architecture.md#ADR-015] — Lambda Layers for shared code
+- [Source: _bmad-output/planning-artifacts/epics.md#Epic 3.2] — Story definition and dependencies
+- [Source: backend/shared/middleware/src/error-handler.ts] — Current error response builder (createErrorResponse, createSuccessResponse)
+- [Source: backend/shared/middleware/src/wrapper.ts] — Current wrapHandler middleware chain and auto-wrap logic
+- [Source: backend/shared/types/src/errors.ts] — Current ErrorCode enum, AppError class, ApiErrorBody interface
+- [Source: backend/shared/types/src/api.ts] — Current ApiResponseMeta, ApiSuccessResponse types
+- [Source: backend/shared/validation/src/validator.ts] — Current formatZodErrors, validate, ValidationErrorDetail
+
+### Git Intelligence
+
+Recent work (Epic 3.1) established patterns for:
+- Shared schema extraction to `@ai-learning-hub/*` packages (PR #194)
+- Shared test utilities in `backend/test-utils/` (PR #196)
+- Handler consolidation using shared middleware (PR #198)
+- Scope enforcement middleware in the handler pipeline (PR #204)
+
+The error-handler.ts patterns from Epic 2 (PRs #123-#143) are the baseline being extended. The `createSuccessResponse` with `ApiResponseMeta` was added during saves list implementation (PR #186) and already wraps responses in `{ data, meta? }` — this story enhances that existing pattern.
+
+### Previous Story Intelligence
+
+Story 3.2.1 (Idempotency & Optimistic Concurrency) established:
+- Pattern for extending `WrapperOptions` with new middleware flags
+- Pattern for new error codes (`VERSION_CONFLICT`, `PRECONDITION_REQUIRED`, `IDEMPOTENCY_KEY_CONFLICT`)
+- Pattern for response headers added by middleware (`X-Idempotent-Replayed`, `X-Idempotency-Status`)
+- Pattern for `details` object carrying transport-only metadata (`responseHeaders`)
+
+This story follows the same patterns: extending types, enhancing middleware, maintaining backward compatibility. The `responseHeaders` stripping in `createErrorResponse` (lines 27-44 of error-handler.ts) is a precedent for separating transport metadata from body content — the same principle applies to promoting `currentState`/`allowedActions` from details to top-level error fields.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+{{agent_model_name_version}}
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/3-2-3-event-history-infrastructure.md
+++ b/_bmad-output/implementation-artifacts/3-2-3-event-history-infrastructure.md
@@ -1,0 +1,598 @@
+# Story 3.2.3: Event History Infrastructure
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a developer building agent-native APIs,
+I want a shared event history infrastructure that records state changes per entity with actor attribution,
+so that all domain entities can expose queryable event history endpoints for audit, debugging, and agent reconciliation after failures.
+
+## Acceptance Criteria
+
+### AC1: Events DynamoDB Table
+
+**Given** the CDK infrastructure is deployed
+**When** the events table is provisioned
+**Then** it has:
+
+- PK: string (`EVENTS#{entityType}#{entityId}`)
+- SK: string (`EVENT#{timestamp}#{eventId}`)
+- TTL attribute: `ttl` (number, epoch seconds)
+- Billing: PAY_PER_REQUEST
+- Point-in-time recovery: enabled
+- Encryption: AWS_MANAGED
+- Table name exported as CfnOutput
+
+### AC2: Event Record Schema
+
+**Given** an event is recorded via `recordEvent()`
+**When** stored in the events table
+**Then** the item contains:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `PK` | string | yes | `EVENTS#{entityType}#{entityId}` |
+| `SK` | string | yes | `EVENT#{timestamp}#{eventId}` |
+| `eventId` | string (ULID) | yes | Auto-generated |
+| `entityType` | string | yes | `save`, `project`, `tutorial`, `link`, `user`, `apiKey` |
+| `entityId` | string | yes | ID of the affected entity |
+| `userId` | string | yes | Owner of the entity |
+| `eventType` | string | yes | PascalCase `{EntityType}{PastTenseVerb}` — e.g., `SaveCreated`, `SaveUpdated`, `SaveDeleted`, `ProjectStatusTransitioned`, `ApiKeyRevoked` |
+| `actorType` | `human` \| `agent` | yes | Who performed the action |
+| `actorId` | string \| null | no | Agent ID if `actorType === 'agent'` |
+| `timestamp` | string (ISO 8601) | yes | Auto-generated |
+| `changes` | object \| null | no | Minimal diff of changed fields only: `{ before: { title: "old" }, after: { title: "new" } }`. If full before/after exceeds 10KB, log WARN and fall back to `{ changedFields: ['title', 'tags'] }` |
+| `context` | object \| null | no | `{ trigger, source, confidence, upstream_ref }` |
+| `requestId` | string | yes | Correlation ID from the originating request |
+| `ttl` | number | yes | Epoch seconds, 90 days from creation (auto-calculated) |
+
+### AC3: `recordEvent()` Shared Utility
+
+**Given** `@ai-learning-hub/db` is imported
+**When** a handler calls `recordEvent(client, params, logger)`
+**Then** the function:
+
+- Generates `eventId` as ULID
+- Generates `timestamp` as ISO 8601 now
+- Calculates `ttl` as `Math.floor(Date.now() / 1000) + 90 * 24 * 60 * 60`
+- Constructs PK/SK from `entityType` + `entityId` + `timestamp` + `eventId`
+- Writes to the events table via `putItem()`
+- Returns the created event record
+- Validates required fields via Zod schema before writing
+- Logs the write at INFO level
+- **Fire-and-forget design:** `recordEvent()` is non-critical. Callers MUST wrap in try/catch and log failures at WARN level without re-throwing. Event recording must never block or fail the primary operation (same pattern as EventBridge emission in saves handlers)
+
+### AC4: `queryEntityEvents()` Shared Utility
+
+**Given** `@ai-learning-hub/db` is imported
+**When** a handler calls `queryEntityEvents(client, entityType, entityId, options, logger)`
+**Then** the function:
+
+- Queries PK `EVENTS#{entityType}#{entityId}` with `ScanIndexForward=false` (newest first)
+- If `options.since` provided and is valid ISO 8601: adds SK condition `SK > EVENT#{since}` to return only events after that timestamp
+- If `options.since` provided and is NOT valid ISO 8601: throws `VALIDATION_ERROR` with `{ field: 'since', message: 'Must be ISO 8601 format' }`
+- If `options.limit` provided: uses it (default 50, capped at 200)
+- If `options.cursor` provided: decodes opaque base64url cursor to `ExclusiveStartKey`
+- Returns `{ events: EntityEvent[], nextCursor: string | null }` where `nextCursor` is base64url-encoded `LastEvaluatedKey` or `null` if no more pages
+
+### AC5: `createEventHistoryHandler()` Generator
+
+**Given** `@ai-learning-hub/middleware` is imported
+**When** a domain module calls `createEventHistoryHandler(config)` where config includes `entityType`, `entityExistsFn`, and `client` (DynamoDB DocumentClient)
+**Then** it returns a `wrapHandler`-compatible handler that:
+
+- Extracts `entityId` from path parameters
+- Calls `entityExistsFn(userId, entityId)` to verify the entity belongs to the user (throws `NOT_FOUND` if not). The function MUST return `true` for both active AND soft-deleted entities — event history must remain accessible for deleted entities for debugging and agent reconciliation
+- Parses query parameters: `since` (ISO 8601), `limit` (number), `cursor` (string)
+- Calls `queryEntityEvents()` with parsed options
+- Returns response in envelope format: `{ data: EntityEvent[], meta: { count, nextCursor, hasMore } }`
+
+### AC6: 90-Day TTL Retention
+
+**Given** events stored in the events table
+**When** 90 days have passed since creation
+**Then** DynamoDB TTL automatically deletes the expired records with no application-level cleanup
+
+### AC7: Query Performance
+
+**Given** an entity with up to 1000 events
+**When** `GET /:entity/:id/events` is called
+**Then** the response returns within 1 second (NFR-AN4: single-entity event query < 1s)
+
+### AC8: Unit Test Coverage
+
+All new code achieves ≥80% coverage. Required test scenarios by module:
+
+**`recordEvent()` tests:**
+- Writes correct PK/SK structure given entityType + entityId
+- Auto-generates ULID for eventId (valid ULID format, monotonically increasing)
+- Auto-generates ISO 8601 timestamp
+- Calculates TTL as epoch seconds 90 days from now (±1s tolerance)
+- Validates required fields via Zod — rejects missing `entityType`, `entityId`, `userId`, `eventType`, `actorType`, `requestId`
+- Rejects invalid `entityType` not in the allowed union
+- Rejects invalid `actorType` not in `['human', 'agent']`
+- Logs at INFO level on successful write
+- Logs at WARN level on DynamoDB write failure (does NOT throw)
+- Accepts null `changes`, `context`, `actorId`
+- Truncates `changes` to field names when diff exceeds 10KB
+
+**`queryEntityEvents()` tests:**
+- Queries correct PK given entityType + entityId
+- Returns events newest-first (ScanIndexForward=false)
+- Applies `since` filter as SK condition when valid ISO 8601
+- Throws VALIDATION_ERROR when `since` is not valid ISO 8601 (e.g. `"yesterday"`, `"2026-13-01"`)
+- Defaults limit to 50 when not provided
+- Caps limit at 200 when caller passes higher value
+- Encodes LastEvaluatedKey as base64url cursor
+- Decodes cursor to ExclusiveStartKey on subsequent call
+- Returns `nextCursor: null` when no LastEvaluatedKey (last page)
+- Returns empty array for entity with no events
+
+**`createEventHistoryHandler()` tests:**
+- Returns 404 NOT_FOUND when `entityExistsFn` returns false
+- Calls `entityExistsFn` with userId from auth context and entityId from path params
+- Passes `since`, `limit`, `cursor` query params to `queryEntityEvents()`
+- Returns events in envelope format `{ data, meta: { count, nextCursor, hasMore } }`
+- Returns 400 VALIDATION_ERROR for non-ISO `since` parameter
+- Returns empty data array with hasMore=false for entity with no events
+- Works for soft-deleted entities (entityExistsFn returns true)
+
+**CDK assertion tests:**
+- Events table has PK=string (partitionKey), SK=string (sortKey)
+- TTL attribute is `ttl`
+- Billing mode is PAY_PER_REQUEST
+- PITR is enabled
+- Table name exported as CfnOutput
+- Removal policy is RETAIN
+
+## Tasks / Subtasks
+
+- [ ] Task 1 — CDK: Add events DynamoDB table (AC: 1, 6)
+  - [ ] 1.1 Add `EventsTable` to `infra/lib/stacks/core/tables.stack.ts`
+  - [ ] 1.2 Configure PK/SK, TTL attribute `ttl`, PAY_PER_REQUEST, PITR, encryption
+  - [ ] 1.3 Export table name and ARN via `CfnOutput`
+  - [ ] 1.4 Add CDK assertion tests in `infra/test/`
+
+- [ ] Task 2 — Types: Define event types in `@ai-learning-hub/types` (AC: 2)
+  - [ ] 2.1 Create `backend/shared/types/src/entities/events.ts`
+  - [ ] 2.2 Add `EntityEvent` interface, `EventEntityType` union, `ActorType` union
+  - [ ] 2.3 Add `RecordEventParams` input interface (omitting auto-generated fields)
+  - [ ] 2.4 Add `EventHistoryQueryOptions` and `EventHistoryResponse` interfaces
+  - [ ] 2.5 Export from `backend/shared/types/src/index.ts` barrel
+
+- [ ] Task 3 — DB: Implement event history utilities in `@ai-learning-hub/db` (AC: 3, 4)
+  - [ ] 3.1 Add `EVENTS_TABLE_CONFIG` to table config file
+  - [ ] 3.2 Create `backend/shared/db/src/operations/events.ts`
+  - [ ] 3.3 Implement `recordEvent()` with ULID, timestamp, TTL auto-generation
+  - [ ] 3.4 Implement `queryEntityEvents()` with since/limit/cursor support
+  - [ ] 3.5 Add Zod validation schema for `RecordEventParams`
+  - [ ] 3.6 Export from `backend/shared/db/src/index.ts` barrel
+  - [ ] 3.7 Write unit tests in `backend/shared/db/test/operations/events.test.ts`
+
+- [ ] Task 4 — Middleware: Implement handler generator (AC: 5)
+  - [ ] 4.1 Create `backend/shared/middleware/src/handlers/event-history.ts`
+  - [ ] 4.2 Implement `createEventHistoryHandler({ entityType, entityExistsFn, client })` returning a `wrapHandler`-compatible function
+  - [ ] 4.3 Add query parameter parsing and validation (`since`, `limit`, `cursor`)
+  - [ ] 4.4 Export from `backend/shared/middleware/src/index.ts` barrel
+  - [ ] 4.5 Write unit tests in `backend/shared/middleware/test/handlers/event-history.test.ts`
+
+- [ ] Task 5 — CDK wiring for future consumers (AC: 1)
+  - [ ] 5.1 Add `EVENTS_TABLE_NAME` to the environment variable registry in `infra/README.md` (or existing env var docs) so API stacks know to include it when wiring Lambdas in 3.2.7/3.2.8
+  - [ ] 5.2 Export `eventsTable` and its `grantReadWriteData()` method from the tables stack so API stacks can grant permissions without importing the table construct directly
+
+- [ ] Task 6 — Quality gates (AC: 8)
+  - [ ] 6.1 Run `npm test` — all tests pass with ≥80% coverage on new files
+  - [ ] 6.2 Run `npm run lint` — no errors
+  - [ ] 6.3 Run `npm run build` — no TypeScript errors
+  - [ ] 6.4 Run `npm run type-check` — passes
+
+## Dev Notes
+
+### Architecture Overview
+
+This story builds the **shared event history infrastructure** for Epic 3.2 (Agent-Native API Foundation). It implements FR102 and NFR-AN4. All domain entities (saves, projects, tutorials, links, user) will use this infrastructure to expose queryable event history endpoints.
+
+**Scope boundary:** This story delivers infrastructure only — the DynamoDB table, shared utilities, and handler generator. No existing handlers are modified to record or expose events. That happens in:
+- Story 3.2.7 (Saves Domain Retrofit) — wires saves handlers to record events and adds `GET /saves/:id/events`
+- Story 3.2.8 (Auth Domain Retrofit) — wires auth handlers similarly
+
+### DynamoDB Events Table Design
+
+```
+Table: events (8th table — extends ADR-001 multi-table design)
+
+PK: EVENTS#{entityType}#{entityId}
+    Examples: "EVENTS#save#01ARZ3NDEKTSV4RRFFQ69G5FAV"
+              "EVENTS#project#01ARZ3NDEKTSV4RRFFQ69G5FAV"
+
+SK: EVENT#{timestamp}#{eventId}
+    Examples: "EVENT#2026-02-25T12:00:00.000Z#01ARZ3NDEKTSV4RRFFQ69G5FAV"
+
+TTL: ttl (epoch seconds — 90 days from event creation)
+```
+
+**Why this key design:**
+
+| Design choice | Rationale |
+|--------------|-----------|
+| PK groups by entity | Single query retrieves full history for one entity |
+| Timestamp in SK prefix | Enables `?since=` via `SK > EVENT#{isoTimestamp}` key condition |
+| ULID suffix in SK | Guarantees uniqueness even for simultaneous events on same entity |
+| Separate table (not in saves/projects) | TTL applies table-wide; events span ALL entity types; isolation from entity CRUD |
+| PAY_PER_REQUEST | Event volume is low at boutique scale; no capacity planning needed |
+
+**No GSIs needed** — the only access pattern is "get events for entity X" which the PK handles directly.
+
+### Event Type Naming Convention
+
+All event types MUST use PascalCase `{EntityType}{PastTenseVerb}` format:
+
+| Entity | Event Types |
+|--------|-------------|
+| save | `SaveCreated`, `SaveUpdated`, `SaveDeleted`, `SaveRestored`, `SaveMetadataUpdated` |
+| project | `ProjectCreated`, `ProjectUpdated`, `ProjectDeleted`, `ProjectStatusTransitioned` |
+| apiKey | `ApiKeyCreated`, `ApiKeyRevoked`, `ApiKeyUsed` |
+| tutorial | `TutorialStarted`, `TutorialCompleted` |
+
+Define a `KNOWN_EVENT_TYPES` record per domain in `@ai-learning-hub/types`. Not enforced at write time in V1 (domains may add new types), but validated in tests to catch typos.
+
+### `apiKey` as Entity Type
+
+`apiKey` is a valid entity type because API keys have their own lifecycle (created, revoked, last-used) independent of the user profile. Event history for `entityType: 'apiKey'` uses the key ID as `entityId`, not the user ID. When 3.2.8 (auth retrofit) implements event recording, it should use `apiKey` for key-specific events and `user` for profile-level events.
+
+### Existing Codebase Patterns — MUST Follow
+
+**Table config pattern** (`backend/shared/db/src/config.ts`):
+
+```typescript
+export const EVENTS_TABLE_CONFIG: TableConfig = {
+  tableName: requireEnv("EVENTS_TABLE_NAME", "dev-ai-learning-hub-events"),
+  partitionKey: "PK",
+  sortKey: "SK",
+};
+```
+
+**DB operation pattern** (`backend/shared/db/src/operations/*.ts`):
+
+```typescript
+export async function recordEvent(
+  client: DynamoDBDocumentClient,
+  params: RecordEventParams,
+  logger?: Logger
+): Promise<EntityEvent> { ... }
+```
+
+All DB functions accept an optional `Logger` parameter (established in PR #151). Use `putItem()` and `queryItems()` from the existing `@ai-learning-hub/db` helpers.
+
+**Handler pattern** (`backend/shared/middleware/src/`):
+
+The handler generator must return a function compatible with `wrapHandler()`:
+
+```typescript
+export function createEventHistoryHandler(config: {
+  entityType: EventEntityType;
+  entityExistsFn: (userId: string, entityId: string) => Promise<boolean>;
+  client: DynamoDBDocumentClient;
+}) {
+  return async function eventHistoryHandler(ctx: HandlerContext) {
+    // ...
+  };
+}
+```
+
+Consumers wire it like:
+
+```typescript
+// In saves handler (done in story 3.2.7, not this story)
+export const savesEventsHandler = wrapHandler(
+  createEventHistoryHandler({
+    entityType: "save",
+    entityExistsFn: async (userId, saveId) => {
+      const save = await getSave(client, userId, saveId, { includeSoftDeleted: true });
+      return save !== null;
+    },
+    client,
+  }),
+  { requireAuth: true }
+);
+```
+
+**Error codes** (from `@ai-learning-hub/types`): Use `ErrorCode.NOT_FOUND` for missing entities, `ErrorCode.VALIDATION_ERROR` for bad query params.
+
+**CDK table pattern** (`infra/lib/stacks/core/tables.stack.ts`): Follow the exact pattern used for the saves, projects, and other tables. Use `TableV2`, `Billing.payPerRequest()`, enable PITR, set removal policy to `RETAIN`.
+
+### Events vs EventBridge — Two Different Concepts
+
+The codebase has two distinct event systems:
+
+| System | Package | Purpose | Storage |
+|--------|---------|---------|---------|
+| EventBridge events | `@ai-learning-hub/events` | Real-time event routing to consumers (enrichment pipeline, search sync) | Transient (EventBridge + CloudWatch Logs) |
+| Event history (this story) | `@ai-learning-hub/db` | Per-entity queryable audit log for agents and debugging | DynamoDB with 90-day TTL |
+
+They are complementary. A `SaveCreated` EventBridge event triggers enrichment. A `SaveCreated` event history record lets an agent query "what happened to this save?" later.
+
+### Cursor Pagination Pattern
+
+Encode `LastEvaluatedKey` as opaque base64url cursor:
+
+```typescript
+function encodeCursor(lastEvaluatedKey: Record<string, any>): string {
+  return Buffer.from(JSON.stringify(lastEvaluatedKey)).toString("base64url");
+}
+
+function decodeCursor(cursor: string): Record<string, any> {
+  return JSON.parse(Buffer.from(cursor, "base64url").toString());
+}
+```
+
+This aligns with the cursor pagination pattern in story 3.2.5. If 3.2.5 lands first and establishes a shared cursor utility, use that instead. If this story lands first, place the cursor helpers in `@ai-learning-hub/db` so 3.2.5 can reuse them.
+
+### Response Format
+
+Until story 3.2.2 (error contract & response envelope) establishes the canonical envelope, use this shape:
+
+```typescript
+{
+  data: EntityEvent[],
+  meta: {
+    count: number,       // items in this page
+    nextCursor: string | null,
+    hasMore: boolean
+  }
+}
+```
+
+Adapt to the 3.2.2 envelope once it lands. This shape is intentionally compatible with the planned `{ data, meta: { cursor, total, rate_limit }, links: { self, next } }` envelope.
+
+### Response Examples
+
+**`recordEvent()` input (what the caller provides):**
+```json
+{
+  "entityType": "save",
+  "entityId": "01HX4Z3NDEKTSV4RRFFQ69G5FAV",
+  "userId": "user_2abc123",
+  "eventType": "SaveCreated",
+  "actorType": "human",
+  "actorId": null,
+  "changes": null,
+  "context": null,
+  "requestId": "req-550e8400-e29b"
+}
+```
+
+**Resulting DynamoDB item (auto-generated fields added):**
+```json
+{
+  "PK": "EVENTS#save#01HX4Z3NDEKTSV4RRFFQ69G5FAV",
+  "SK": "EVENT#2026-02-25T12:00:00.000Z#01HX5A7BEKTSV4RRFFQ69G5FBW",
+  "eventId": "01HX5A7BEKTSV4RRFFQ69G5FBW",
+  "entityType": "save",
+  "entityId": "01HX4Z3NDEKTSV4RRFFQ69G5FAV",
+  "userId": "user_2abc123",
+  "eventType": "SaveCreated",
+  "actorType": "human",
+  "actorId": null,
+  "changes": null,
+  "context": null,
+  "requestId": "req-550e8400-e29b",
+  "timestamp": "2026-02-25T12:00:00.000Z",
+  "ttl": 1748174400
+}
+```
+
+**`GET /saves/01HX4Z.../events` — success response (first page):**
+```json
+{
+  "data": [
+    {
+      "eventId": "01HX5A7BEKTSV4RRFFQ69G5FBW",
+      "entityType": "save",
+      "entityId": "01HX4Z3NDEKTSV4RRFFQ69G5FAV",
+      "eventType": "SaveUpdated",
+      "actorType": "agent",
+      "actorId": "claude-code-v1",
+      "timestamp": "2026-02-25T14:30:00.000Z",
+      "changes": { "before": { "title": "Old Title" }, "after": { "title": "New Title" } },
+      "context": { "trigger": "bulk-update", "source": "batch-endpoint" },
+      "requestId": "req-662f9511-c38a"
+    },
+    {
+      "eventId": "01HX4Z3NDEKTSV4RRFFQ69G5FAV",
+      "entityType": "save",
+      "entityId": "01HX4Z3NDEKTSV4RRFFQ69G5FAV",
+      "eventType": "SaveCreated",
+      "actorType": "human",
+      "actorId": null,
+      "timestamp": "2026-02-25T12:00:00.000Z",
+      "changes": null,
+      "context": null,
+      "requestId": "req-550e8400-e29b"
+    }
+  ],
+  "meta": {
+    "count": 2,
+    "nextCursor": null,
+    "hasMore": false
+  }
+}
+```
+
+**`GET /saves/01HX4Z.../events?since=2026-02-25T13:00:00Z&limit=10` — filtered response:**
+```json
+{
+  "data": [
+    {
+      "eventId": "01HX5A7BEKTSV4RRFFQ69G5FBW",
+      "eventType": "SaveUpdated",
+      "actorType": "agent",
+      "actorId": "claude-code-v1",
+      "timestamp": "2026-02-25T14:30:00.000Z",
+      "changes": { "before": { "title": "Old Title" }, "after": { "title": "New Title" } }
+    }
+  ],
+  "meta": { "count": 1, "nextCursor": null, "hasMore": false }
+}
+```
+
+**Error — entity not found (404):**
+```json
+{
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Save not found",
+    "requestId": "req-773a0622-d49c"
+  }
+}
+```
+
+**Error — invalid `since` parameter (400):**
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Invalid query parameter",
+    "requestId": "req-884b1733-e5ad",
+    "details": {
+      "fields": [{ "field": "since", "message": "Must be ISO 8601 format", "code": "invalid_string" }]
+    }
+  }
+}
+```
+
+### File Locations
+
+**New files:**
+
+| File | Package | Purpose |
+|------|---------|---------|
+| `backend/shared/types/src/entities/events.ts` | `@ai-learning-hub/types` | Event types and interfaces |
+| `backend/shared/db/src/operations/events.ts` | `@ai-learning-hub/db` | `recordEvent()`, `queryEntityEvents()` |
+| `backend/shared/db/test/operations/events.test.ts` | `@ai-learning-hub/db` | DB utility tests |
+| `backend/shared/middleware/src/handlers/event-history.ts` | `@ai-learning-hub/middleware` | `createEventHistoryHandler()` |
+| `backend/shared/middleware/test/handlers/event-history.test.ts` | `@ai-learning-hub/middleware` | Handler generator tests |
+
+**Modified files:**
+
+| File | Change |
+|------|--------|
+| `infra/lib/stacks/core/tables.stack.ts` | Add events table definition |
+| `infra/test/stacks/core/tables.test.ts` | Add events table assertions |
+| `backend/shared/types/src/index.ts` | Export event types |
+| `backend/shared/db/src/index.ts` | Export event operations |
+| `backend/shared/middleware/src/index.ts` | Export handler generator |
+
+### V2 Consideration: User-Scoped Event Query
+
+If "all events for a user" becomes a requirement, add `GSI: userId-timestamp-index` (PK: `userId`, SK: `timestamp`). Do not add preemptively — CloudWatch Logs Insights covers admin audit needs in V1. Every `recordEvent()` call logs at INFO level with structured fields including `actorId`, `entityType`, `entityId`, and `eventType`, making cross-entity queries like "what did agent X do?" a simple Logs Insights query.
+
+### Handler Generator Escape Hatch
+
+Domains can bypass `createEventHistoryHandler()` and call `queryEntityEvents()` directly for custom filtering needs (e.g., filter by `eventType`, include related entity events, combine events across linked entities). The generator handles the 80% case — entity-scoped history with since/limit/cursor. The utility layer (`recordEvent` + `queryEntityEvents`) is the real value; the handler generator is convenience.
+
+### Anti-Patterns to Avoid
+
+- **Do NOT store events in the saves or projects table.** Events get their own table for TTL isolation and cross-entity querying.
+- **Do NOT use DynamoDB Streams for event history.** Streams are for triggering downstream processing; this is a queryable audit log written explicitly by handlers.
+- **Do NOT wire event recording into existing handlers in this story.** That's 3.2.7/3.2.8 scope.
+- **Do NOT create a new shared package.** Event history utilities go in the existing `@ai-learning-hub/db` and `@ai-learning-hub/middleware` packages.
+- **Do NOT use `console.log`.** Use `@ai-learning-hub/logging` structured logger.
+- **Do NOT hardcode table names.** Use `requireEnv()` pattern with sensible dev defaults.
+- **Do NOT let `recordEvent()` failures propagate.** Event recording is fire-and-forget — catch errors, log WARN, and continue. The primary operation (save, update, delete) must succeed even if event recording fails.
+- **Do NOT record full entity state in `changes`.** Record only the changed fields as a minimal diff. Truncate to field names if the diff exceeds 10KB.
+- **Do NOT add GSIs for cross-entity queries** (by actorId, by eventType, etc.). Agent audit queries use CloudWatch Logs Insights on the structured logs emitted by `recordEvent()`. DynamoDB is for entity-scoped queries only.
+
+### Testing Strategy
+
+**Unit tests (Vitest):**
+- Mock DynamoDB client using existing mock patterns from `backend/shared/db/test/`
+- Test `recordEvent()`: validates required fields, generates ULID, calculates TTL correctly (90 days), constructs correct PK/SK, handles errors
+- Test `queryEntityEvents()`: queries correct PK, applies `since` filter, respects `limit` cap (200 max), handles cursor encoding/decoding, returns null cursor on last page
+- Test `createEventHistoryHandler()`: requires auth, validates entity exists, parses query params, returns 404 for missing entity, returns correct response shape
+
+**CDK assertion tests:**
+- Events table has correct PK/SK schema
+- TTL attribute is `ttl`
+- Billing mode is PAY_PER_REQUEST
+- PITR is enabled
+
+### Dependencies and Risks
+
+| Dependency | Status | Impact |
+|-----------|--------|--------|
+| 3.2.1 (Idempotency) | Not started | None — this story is independent |
+| 3.2.2 (Error contract) | Not started | Response envelope may change — use compatible shape |
+| 3.2.4 (Agent identity) | Not started | `actorType`/`actorId` fields are defined here but populated later |
+| 3.2.5 (Cursor pagination) | Not started | Cursor helpers may be shared — place in `@ai-learning-hub/db` |
+
+**Risk:** Stories 3.2.1-3.2.6 are all parallelizable shared infra. If 3.2.2 (error contract) or 3.2.5 (cursor pagination) land first, the event history handler should adopt their patterns. If this story lands first, the patterns established here should be reusable.
+
+**Batch event recording (3.2.9 consideration):** Story 3.2.9 (batch operations) processes up to 25 operations per request and may need to record multiple events. For now, callers can invoke `recordEvent()` per operation (fire-and-forget, so latency is acceptable). If batch event recording becomes a bottleneck, add a `recordEvents(client, events[], logger)` batch utility as a follow-up — but do NOT add it in this story (YAGNI).
+
+### Key Technical Decisions
+
+1. **Separate events table (not saves/projects table):** Cross-cutting concern used by ALL future domains. Own table with TTL keeps it clean, prevents entity CRUD interference, and allows 90-day retention without affecting entity data. Consistent with ADR-001 (multi-table design).
+2. **PK = `EVENTS#{entityType}#{entityId}` (no userId in PK):** The access pattern is "events for entity X", not "all events for user Y." userId is an attribute for authorization, not a partition key. This keeps queries fast (single partition) at the cost of no user-scoped event queries — acceptable because CloudWatch Logs Insights handles that need in V1.
+3. **ISO timestamp string in SK (not epoch number):** `new Date().toISOString()` always produces UTC zero-padded strings that sort lexicographically. Readable in DynamoDB console for debugging. The `recordEvent()` utility auto-generates timestamps — callers never provide them, guaranteeing sort correctness.
+4. **Fire-and-forget recording (not critical path):** Same pattern as EventBridge emission in saves handlers. Event recording failure must never block or fail the primary operation. Callers wrap in try/catch, log WARN, continue. This is acceptable because events are supplementary audit data, not transactional.
+5. **Minimal diff in `changes` (not full entity state):** Only changed fields are recorded, with a 10KB safety cap. Prevents approaching DynamoDB's 400KB item limit on large entities. Falls back to field names only (`{ changedFields: [...] }`) when the diff is too large.
+6. **Handler generator with escape hatch:** `createEventHistoryHandler()` covers the 80% case. Domains with custom filtering needs can call `queryEntityEvents()` directly. The utility layer is the value; the generator is convenience.
+7. **No GSIs — CloudWatch for cross-entity queries:** Agent audit ("what did agent X do?") uses CloudWatch Logs Insights on structured logs from `recordEvent()`. DynamoDB is entity-scoped only. No speculative GSIs.
+8. **Soft-deleted entities remain queryable:** `entityExistsFn` must return `true` for soft-deleted entities. Event history of deleted entities is the most valuable for debugging and reconciliation.
+
+### Git Intelligence
+
+Recent work (Epics 3 and 3.1) established patterns for:
+- Shared schema extraction to `@ai-learning-hub/*` packages (PR #194)
+- Shared test utilities in `backend/test-utils/` (PR #196)
+- Handler consolidation using shared middleware (PR #198)
+- EventBridge observability infrastructure — CDK rule + CloudWatch log group target (PR #216, Story 3.1.8) — this is the EventBridge side of event capture; the current story adds the DynamoDB queryable side
+- API key scope enforcement across endpoints (PR #204)
+- Fire-and-forget event emission pattern in saves handlers (PR #182, Story 3-1b)
+
+The fire-and-forget pattern from PR #182 is directly relevant — `recordEvent()` follows the same try/catch/warn/continue approach used for `emitEvent()` in the saves create handler.
+
+### Previous Story Intelligence
+
+Story 3.2.1 (Idempotency & Optimistic Concurrency) established:
+- Pattern for new DynamoDB tables as CDK stacks (idempotency table — PK string, TTL attribute, on-demand, PITR)
+- Pattern for extending `@ai-learning-hub/db` with new table configs and operation files
+- Pattern for extending `@ai-learning-hub/types` with new interfaces and enums
+- New error codes (`VERSION_CONFLICT`, `PRECONDITION_REQUIRED`, `IDEMPOTENCY_KEY_CONFLICT`) — follow same pattern for any event-specific error codes
+- Fail-open philosophy for non-critical infrastructure (idempotency fails open; event recording also fails open)
+
+Story 3.2.2 (Error Contract & Response Envelope) established:
+- `EnvelopeMeta` interface with `cursor`, `total`, `rateLimit` — the event history response `meta` should use this type once 3.2.2 lands
+- `ResponseEnvelope<T>` generic — event history response should be `ResponseEnvelope<EntityEvent[]>`
+- `createSuccessResponse` options object pattern — use this when building the handler generator response
+- `fields` key (not `errors`) for validation error details — use in `since` parameter validation
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/prd.md — FR102: Event History & Reconciliation]
+- [Source: _bmad-output/planning-artifacts/prd.md — NFR-AN4: Event history retention, 90 days, < 1s query]
+- [Source: _bmad-output/planning-artifacts/architecture.md — ADR-001: Multi-Table DynamoDB Design]
+- [Source: _bmad-output/planning-artifacts/architecture.md — ADR-008: Standardized Error Handling]
+- [Source: _bmad-output/planning-artifacts/architecture.md — ADR-015: Lambda Layers for Shared Code]
+- [Source: _bmad-output/planning-artifacts/epics.md — Epic 3.2, Story 3.2.3 description]
+- [Source: backend/shared/db/src/ — DB utility patterns (TableConfig, putItem, queryItems)]
+- [Source: backend/shared/middleware/src/ — Middleware patterns (wrapHandler, HandlerContext)]
+- [Source: backend/shared/types/src/ — Type patterns (ErrorCode, AppError, entity interfaces)]
+- [Source: backend/shared/events/src/ — EventBridge event patterns (complementary system)]
+- [Source: infra/lib/stacks/core/tables.stack.ts — CDK table definition patterns]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+{{agent_model_name_version}}
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -112,6 +112,19 @@ development_status:
   3-1-9-eventbridge-verification: ready-for-dev
   epic-3-1-retrospective: optional
 
+  # Epic 3.2: Agent-Native API Foundation (9 stories)
+  epic-3-2: in-progress
+  3-2-1-idempotency-concurrency-middleware: backlog
+  3-2-2-error-contract-response-envelope: backlog
+  3-2-3-event-history-infrastructure: ready-for-dev
+  3-2-4-agent-identity-context-rate-limit: backlog
+  3-2-5-cursor-based-pagination: backlog
+  3-2-6-scoped-api-key-permissions: backlog
+  3-2-7-saves-domain-retrofit: backlog
+  3-2-8-auth-domain-retrofit: backlog
+  3-2-9-health-readiness-batch: backlog
+  epic-3-2-retrospective: optional
+
   # Epic 4: Project Management (stories TBD)
   epic-4: backlog
   epic-4-retrospective: optional


### PR DESCRIPTION
## Summary

- Add three story files for Epic 3.2 (Agent-Native API Foundation): Idempotency & Optimistic Concurrency Middleware (3.2.1), Consistent Error Contract & Response Envelope (3.2.2), Event History Infrastructure (3.2.3)
- Register all 9 Epic 3.2 stories in sprint-status.yaml

Closes #219

## Changes

| File | Change |
|------|--------|
| `3-2-1-idempotency-optimistic-concurrency-middleware.md` | New story — 21 ACs, 6 key technical decisions, explicit scope boundaries |
| `3-2-2-consistent-error-contract-response-envelope.md` | New story — before/after JSON examples, migration plan for existing code, 7 key technical decisions |
| `3-2-3-event-history-infrastructure.md` | New story — 8 ACs with 31 named test scenarios, response examples, key technical decisions, git + previous story intelligence |
| `sprint-status.yaml` | Added Epic 3.2 block (9 stories, 3.2.3 = ready-for-dev, rest = backlog) |

## Testing

- [x] Story files follow BMAD template structure
- [x] Sprint status YAML is valid
- [x] Stories 3.2.1-3.2.3 cross-reference each other correctly
- [x] No code changes — docs only

## Checklist

- [x] Stories reference correct FRs/NFRs from PRD
- [x] Stories reference correct ADRs from architecture doc
- [x] File paths match existing codebase patterns
- [x] Acceptance criteria are specific and testable
- [x] Key technical decisions are numbered and justified
- [x] Anti-patterns section prevents common dev agent mistakes


Made with [Cursor](https://cursor.com)