### PR TITLE
fix: WAF DependsOn stage + CloudWatch filter syntax

### DIFF
--- a/infra/lib/stacks/api/api-deployment.stack.ts
+++ b/infra/lib/stacks/api/api-deployment.stack.ts
@@ -64,7 +64,7 @@ export class ApiDeploymentStack extends cdk.Stack {
       ],
     });
 
-    // Construct the stage ARN for WAF association
+    // Construct the stage ARN for WAF association and cross-stack references.
     this.stageArn = cdk.Arn.format(
       {
         service: "apigateway",
@@ -75,10 +75,17 @@ export class ApiDeploymentStack extends cdk.Stack {
     );
 
     // --- WAF Association (AC2) ---
-    new wafv2.CfnWebACLAssociation(this, "WebAclAssociation", {
-      resourceArn: this.stageArn,
-      webAclArn: webAcl.attrArn,
-    });
+    const wafAssociation = new wafv2.CfnWebACLAssociation(
+      this,
+      "WebAclAssociation",
+      {
+        resourceArn: this.stageArn,
+        webAclArn: webAcl.attrArn,
+      }
+    );
+    // Explicit DependsOn: WAF association requires the stage to exist.
+    // CloudFormation can't infer this from the string-based stageArn.
+    wafAssociation.addDependency(stage);
 
     // --- CDK Nag Suppressions ---
     NagSuppressions.addResourceSuppressions(

--- a/scripts/smoke-test/cloudwatch-helpers.ts
+++ b/scripts/smoke-test/cloudwatch-helpers.ts
@@ -54,7 +54,10 @@ export async function waitForLogEvent(
     await import("@aws-sdk/client-cloudwatch-logs");
 
   const cwlClient = new CloudWatchLogsClient({});
-  const filterPattern = `{ $.detail.saveId = "${saveId}" && $["detail-type"] = "${detailType}" }`;
+  // CloudWatch Logs filter patterns do not support bracket notation for
+  // hyphenated keys like "detail-type". Filter by saveId only, then match
+  // detail-type in application code after parsing.
+  const filterPattern = `{ $.detail.saveId = "${saveId}" }`;
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     if (attempt > 1) {
@@ -81,28 +84,25 @@ export async function waitForLogEvent(
     }
 
     const events = result.events ?? [];
-    if (events.length > 0) {
-      // Parse the first matching log event
-      const message = events[0].message;
-      if (!message) {
-        throw new Error(
-          `CloudWatch log event has no message field (attempt ${attempt})`
-        );
-      }
+    // Find the event matching the requested detail-type
+    for (const logEvent of events) {
+      const message = logEvent.message;
+      if (!message) continue;
 
       let parsed;
       try {
         parsed = JSON.parse(message);
       } catch {
-        throw new Error(
-          `Failed to parse CloudWatch log event as JSON (attempt ${attempt}): ${message.slice(0, 200)}`
-        );
+        continue;
       }
-      return {
-        detailType: parsed["detail-type"],
-        source: parsed.source,
-        detail: parsed.detail,
-      };
+
+      if (parsed["detail-type"] === detailType) {
+        return {
+          detailType: parsed["detail-type"],
+          source: parsed.source,
+          detail: parsed.detail,
+        };
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Add explicit `DependsOn` from WAF `CfnWebACLAssociation` to `CfnStage` in `ApiDeploymentStack` — CloudFormation can't infer the dependency from a string-constructed ARN, causing parallel creation and WAF "resource doesn't exist" errors
- Fix CloudWatch Logs filter pattern in smoke test EB scenarios — bracket notation (`$["detail-type"]`) is unsupported; now filters by `saveId` only and matches `detail-type` in application code

## Test plan
- [x] All 577 unit tests pass
- [x] `cdk synth` output confirms `DependsOn: [Stage]` on `WebAclAssociation`
- [x] `ApiDeploymentStack` deployed successfully (Deployment → Stage → WAF in correct order)
- [x] Smoke tests: 24/29 pass (2 optional skips, 3 EB failures from pre-existing fire-and-forget event emission)

🤖 Generated with [Claude Code](https://claude.com/claude-code)