### PR TITLE
feat: extract ApiDeploymentStack for cross-stack deployment fix

### DIFF
--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -12,6 +12,7 @@ import { ApiGatewayStack } from "../lib/stacks/api/api-gateway.stack";
 import { AuthRoutesStack } from "../lib/stacks/api/auth-routes.stack";
 import { EventsStack } from "../lib/stacks/core/events.stack";
 import { SavesRoutesStack } from "../lib/stacks/api/saves-routes.stack";
+import { ApiDeploymentStack } from "../lib/stacks/api/api-deployment.stack";
 
 const app = new cdk.App();
 
@@ -75,15 +76,13 @@ const rateLimitingStack = new RateLimitingStack(
 const apiGatewayStack = new ApiGatewayStack(app, "AiLearningHubApiGateway", {
   env: awsEnv,
   description:
-    "API Gateway REST API for ai-learning-hub (authorizers, CORS, WAF)",
+    "API Gateway REST API for ai-learning-hub (authorizers, CORS, gateway responses)",
   jwtAuthorizerFunctionArn: cdk.Fn.importValue(
     "AiLearningHub-JwtAuthorizerFunctionArn"
   ),
   apiKeyAuthorizerFunctionArn: cdk.Fn.importValue(
     "AiLearningHub-ApiKeyAuthorizerFunctionArn"
   ),
-  webAcl: rateLimitingStack.webAcl,
-  stageName,
 });
 apiGatewayStack.addDependency(rateLimitingStack);
 
@@ -131,6 +130,24 @@ savesRoutesStack.addDependency(apiGatewayStack);
 savesRoutesStack.addDependency(tablesStack);
 savesRoutesStack.addDependency(eventsStack);
 
+// API Deployment Stack -- Deployment + Stage + WAF (after all route stacks)
+// Solves the CDK cross-stack deployment problem: ensures the deployed stage
+// includes routes from ALL route stacks, not just the ApiGatewayStack scope.
+const apiDeploymentStack = new ApiDeploymentStack(
+  app,
+  "AiLearningHubApiDeployment",
+  {
+    env: awsEnv,
+    description:
+      "API Gateway deployment and stage for ai-learning-hub (Deployment, Stage, WAF)",
+    restApiId: apiGatewayStack.restApi.restApiId,
+    stageName,
+    webAcl: rateLimitingStack.webAcl,
+  }
+);
+apiDeploymentStack.addDependency(authRoutesStack);
+apiDeploymentStack.addDependency(savesRoutesStack);
+
 // Export stack instances for future cross-stack references (avoids unused variable lint errors)
 export {
   tablesStack,
@@ -142,6 +159,7 @@ export {
   authRoutesStack,
   eventsStack,
   savesRoutesStack,
+  apiDeploymentStack,
 };
 
 cdk.Tags.of(app).add("Project", "ai-learning-hub");

--- a/infra/lib/stacks/api/api-deployment.stack.ts
+++ b/infra/lib/stacks/api/api-deployment.stack.ts
@@ -1,0 +1,120 @@
+/**
+ * API Deployment Stack -- Deployment + Stage + WAF for the REST API
+ *
+ * Solves the CDK cross-stack deployment problem: routes are added by separate
+ * stacks (AuthRoutesStack, SavesRoutesStack) via fromRestApiAttributes(), but
+ * CDK's RestApi auto-deployment only hashes resources in its own construct scope.
+ * By managing the Deployment + Stage in a dedicated stack that depends on ALL
+ * route stacks, we guarantee every route is included in the deployed stage.
+ *
+ * Dependency chain:
+ *   ApiGatewayStack → AuthRoutesStack  ─┐
+ *                   → SavesRoutesStack ─┤→ ApiDeploymentStack
+ *
+ * Uses L1 constructs (CfnDeployment, CfnStage) for full control over
+ * deployment lifecycle without CDK's auto-hashing behavior.
+ */
+import * as cdk from "aws-cdk-lib";
+import * as apigateway from "aws-cdk-lib/aws-apigateway";
+import * as wafv2 from "aws-cdk-lib/aws-wafv2";
+import { NagSuppressions } from "cdk-nag";
+import { Construct } from "constructs";
+
+export interface ApiDeploymentStackProps extends cdk.StackProps {
+  /** REST API ID from ApiGatewayStack */
+  restApiId: string;
+  /** Deployment stage name (e.g., "dev", "staging", "prod"). Defaults to "dev". */
+  stageName?: string;
+  /** WAF WebACL (from RateLimitingStack) */
+  webAcl: wafv2.CfnWebACL;
+}
+
+export class ApiDeploymentStack extends cdk.Stack {
+  /** The deployment stage ARN — for cross-stack references */
+  public readonly stageArn: string;
+
+  constructor(scope: Construct, id: string, props: ApiDeploymentStackProps) {
+    super(scope, id, props);
+
+    const { restApiId, stageName = "dev", webAcl } = props;
+
+    // --- Deployment ---
+    // A new CfnDeployment is created on every synth because the Description
+    // includes a timestamp. CloudFormation treats Description changes as a
+    // resource replacement, which creates a fresh API Gateway deployment
+    // snapshot that includes all current routes.
+    const deployment = new apigateway.CfnDeployment(this, "Deployment", {
+      restApiId,
+      description: `Managed by ApiDeploymentStack — ${new Date().toISOString()}`,
+    });
+
+    // --- Stage ---
+    const stage = new apigateway.CfnStage(this, "Stage", {
+      restApiId,
+      deploymentId: deployment.ref,
+      stageName,
+      tracingEnabled: true,
+      methodSettings: [
+        {
+          httpMethod: "*",
+          resourcePath: "/*",
+          throttlingRateLimit: 100,
+          throttlingBurstLimit: 200,
+        },
+      ],
+    });
+
+    // Construct the stage ARN for WAF association
+    this.stageArn = cdk.Arn.format(
+      {
+        service: "apigateway",
+        resource: "/restapis",
+        resourceName: `${restApiId}/stages/${stageName}`,
+      },
+      this
+    );
+
+    // --- WAF Association (AC2) ---
+    new wafv2.CfnWebACLAssociation(this, "WebAclAssociation", {
+      resourceArn: this.stageArn,
+      webAclArn: webAcl.attrArn,
+    });
+
+    // --- CDK Nag Suppressions ---
+    NagSuppressions.addResourceSuppressions(
+      stage,
+      [
+        {
+          id: "AwsSolutions-APIG3",
+          reason:
+            "WAF is associated via CfnWebACLAssociation. CDK Nag does not detect CfnWebACLAssociation automatically.",
+        },
+        {
+          id: "AwsSolutions-APIG1",
+          reason:
+            "API Gateway access logging will be configured in observability stack enhancement",
+        },
+        {
+          id: "AwsSolutions-APIG6",
+          reason:
+            "CloudWatch logging for API Gateway stages will be configured when observability stack is enhanced",
+        },
+      ],
+      true
+    );
+
+    // --- Stack Outputs ---
+    const restApiUrl = `https://${restApiId}.execute-api.${this.region}.amazonaws.com/${stageName}/`;
+
+    new cdk.CfnOutput(this, "RestApiUrl", {
+      value: restApiUrl,
+      description: "REST API URL (deployed stage)",
+      exportName: "AiLearningHub-RestApiUrl",
+    });
+
+    new cdk.CfnOutput(this, "StageName", {
+      value: stageName,
+      description: "Deployed stage name",
+    });
+  }
+}

--- a/infra/lib/stacks/api/api-gateway.stack.ts
+++ b/infra/lib/stacks/api/api-gateway.stack.ts
@@ -1,9 +1,10 @@
 /**
- * API Gateway Stack -- REST API with shared authorizers, CORS, WAF, Gateway Responses
+ * API Gateway Stack -- REST API with shared authorizers, CORS, Gateway Responses
  *
- * Creates the central RestApi resource with authorizers, CORS config,
- * ADR-008 Gateway Responses, and WAF association. Does NOT create routes --
- * route stacks (e.g., AuthRoutesStack) consume restApi and authorizers via props.
+ * Creates the central RestApi resource with authorizers, CORS config, and
+ * ADR-008 Gateway Responses. Does NOT create routes or deployments --
+ * route stacks (e.g., AuthRoutesStack) consume restApi and authorizers via props,
+ * and ApiDeploymentStack manages the Deployment + Stage + WAF association.
  *
  * Extensibility (AC11): Future epics add routes by creating separate route stacks
  * and passing restApi + authorizers via props. The restApi, jwtAuthorizer, and
@@ -17,7 +18,7 @@
 import * as cdk from "aws-cdk-lib";
 import * as apigateway from "aws-cdk-lib/aws-apigateway";
 import * as lambda from "aws-cdk-lib/aws-lambda";
-import * as wafv2 from "aws-cdk-lib/aws-wafv2";
+// wafv2 import removed — WAF association moved to ApiDeploymentStack
 import { NagSuppressions } from "cdk-nag";
 import { Construct } from "constructs";
 
@@ -28,10 +29,7 @@ export interface ApiGatewayStackProps extends cdk.StackProps {
   /** API Key authorizer Lambda ARN (from AuthStack.apiKeyAuthorizerFunction.functionArn).
    *  Passed as string to avoid CDK cross-stack permission grants that create cycles. */
   apiKeyAuthorizerFunctionArn: string;
-  /** WAF WebACL (from RateLimitingStack) */
-  webAcl: wafv2.CfnWebACL;
-  /** API Gateway deployment stage name (e.g., "dev", "staging", "prod"). Defaults to "dev". */
-  stageName?: string;
+  // WAF WebACL and stageName moved to ApiDeploymentStack
 }
 
 export class ApiGatewayStack extends cdk.Stack {
@@ -45,12 +43,7 @@ export class ApiGatewayStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: ApiGatewayStackProps) {
     super(scope, id, props);
 
-    const {
-      jwtAuthorizerFunctionArn,
-      apiKeyAuthorizerFunctionArn,
-      webAcl,
-      stageName = "dev",
-    } = props;
+    const { jwtAuthorizerFunctionArn, apiKeyAuthorizerFunctionArn } = props;
 
     // Import authorizer Lambdas by ARN to avoid CDK cross-stack permission
     // grants. When real Lambda constructs are passed across stacks, CDK
@@ -69,15 +62,14 @@ export class ApiGatewayStack extends cdk.Stack {
     );
 
     // --- REST API (AC1) ---
+    // deploy: false — Deployment and Stage are managed by ApiDeploymentStack,
+    // which deploys AFTER all route stacks, ensuring every route is included.
+    // See: CDK cross-stack deployment issue — routes added via fromRestApiAttributes()
+    // in separate stacks are not visible to the RestApi's auto-deployment hash.
     this.restApi = new apigateway.RestApi(this, "RestApi", {
       restApiName: "ai-learning-hub-api",
       description: "AI Learning Hub REST API (Epic 2.1-D1)",
-      deployOptions: {
-        stageName,
-        throttlingRateLimit: 100,
-        throttlingBurstLimit: 200,
-        tracingEnabled: true,
-      },
+      deploy: false,
       defaultCorsPreflightOptions: {
         allowOrigins: apigateway.Cors.ALL_ORIGINS,
         allowMethods: apigateway.Cors.ALL_METHODS,
@@ -202,11 +194,7 @@ export class ApiGatewayStack extends cdk.Stack {
       sourceArn: this.apiKeyAuthorizer.authorizerArn,
     });
 
-    // --- WAF Association (AC2) ---
-    new wafv2.CfnWebACLAssociation(this, "WebAclAssociation", {
-      resourceArn: this.restApi.deploymentStage.stageArn,
-      webAclArn: webAcl.attrArn,
-    });
+    // WAF Association is managed by ApiDeploymentStack (owns the Stage).
 
     // --- CDK Nag Suppressions ---
     NagSuppressions.addResourceSuppressions(
@@ -231,17 +219,7 @@ export class ApiGatewayStack extends cdk.Stack {
       true
     );
 
-    NagSuppressions.addResourceSuppressions(
-      this.restApi.deploymentStage,
-      [
-        {
-          id: "AwsSolutions-APIG3",
-          reason:
-            "WAF is associated via CfnWebACLAssociation. CDK Nag does not detect CfnWebACLAssociation automatically.",
-        },
-      ],
-      true
-    );
+    // APIG3 suppression moved to ApiDeploymentStack (owns the Stage).
 
     NagSuppressions.addStackSuppressions(this, [
       {
@@ -261,10 +239,12 @@ export class ApiGatewayStack extends cdk.Stack {
       exportName: "AiLearningHub-RestApiId",
     });
 
-    new cdk.CfnOutput(this, "RestApiUrl", {
-      value: this.restApi.url,
-      description: "REST API URL (dev stage)",
-      exportName: "AiLearningHub-RestApiUrl",
+    // REST API URL output moved to ApiDeploymentStack (which owns the Stage).
+    // Export rootResourceId for route stacks.
+    new cdk.CfnOutput(this, "RestApiRootResourceId", {
+      value: this.restApi.restApiRootResourceId,
+      description: "REST API root resource ID",
+      exportName: "AiLearningHub-RestApiRootResourceId",
     });
   }
 }

--- a/infra/test/architecture-enforcement/api-gateway-contract.test.ts
+++ b/infra/test/architecture-enforcement/api-gateway-contract.test.ts
@@ -14,11 +14,13 @@ import { createTestApiStacks } from "../helpers/create-test-api-stacks";
 describe("T1: API Gateway Contract", () => {
   let apiGwTemplate: Template;
   let routesTemplate: Template;
+  let deploymentTemplate: Template;
 
   beforeAll(() => {
     const stacks = createTestApiStacks();
     apiGwTemplate = stacks.apiGwTemplate;
     routesTemplate = stacks.routesTemplate;
+    deploymentTemplate = stacks.deploymentTemplate;
   });
 
   describe("AC1: Every non-OPTIONS method has AuthorizationType != NONE", () => {
@@ -161,14 +163,16 @@ describe("T1: API Gateway Contract", () => {
   });
 
   describe("AC4: WAF WebACL Association", () => {
-    it("has a CfnWebACLAssociation linking WAF to the RestApi stage", () => {
-      const associations = apiGwTemplate.findResources(
+    it("has a CfnWebACLAssociation linking WAF to the RestApi stage (in ApiDeploymentStack)", () => {
+      // WAF association is managed by ApiDeploymentStack (owns the Stage),
+      // not ApiGatewayStack (which only creates the RestApi + authorizers).
+      const associations = deploymentTemplate.findResources(
         "AWS::WAFv2::WebACLAssociation"
       );
 
       expect(
         Object.keys(associations).length,
-        "Expected exactly 1 WebACLAssociation"
+        "Expected exactly 1 WebACLAssociation in ApiDeploymentStack"
       ).toBe(1);
     });
   });

--- a/infra/test/architecture-enforcement/handler-miswiring-detection.test.ts
+++ b/infra/test/architecture-enforcement/handler-miswiring-detection.test.ts
@@ -11,7 +11,6 @@
 import { describe, it, expect } from "vitest";
 import { App, Stack } from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
-import * as wafv2 from "aws-cdk-lib/aws-wafv2";
 import { Template } from "aws-cdk-lib/assertions";
 import { ApiGatewayStack } from "../../lib/stacks/api/api-gateway.stack";
 import { AuthRoutesStack } from "../../lib/stacks/api/auth-routes.stack";
@@ -28,16 +27,6 @@ describe("Miswiring Detection", () => {
     const awsEnv = getAwsEnv();
     const depsStack = new Stack(app, "MiswiringDeps", { env: awsEnv });
 
-    const webAcl = new wafv2.CfnWebACL(depsStack, "TestWebAcl", {
-      scope: "REGIONAL",
-      defaultAction: { allow: {} },
-      visibilityConfig: {
-        cloudWatchMetricsEnabled: true,
-        metricName: "MiswiringMetric",
-        sampledRequestsEnabled: true,
-      },
-    });
-
     const testAccount = awsEnv.account ?? `${"123456"}789012`;
     const testRegion = awsEnv.region ?? "us-east-2";
     const makeArn = (name: string) =>
@@ -49,7 +38,6 @@ describe("Miswiring Detection", () => {
       env: awsEnv,
       jwtAuthorizerFunctionArn: makeArn("JwtAuthFn"),
       apiKeyAuthorizerFunctionArn: makeArn("ApiKeyAuthFn"),
-      webAcl,
     });
 
     // INTENTIONAL MISWIRING: swap usersMeFunction and apiKeysFunction

--- a/infra/test/helpers/create-test-api-stacks.ts
+++ b/infra/test/helpers/create-test-api-stacks.ts
@@ -14,9 +14,11 @@ import * as events from "aws-cdk-lib/aws-events";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as wafv2 from "aws-cdk-lib/aws-wafv2";
 import { Template } from "aws-cdk-lib/assertions";
+
 import { ApiGatewayStack } from "../../lib/stacks/api/api-gateway.stack";
 import { AuthRoutesStack } from "../../lib/stacks/api/auth-routes.stack";
 import { SavesRoutesStack } from "../../lib/stacks/api/saves-routes.stack";
+import { ApiDeploymentStack } from "../../lib/stacks/api/api-deployment.stack";
 import { getAwsEnv } from "../../config/aws-env";
 
 /**
@@ -99,9 +101,11 @@ export interface TestApiStacks {
   apiGatewayStack: ApiGatewayStack;
   authRoutesStack: AuthRoutesStack;
   savesRoutesStack: SavesRoutesStack;
+  apiDeploymentStack: ApiDeploymentStack;
   apiGwTemplate: Template;
   routesTemplate: Template;
   savesRoutesTemplate: Template;
+  deploymentTemplate: Template;
   /** All route templates combined for searching across all route stacks */
   allRouteTemplates: Template[];
 }
@@ -130,16 +134,6 @@ export function createTestApiStacks(): TestApiStacks {
 
   const depsStack = new Stack(app, "ArchTestDeps", { env: awsEnv });
 
-  const webAcl = new wafv2.CfnWebACL(depsStack, "TestWebAcl", {
-    scope: "REGIONAL",
-    defaultAction: { allow: {} },
-    visibilityConfig: {
-      cloudWatchMetricsEnabled: true,
-      metricName: "ArchTestMetric",
-      sampledRequestsEnabled: true,
-    },
-  });
-
   // Use env or synthesize a dummy account (split to avoid secrets-scan false positive)
   const testAccount = awsEnv.account ?? `${"123456"}789012`;
   const testRegion = awsEnv.region ?? "us-east-2";
@@ -152,7 +146,6 @@ export function createTestApiStacks(): TestApiStacks {
     env: awsEnv,
     jwtAuthorizerFunctionArn: makeArn("JwtAuthFn"),
     apiKeyAuthorizerFunctionArn: makeArn("ApiKeyAuthFn"),
-    webAcl,
   });
 
   const authRoutesStack = new AuthRoutesStack(app, "ArchTestAuthRoutes", {
@@ -196,18 +189,43 @@ export function createTestApiStacks(): TestApiStacks {
     eventBus,
   });
 
+  // WAF WebACL for ApiDeploymentStack
+  const webAcl = new wafv2.CfnWebACL(depsStack, "TestWebAcl", {
+    scope: "REGIONAL",
+    defaultAction: { allow: {} },
+    visibilityConfig: {
+      cloudWatchMetricsEnabled: true,
+      metricName: "ArchTestMetric",
+      sampledRequestsEnabled: true,
+    },
+  });
+
+  const apiDeploymentStack = new ApiDeploymentStack(
+    app,
+    "ArchTestApiDeployment",
+    {
+      env: awsEnv,
+      restApiId: apiGatewayStack.restApi.restApiId,
+      stageName: "dev",
+      webAcl,
+    }
+  );
+
   const apiGwTemplate = Template.fromStack(apiGatewayStack);
   const routesTemplate = Template.fromStack(authRoutesStack);
   const savesRoutesTemplate = Template.fromStack(savesRoutesStack);
+  const deploymentTemplate = Template.fromStack(apiDeploymentStack);
 
   const result: TestApiStacks = {
     app,
     apiGatewayStack,
     authRoutesStack,
     savesRoutesStack,
+    apiDeploymentStack,
     apiGwTemplate,
     routesTemplate,
     savesRoutesTemplate,
+    deploymentTemplate,
     allRouteTemplates: [routesTemplate, savesRoutesTemplate],
   };
 

--- a/infra/test/stacks/api/api-deployment.stack.test.ts
+++ b/infra/test/stacks/api/api-deployment.stack.test.ts
@@ -1,0 +1,112 @@
+/**
+ * ApiDeploymentStack Tests
+ *
+ * Tests the dedicated Deployment + Stage + WAF stack that solves the CDK
+ * cross-stack deployment problem. Validates that Stage, Deployment, throttling,
+ * tracing, WAF association, and outputs are correctly configured.
+ */
+import { App, Stack } from "aws-cdk-lib";
+import * as wafv2 from "aws-cdk-lib/aws-wafv2";
+import { Template, Match } from "aws-cdk-lib/assertions";
+import { describe, it, beforeAll } from "vitest";
+import { ApiDeploymentStack } from "../../../lib/stacks/api/api-deployment.stack";
+import { getAwsEnv } from "../../../config/aws-env";
+
+describe("ApiDeploymentStack", () => {
+  let template: Template;
+
+  beforeAll(() => {
+    const app = new App();
+    const awsEnv = getAwsEnv();
+
+    const depsStack = new Stack(app, "DeployTestDeps", { env: awsEnv });
+
+    const webAcl = new wafv2.CfnWebACL(depsStack, "TestWebAcl", {
+      scope: "REGIONAL",
+      defaultAction: { allow: {} },
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: true,
+        metricName: "TestMetric",
+        sampledRequestsEnabled: true,
+      },
+    });
+
+    const deploymentStack = new ApiDeploymentStack(
+      app,
+      "TestApiDeploymentStack",
+      {
+        env: awsEnv,
+        restApiId: "test-api-id",
+        stageName: "dev",
+        webAcl,
+      }
+    );
+
+    template = Template.fromStack(deploymentStack);
+  });
+
+  describe("Deployment", () => {
+    it("creates an API Gateway Deployment", () => {
+      template.resourceCountIs("AWS::ApiGateway::Deployment", 1);
+    });
+
+    it("Deployment references the correct REST API", () => {
+      template.hasResourceProperties("AWS::ApiGateway::Deployment", {
+        RestApiId: "test-api-id",
+      });
+    });
+
+    it("Deployment has a timestamp in Description to force new deployments", () => {
+      template.hasResourceProperties("AWS::ApiGateway::Deployment", {
+        Description: Match.stringLikeRegexp("Managed by ApiDeploymentStack"),
+      });
+    });
+  });
+
+  describe("Stage", () => {
+    it("creates an API Gateway Stage", () => {
+      template.resourceCountIs("AWS::ApiGateway::Stage", 1);
+    });
+
+    it("Stage has correct name", () => {
+      template.hasResourceProperties("AWS::ApiGateway::Stage", {
+        StageName: "dev",
+      });
+    });
+
+    it("configures stage throttling (100 req/s, burst 200)", () => {
+      template.hasResourceProperties("AWS::ApiGateway::Stage", {
+        MethodSettings: Match.arrayWith([
+          Match.objectLike({
+            ThrottlingRateLimit: 100,
+            ThrottlingBurstLimit: 200,
+          }),
+        ]),
+      });
+    });
+
+    it("enables X-Ray tracing on the stage", () => {
+      template.hasResourceProperties("AWS::ApiGateway::Stage", {
+        TracingEnabled: true,
+      });
+    });
+  });
+
+  describe("WAF Association", () => {
+    it("creates a WAF WebACL association", () => {
+      template.resourceCountIs("AWS::WAFv2::WebACLAssociation", 1);
+    });
+  });
+
+  describe("Stack Outputs", () => {
+    it("exports REST API URL", () => {
+      template.hasOutput("RestApiUrl", {
+        Export: { Name: "AiLearningHub-RestApiUrl" },
+      });
+    });
+
+    it("outputs the stage name", () => {
+      template.hasOutput("StageName", {});
+    });
+  });
+});

--- a/infra/test/stacks/api/api-gateway.stack.test.ts
+++ b/infra/test/stacks/api/api-gateway.stack.test.ts
@@ -2,7 +2,10 @@
  * ApiGatewayStack Tests (AC1-AC6, AC12)
  *
  * Tests the shared REST API infrastructure: RestApi, CORS, Gateway Responses,
- * WAF association, authorizers, and stack outputs.
+ * authorizers, and stack outputs.
+ *
+ * Stage, Deployment, and WAF association are tested in api-deployment.stack.test.ts
+ * (managed by ApiDeploymentStack).
  *
  * Since CDK authorizers must be attached to at least one method to synthesize,
  * this test also creates an AuthRoutesStack to consume the authorizers.
@@ -10,7 +13,6 @@
  */
 import { App, Stack } from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
-import * as wafv2 from "aws-cdk-lib/aws-wafv2";
 import { Template, Match } from "aws-cdk-lib/assertions";
 import { describe, it, expect, beforeAll } from "vitest";
 import { ApiGatewayStack } from "../../../lib/stacks/api/api-gateway.stack";
@@ -26,16 +28,6 @@ describe("ApiGatewayStack", () => {
 
     const depsStack = new Stack(app, "TestDepsStack", { env: awsEnv });
 
-    const webAcl = new wafv2.CfnWebACL(depsStack, "TestWebAcl", {
-      scope: "REGIONAL",
-      defaultAction: { allow: {} },
-      visibilityConfig: {
-        cloudWatchMetricsEnabled: true,
-        metricName: "TestMetric",
-        sampledRequestsEnabled: true,
-      },
-    });
-
     const testAccount = awsEnv.account ?? "123456789012";
     const testRegion = awsEnv.region ?? "us-east-2";
     const makeArn = (name: string) =>
@@ -43,12 +35,12 @@ describe("ApiGatewayStack", () => {
     const importFn = (stack: Stack, name: string) =>
       lambda.Function.fromFunctionArn(stack, name, makeArn(name));
 
-    // ApiGatewayStack now accepts ARN strings, matching the real app.ts pattern.
+    // ApiGatewayStack accepts ARN strings, matching the real app.ts pattern.
+    // Stage, Deployment, and WAF are managed by ApiDeploymentStack.
     const apiGatewayStack = new ApiGatewayStack(app, "TestApiGatewayStack", {
       env: awsEnv,
       jwtAuthorizerFunctionArn: makeArn("JwtAuthFn"),
       apiKeyAuthorizerFunctionArn: makeArn("ApiKeyAuthFn"),
-      webAcl,
     });
 
     // CDK authorizers must be attached to at least one method to synthesize.
@@ -79,33 +71,9 @@ describe("ApiGatewayStack", () => {
       });
     });
 
-    it("creates a stage deployment with dev stage", () => {
-      template.hasResourceProperties("AWS::ApiGateway::Stage", {
-        StageName: "dev",
-      });
-    });
-
-    it("configures stage throttling (100 req/s, burst 200)", () => {
-      template.hasResourceProperties("AWS::ApiGateway::Stage", {
-        MethodSettings: Match.arrayWith([
-          Match.objectLike({
-            ThrottlingRateLimit: 100,
-            ThrottlingBurstLimit: 200,
-          }),
-        ]),
-      });
-    });
-
-    it("enables X-Ray tracing on the stage", () => {
-      template.hasResourceProperties("AWS::ApiGateway::Stage", {
-        TracingEnabled: true,
-      });
-    });
-  });
-
-  describe("WAF Association (AC2)", () => {
-    it("creates a WAF WebACL association", () => {
-      template.resourceCountIs("AWS::WAFv2::WebACLAssociation", 1);
+    it("does NOT create a Stage or Deployment (managed by ApiDeploymentStack)", () => {
+      template.resourceCountIs("AWS::ApiGateway::Stage", 0);
+      template.resourceCountIs("AWS::ApiGateway::Deployment", 0);
     });
   });
 
@@ -307,9 +275,9 @@ describe("ApiGatewayStack", () => {
       });
     });
 
-    it("exports REST API URL", () => {
-      template.hasOutput("RestApiUrl", {
-        Export: { Name: "AiLearningHub-RestApiUrl" },
+    it("exports REST API root resource ID", () => {
+      template.hasOutput("RestApiRootResourceId", {
+        Export: { Name: "AiLearningHub-RestApiRootResourceId" },
       });
     });
   });

--- a/infra/test/stacks/api/auth-routes.stack.test.ts
+++ b/infra/test/stacks/api/auth-routes.stack.test.ts
@@ -7,7 +7,6 @@
  */
 import { App, Stack } from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
-import * as wafv2 from "aws-cdk-lib/aws-wafv2";
 import { Template } from "aws-cdk-lib/assertions";
 import { describe, it, expect, beforeAll } from "vitest";
 import { ApiGatewayStack } from "../../../lib/stacks/api/api-gateway.stack";
@@ -26,16 +25,6 @@ describe("AuthRoutesStack", () => {
 
     const depsStack = new Stack(app, "TestDepsStack", { env: awsEnv });
 
-    const webAcl = new wafv2.CfnWebACL(depsStack, "TestWebAcl", {
-      scope: "REGIONAL",
-      defaultAction: { allow: {} },
-      visibilityConfig: {
-        cloudWatchMetricsEnabled: true,
-        metricName: "TestMetric",
-        sampledRequestsEnabled: true,
-      },
-    });
-
     const testAccount = awsEnv.account ?? "123456789012";
     const testRegion = awsEnv.region ?? "us-east-2";
     const makeArn = (name: string) =>
@@ -47,7 +36,6 @@ describe("AuthRoutesStack", () => {
       env: awsEnv,
       jwtAuthorizerFunctionArn: makeArn("JwtAuthFn"),
       apiKeyAuthorizerFunctionArn: makeArn("ApiKeyAuthFn"),
-      webAcl,
     });
 
     const authRoutesStack = new AuthRoutesStack(app, "TestAuthRoutesStack", {

--- a/infra/test/stacks/api/cross-stack-deps.test.ts
+++ b/infra/test/stacks/api/cross-stack-deps.test.ts
@@ -9,7 +9,6 @@
  */
 import { App, Stack } from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
-import * as wafv2 from "aws-cdk-lib/aws-wafv2";
 import { Template } from "aws-cdk-lib/assertions";
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
@@ -31,16 +30,6 @@ describe("T7: Cross-Stack Dependency Validation", () => {
 
       const depsStack = new Stack(app, "SynthTestDepsStack", { env: awsEnv });
 
-      const webAcl = new wafv2.CfnWebACL(depsStack, "TestWebAcl", {
-        scope: "REGIONAL",
-        defaultAction: { allow: {} },
-        visibilityConfig: {
-          cloudWatchMetricsEnabled: true,
-          metricName: "TestMetric",
-          sampledRequestsEnabled: true,
-        },
-      });
-
       const testAccount = awsEnv.account ?? "123456789012";
       const testRegion = awsEnv.region ?? "us-east-2";
       const makeArn = (name: string) =>
@@ -55,7 +44,6 @@ describe("T7: Cross-Stack Dependency Validation", () => {
           env: awsEnv,
           jwtAuthorizerFunctionArn: makeArn("JwtAuthFn"),
           apiKeyAuthorizerFunctionArn: makeArn("ApiKeyAuthFn"),
-          webAcl,
         }
       );
 
@@ -90,20 +78,10 @@ describe("T7: Cross-Stack Dependency Validation", () => {
       ).toBeGreaterThanOrEqual(7);
     });
 
-    it("ApiGatewayStack template exports RestApiId and RestApiUrl", () => {
+    it("ApiGatewayStack template exports RestApiId and RestApiRootResourceId", () => {
       const app = new App();
       const awsEnv = getAwsEnv();
       const depsStack = new Stack(app, "OutputTestDeps", { env: awsEnv });
-
-      const webAcl = new wafv2.CfnWebACL(depsStack, "TestWebAcl", {
-        scope: "REGIONAL",
-        defaultAction: { allow: {} },
-        visibilityConfig: {
-          cloudWatchMetricsEnabled: true,
-          metricName: "TestMetric",
-          sampledRequestsEnabled: true,
-        },
-      });
 
       const testAccount = awsEnv.account ?? "123456789012";
       const testRegion = awsEnv.region ?? "us-east-2";
@@ -116,7 +94,6 @@ describe("T7: Cross-Stack Dependency Validation", () => {
         env: awsEnv,
         jwtAuthorizerFunctionArn: makeArn("JwtAuthFn"),
         apiKeyAuthorizerFunctionArn: makeArn("ApiKeyAuthFn"),
-        webAcl,
       });
 
       // Create routes stack so authorizers are consumed (required for synth)
@@ -136,20 +113,22 @@ describe("T7: Cross-Stack Dependency Validation", () => {
       template.hasOutput("RestApiId", {
         Export: { Name: "AiLearningHub-RestApiId" },
       });
-      template.hasOutput("RestApiUrl", {
-        Export: { Name: "AiLearningHub-RestApiUrl" },
+      template.hasOutput("RestApiRootResourceId", {
+        Export: { Name: "AiLearningHub-RestApiRootResourceId" },
       });
     });
   });
 
   describe("Stack instantiation order (source-text supplementary)", () => {
-    it("instantiates stacks in correct ADR-006 order: Core -> Auth -> API -> AuthRoutes", () => {
+    it("instantiates stacks in correct order: Core -> Auth -> API -> Routes -> Deployment", () => {
       const tablesPos = appSource.indexOf("new TablesStack");
       const bucketsPos = appSource.indexOf("new BucketsStack");
       const authPos = appSource.indexOf("new AuthStack");
       const rateLimitPos = appSource.indexOf("new RateLimitingStack");
       const apiGatewayPos = appSource.indexOf("new ApiGatewayStack");
       const authRoutesPos = appSource.indexOf("new AuthRoutesStack");
+      const savesRoutesPos = appSource.indexOf("new SavesRoutesStack");
+      const apiDeploymentPos = appSource.indexOf("new ApiDeploymentStack");
       const observabilityPos = appSource.indexOf("new ObservabilityStack");
 
       // All stacks must exist
@@ -159,6 +138,8 @@ describe("T7: Cross-Stack Dependency Validation", () => {
       expect(rateLimitPos).toBeGreaterThan(-1);
       expect(apiGatewayPos).toBeGreaterThan(-1);
       expect(authRoutesPos).toBeGreaterThan(-1);
+      expect(savesRoutesPos).toBeGreaterThan(-1);
+      expect(apiDeploymentPos).toBeGreaterThan(-1);
       expect(observabilityPos).toBeGreaterThan(-1);
 
       // Core stacks before Auth
@@ -169,6 +150,10 @@ describe("T7: Cross-Stack Dependency Validation", () => {
 
       // API Gateway before Auth Routes
       expect(apiGatewayPos).toBeLessThan(authRoutesPos);
+
+      // Route stacks before Deployment
+      expect(authRoutesPos).toBeLessThan(apiDeploymentPos);
+      expect(savesRoutesPos).toBeLessThan(apiDeploymentPos);
     });
   });
 
@@ -200,6 +185,18 @@ describe("T7: Cross-Stack Dependency Validation", () => {
     it("authRoutesStack depends on authStack", () => {
       expect(appSource).toContain("authRoutesStack.addDependency(authStack)");
     });
+
+    it("apiDeploymentStack depends on authRoutesStack", () => {
+      expect(appSource).toContain(
+        "apiDeploymentStack.addDependency(authRoutesStack)"
+      );
+    });
+
+    it("apiDeploymentStack depends on savesRoutesStack", () => {
+      expect(appSource).toContain(
+        "apiDeploymentStack.addDependency(savesRoutesStack)"
+      );
+    });
   });
 
   describe("No circular dependencies", () => {
@@ -213,6 +210,12 @@ describe("T7: Cross-Stack Dependency Validation", () => {
       );
       expect(appSource).not.toContain(
         "apiGatewayStack.addDependency(authRoutesStack)"
+      );
+      expect(appSource).not.toContain(
+        "authRoutesStack.addDependency(apiDeploymentStack)"
+      );
+      expect(appSource).not.toContain(
+        "savesRoutesStack.addDependency(apiDeploymentStack)"
       );
     });
   });
@@ -231,7 +234,7 @@ describe("T7: Cross-Stack Dependency Validation", () => {
       );
     });
 
-    it("ApiGatewayStack receives WAF WebACL from RateLimitingStack via props", () => {
+    it("ApiDeploymentStack receives WAF WebACL from RateLimitingStack via props", () => {
       expect(appSource).toContain("webAcl: rateLimitingStack.webAcl");
     });
 
@@ -296,7 +299,16 @@ describe("T7: Cross-Stack Dependency Validation", () => {
       );
       expect(apiGatewaySource).toContain("CfnOutput");
       expect(apiGatewaySource).toContain("AiLearningHub-RestApiId");
-      expect(apiGatewaySource).toContain("AiLearningHub-RestApiUrl");
+      expect(apiGatewaySource).toContain("AiLearningHub-RestApiRootResourceId");
+    });
+
+    it("ApiDeploymentStack exports REST API URL via CfnOutput", () => {
+      const deploymentSource = readFileSync(
+        join(__dirname, "../../../lib/stacks/api/api-deployment.stack.ts"),
+        "utf-8"
+      );
+      expect(deploymentSource).toContain("CfnOutput");
+      expect(deploymentSource).toContain("AiLearningHub-RestApiUrl");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Extracts Deployment, Stage, and WAF association from `ApiGatewayStack` into a new `ApiDeploymentStack` to solve the CDK cross-stack deployment problem
- Routes added by separate stacks (`AuthRoutesStack`, `SavesRoutesStack`) via `fromRestApiAttributes()` were not included in the RestApi's auto-deployment hash — this fix ensures the deployed stage includes all routes
- Uses L1 `CfnDeployment`/`CfnStage` constructs for full control over deployment lifecycle

## Changes
- **New**: `infra/lib/stacks/api/api-deployment.stack.ts` — Deployment + Stage + WAF stack
- **New**: `infra/test/stacks/api/api-deployment.stack.test.ts` — Tests for the new stack
- **Modified**: `infra/lib/stacks/api/api-gateway.stack.ts` — Removed Stage/Deployment/WAF, set `deploy: false`
- **Modified**: `infra/bin/app.ts` — Added `ApiDeploymentStack` with dependencies on all route stacks
- **Modified**: 6 test files — Removed stale `webAcl` props, updated WAF assertion to check `ApiDeploymentStack`, added deployment stack to test helper

## Test plan
- [x] TypeScript compilation passes (`npx tsc --noEmit` — 0 errors)
- [x] All 577 tests pass across 21 test files
- [x] Architecture enforcement tests updated (WAF assertion now checks `ApiDeploymentStack`)
- [x] Cross-stack dependency tests updated (new stack order + dependency assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)