### PR TITLE
feat: Scoped API Key Permissions (Story 3.2.6)

### DIFF
--- a/backend/functions/api-keys/handler.test.ts
+++ b/backend/functions/api-keys/handler.test.ts
@@ -89,12 +89,12 @@ describe("API Keys Handler", () => {
       expect(body.data.createdAt).toBeDefined();
     });
 
-    it("calls createApiKey with correct arguments", async () => {
+    it("calls createApiKey with correct arguments (AC12: * normalized to full)", async () => {
       mockCreateApiKey.mockResolvedValueOnce({
         id: "key_01",
         name: "Test",
         key: "test-key",
-        scopes: ["*"],
+        scopes: ["full"],
         createdAt: "2026-02-16T12:00:00Z",
       });
 
@@ -109,7 +109,7 @@ describe("API Keys Handler", () => {
         expect.anything(),
         "user_abc",
         "Test",
-        ["*"],
+        ["full"],
         expect.anything()
       );
     });

--- a/backend/shared/middleware/src/auth.ts
+++ b/backend/shared/middleware/src/auth.ts
@@ -3,7 +3,14 @@
  * Full implementation will come in Epic 2 (Authentication)
  */
 import type { APIGatewayProxyEvent } from "aws-lambda";
-import { AppError, ErrorCode, type AuthContext } from "@ai-learning-hub/types";
+import {
+  AppError,
+  ErrorCode,
+  type AuthContext,
+  type ApiKeyScope,
+} from "@ai-learning-hub/types";
+import type { OperationScope } from "@ai-learning-hub/types";
+import { checkScopeAccess, VALID_SCOPES } from "./scope-resolver.js";
 
 /**
  * Extract auth context from API Gateway event
@@ -36,13 +43,16 @@ export function extractAuthContext(
     }
 
     const rawScopes = authorizerContext.scopes;
-    let scopes: string[] | undefined;
+    let scopes: ApiKeyScope[] | undefined;
     if (Array.isArray(rawScopes)) {
-      scopes = rawScopes;
+      // Runtime-validate: drop unrecognized scopes to prevent privilege escalation
+      scopes = rawScopes.filter((s) => VALID_SCOPES.has(s)) as ApiKeyScope[];
     } else if (typeof rawScopes === "string") {
       try {
         const parsed = JSON.parse(rawScopes);
-        scopes = Array.isArray(parsed) ? parsed : undefined;
+        scopes = Array.isArray(parsed)
+          ? (parsed.filter((s: string) => VALID_SCOPES.has(s)) as ApiKeyScope[])
+          : undefined;
       } catch {
         scopes = undefined;
       }
@@ -106,25 +116,27 @@ export function requireRole(auth: AuthContext, requiredRoles: string[]): void {
 }
 
 /**
- * Require specific API key scope
+ * Require specific API key scope (Story 3.2.6, AC3/AC5/AC6).
+ * Uses hierarchical scope resolution via checkScopeAccess.
  */
-export function requireScope(auth: AuthContext, requiredScope: string): void {
+export function requireScope(
+  auth: AuthContext,
+  requiredScope: OperationScope
+): void {
   if (!auth.isApiKey) {
     // JWT auth has all scopes by default
     return;
   }
 
   const scopes = auth.scopes ?? [];
-  const hasWildcard = scopes.includes("*");
-  const hasScope = scopes.includes(requiredScope);
-
-  if (!hasWildcard && !hasScope) {
+  if (!checkScopeAccess(scopes, requiredScope)) {
     throw new AppError(
       ErrorCode.SCOPE_INSUFFICIENT,
-      "API key lacks required scope",
+      `API key lacks required scope: ${requiredScope}`,
       {
-        requiredScope,
-        keyScopes: scopes,
+        required_scope: requiredScope,
+        granted_scopes: scopes,
+        allowedActions: ["request-api-key-with-scope"],
       }
     );
   }

--- a/backend/shared/middleware/src/index.ts
+++ b/backend/shared/middleware/src/index.ts
@@ -78,5 +78,16 @@ export {
   type RateLimitMiddlewareConfig,
 } from "./rate-limit-headers.js";
 
+// Scope resolution (Story 3.2.6)
+export {
+  SCOPE_GRANTS,
+  VALID_SCOPES,
+  resolveScopeGrants,
+  checkScopeAccess,
+} from "./scope-resolver.js";
+
+// Re-export scope types from types package (Story 3.2.6)
+export type { ApiKeyScope, OperationScope } from "@ai-learning-hub/types";
+
 // SSM utilities
 export { getClerkSecretKey, resetClerkSecretKeyCache } from "./ssm.js";

--- a/backend/shared/middleware/src/scope-resolver.ts
+++ b/backend/shared/middleware/src/scope-resolver.ts
@@ -1,0 +1,78 @@
+/**
+ * Scope tier resolution module (Story 3.2.6, AC2).
+ *
+ * Maps named permission tiers to granular operation permissions.
+ * Handles hierarchical scope resolution for API key authorization.
+ */
+import type { ApiKeyScope } from "@ai-learning-hub/types";
+
+/** Known valid scope tier values — used for runtime validation of deserialized scopes. */
+export const VALID_SCOPES: ReadonlySet<string> = new Set<string>([
+  "full",
+  "capture",
+  "read",
+  "saves:write",
+  "projects:write",
+  "*",
+  "saves:read",
+]);
+
+/**
+ * Maps each API key tier to the operation permissions it grants.
+ * Treat changes to this map as security-sensitive — modifying grants
+ * affects ALL existing keys using the affected tiers.
+ *
+ * IMPORTANT: Every ApiKeyScope value MUST have an entry here.
+ * Unrecognized scopes are dropped (not passed through) to prevent
+ * privilege escalation via corrupted scope data.
+ */
+export const SCOPE_GRANTS: Record<ApiKeyScope, readonly string[]> = {
+  full: ["*"],
+  "*": ["*"],
+  capture: ["saves:create"],
+  read: [
+    "saves:read",
+    "projects:read",
+    "links:read",
+    "users:read",
+    "keys:read",
+  ],
+  "saves:read": ["saves:read"],
+  "saves:write": [
+    "saves:read",
+    "saves:write",
+    "saves:create",
+    "links:read",
+    "links:write",
+  ],
+  "projects:write": ["projects:read", "projects:write"],
+};
+
+/**
+ * Resolve granted scope tiers to a set of operation permissions.
+ * Multiple tiers combine additively. Unrecognized scopes are silently
+ * dropped to prevent privilege escalation via corrupted scope data.
+ */
+export function resolveScopeGrants(grantedScopes: string[]): Set<string> {
+  const resolved = new Set<string>();
+  for (const scope of grantedScopes) {
+    const grants = SCOPE_GRANTS[scope as ApiKeyScope];
+    if (grants) {
+      for (const g of grants) resolved.add(g);
+    }
+    // Unrecognized scopes are dropped — not passed through as direct grants
+  }
+  return resolved;
+}
+
+/**
+ * Check if granted scopes satisfy the required operation scope.
+ * Returns true if the resolved grants include wildcard (`*`) or the exact required scope.
+ */
+export function checkScopeAccess(
+  grantedScopes: string[],
+  requiredScope: string
+): boolean {
+  const resolved = resolveScopeGrants(grantedScopes);
+  return resolved.has("*") || resolved.has(requiredScope);
+}

--- a/backend/shared/middleware/src/wrapper.ts
+++ b/backend/shared/middleware/src/wrapper.ts
@@ -11,6 +11,7 @@ import {
   ErrorCode,
   type AuthContext,
   type ActorType,
+  type OperationScope,
 } from "@ai-learning-hub/types";
 import { createLogger, type Logger } from "@ai-learning-hub/logging";
 import {
@@ -21,7 +22,12 @@ import {
   type RateLimitResult,
 } from "@ai-learning-hub/db";
 import { handleError, createSuccessResponse } from "./error-handler.js";
-import { extractAuthContext, requireAuth } from "./auth.js";
+import {
+  extractAuthContext,
+  requireAuth,
+  requireRole,
+  requireScope,
+} from "./auth.js";
 import {
   extractIdempotencyKey,
   checkIdempotency,
@@ -77,7 +83,7 @@ export type WrappedHandler<T = unknown> = (
 export interface WrapperOptions {
   requireAuth?: boolean;
   requiredRoles?: string[];
-  requiredScope?: string;
+  requiredScope?: OperationScope;
   idempotent?: boolean;
   requireVersion?: boolean;
   /** Rate limit configuration — opt-in per handler (Story 3.2.4) */
@@ -185,32 +191,15 @@ export function wrapHandler<T = unknown>(
         auth = requireAuth(event);
         logger.setRequestContext({ userId: auth.userId });
 
-        // Check required roles
+        // Check required roles (delegates to requireRole for consistent error details)
         if (options.requiredRoles && options.requiredRoles.length > 0) {
-          const hasRequiredRole = options.requiredRoles.some((role) =>
-            auth!.roles.includes(role)
-          );
-          if (!hasRequiredRole) {
-            throw new AppError(ErrorCode.FORBIDDEN, "Insufficient permissions");
-          }
+          requireRole(auth, options.requiredRoles);
         }
 
-        // Check required scope for API keys
-        if (options.requiredScope && auth.isApiKey) {
-          const scopes = auth.scopes ?? [];
-          if (
-            !scopes.includes("*") &&
-            !scopes.includes(options.requiredScope)
-          ) {
-            throw new AppError(
-              ErrorCode.SCOPE_INSUFFICIENT,
-              "API key lacks required scope",
-              {
-                requiredScope: options.requiredScope,
-                keyScopes: scopes,
-              }
-            );
-          }
+        // Check required scope for API keys (delegates to requireScope — Story 3.2.6, AC3)
+        // requireScope handles isApiKey check and JWT bypass internally
+        if (options.requiredScope) {
+          requireScope(auth, options.requiredScope);
         }
       } else {
         auth = extractAuthContext(event);

--- a/backend/shared/middleware/test/auth.test.ts
+++ b/backend/shared/middleware/test/auth.test.ts
@@ -5,7 +5,7 @@ import {
   requireRole,
   requireScope,
 } from "../src/auth.js";
-import { AppError, ErrorCode } from "@ai-learning-hub/types";
+import { AppError, ErrorCode, type ApiKeyScope } from "@ai-learning-hub/types";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 
 // Helper to create mock API Gateway event
@@ -304,7 +304,7 @@ describe("Auth Middleware", () => {
         userId: "user_123",
         roles: ["user"],
         isApiKey: true,
-        scopes: ["*"],
+        scopes: ["*"] as ApiKeyScope[],
       };
 
       expect(() => requireScope(auth, "saves:write")).not.toThrow();
@@ -315,7 +315,7 @@ describe("Auth Middleware", () => {
         userId: "user_123",
         roles: ["user"],
         isApiKey: true,
-        scopes: ["saves:write"],
+        scopes: ["saves:write"] as ApiKeyScope[],
       };
 
       expect(() => requireScope(auth, "saves:write")).not.toThrow();
@@ -327,7 +327,7 @@ describe("Auth Middleware", () => {
         userId: "user_123",
         roles: ["user"],
         isApiKey: true,
-        scopes: ["saves:read"],
+        scopes: ["saves:read"] as ApiKeyScope[],
       };
 
       expect(() => requireScope(auth, "saves:write")).toThrow(AppError);
@@ -348,6 +348,86 @@ describe("Auth Middleware", () => {
       };
 
       expect(() => requireScope(auth, "saves:write")).toThrow(AppError);
+    });
+
+    // Story 3.2.6 — hierarchical scope resolution (AC19)
+    it("full scope satisfies any required scope", () => {
+      const auth = {
+        userId: "user_123",
+        roles: ["user"],
+        isApiKey: true,
+        scopes: ["full"] as ApiKeyScope[],
+      };
+      expect(() => requireScope(auth, "saves:create")).not.toThrow();
+      expect(() => requireScope(auth, "keys:manage")).not.toThrow();
+    });
+
+    it("capture scope satisfies saves:create but rejects saves:read", () => {
+      const auth = {
+        userId: "user_123",
+        roles: ["user"],
+        isApiKey: true,
+        scopes: ["capture"] as ApiKeyScope[],
+      };
+      expect(() => requireScope(auth, "saves:create")).not.toThrow();
+      expect(() => requireScope(auth, "saves:read")).toThrow(AppError);
+    });
+
+    it("read scope satisfies saves:read but rejects saves:write", () => {
+      const auth = {
+        userId: "user_123",
+        roles: ["user"],
+        isApiKey: true,
+        scopes: ["read"] as ApiKeyScope[],
+      };
+      expect(() => requireScope(auth, "saves:read")).not.toThrow();
+      expect(() => requireScope(auth, "projects:read")).not.toThrow();
+      expect(() => requireScope(auth, "saves:write")).toThrow(AppError);
+    });
+
+    it("saves:write satisfies saves:read (implicit read from write)", () => {
+      const auth = {
+        userId: "user_123",
+        roles: ["user"],
+        isApiKey: true,
+        scopes: ["saves:write"] as ApiKeyScope[],
+      };
+      expect(() => requireScope(auth, "saves:read")).not.toThrow();
+      expect(() => requireScope(auth, "saves:create")).not.toThrow();
+    });
+
+    it("combined tiers work", () => {
+      const auth = {
+        userId: "user_123",
+        roles: ["user"],
+        isApiKey: true,
+        scopes: ["capture", "read"] as ApiKeyScope[],
+      };
+      expect(() => requireScope(auth, "saves:create")).not.toThrow();
+      expect(() => requireScope(auth, "saves:read")).not.toThrow();
+      expect(() => requireScope(auth, "saves:write")).toThrow(AppError);
+    });
+
+    it("SCOPE_INSUFFICIENT error includes required_scope, granted_scopes, allowedActions (AC5/AC6)", () => {
+      const auth = {
+        userId: "user_123",
+        roles: ["user"],
+        isApiKey: true,
+        scopes: ["capture"] as ApiKeyScope[],
+      };
+      try {
+        requireScope(auth, "saves:read");
+      } catch (e) {
+        if (AppError.isAppError(e)) {
+          expect(e.code).toBe(ErrorCode.SCOPE_INSUFFICIENT);
+          expect(e.message).toBe("API key lacks required scope: saves:read");
+          expect(e.details).toEqual({
+            required_scope: "saves:read",
+            granted_scopes: ["capture"],
+            allowedActions: ["request-api-key-with-scope"],
+          });
+        }
+      }
     });
   });
 

--- a/backend/shared/middleware/test/scope-resolver.test.ts
+++ b/backend/shared/middleware/test/scope-resolver.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Unit tests for scope-resolver module (Story 3.2.6, AC18).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  SCOPE_GRANTS,
+  resolveScopeGrants,
+  checkScopeAccess,
+} from "../src/scope-resolver.js";
+
+describe("SCOPE_GRANTS", () => {
+  it("defines grants for all 5 named tiers plus 2 legacy values", () => {
+    expect(Object.keys(SCOPE_GRANTS)).toEqual(
+      expect.arrayContaining([
+        "full",
+        "*",
+        "capture",
+        "read",
+        "saves:read",
+        "saves:write",
+        "projects:write",
+      ])
+    );
+    expect(Object.keys(SCOPE_GRANTS)).toHaveLength(7);
+  });
+
+  it("full tier grants wildcard", () => {
+    expect(SCOPE_GRANTS["full"]).toContain("*");
+  });
+
+  it("* tier grants wildcard (backward compat)", () => {
+    expect(SCOPE_GRANTS["*"]).toContain("*");
+  });
+
+  it("capture tier grants only saves:create", () => {
+    expect(SCOPE_GRANTS["capture"]).toEqual(["saves:create"]);
+  });
+
+  it("read tier grants all read operations", () => {
+    const readGrants = SCOPE_GRANTS["read"];
+    expect(readGrants).toContain("saves:read");
+    expect(readGrants).toContain("projects:read");
+    expect(readGrants).toContain("links:read");
+    expect(readGrants).toContain("users:read");
+    expect(readGrants).toContain("keys:read");
+    expect(readGrants).toHaveLength(5);
+  });
+
+  it("saves:write tier grants saves and links operations", () => {
+    const grants = SCOPE_GRANTS["saves:write"];
+    expect(grants).toContain("saves:read");
+    expect(grants).toContain("saves:write");
+    expect(grants).toContain("saves:create");
+    expect(grants).toContain("links:read");
+    expect(grants).toContain("links:write");
+    expect(grants).toHaveLength(5);
+  });
+
+  it("projects:write tier grants projects read and write", () => {
+    expect(SCOPE_GRANTS["projects:write"]).toEqual([
+      "projects:read",
+      "projects:write",
+    ]);
+  });
+
+  it("saves:read legacy grants only saves:read (narrower than read tier)", () => {
+    expect(SCOPE_GRANTS["saves:read"]).toEqual(["saves:read"]);
+  });
+});
+
+describe("resolveScopeGrants", () => {
+  it("resolves full to wildcard", () => {
+    const resolved = resolveScopeGrants(["full"]);
+    expect(resolved.has("*")).toBe(true);
+  });
+
+  it("resolves * to wildcard (backward compat)", () => {
+    const resolved = resolveScopeGrants(["*"]);
+    expect(resolved.has("*")).toBe(true);
+  });
+
+  it("resolves capture to saves:create only", () => {
+    const resolved = resolveScopeGrants(["capture"]);
+    expect(resolved).toEqual(new Set(["saves:create"]));
+  });
+
+  it("resolves read to all read operations", () => {
+    const resolved = resolveScopeGrants(["read"]);
+    expect(resolved).toEqual(
+      new Set([
+        "saves:read",
+        "projects:read",
+        "links:read",
+        "users:read",
+        "keys:read",
+      ])
+    );
+  });
+
+  it("resolves saves:write to saves and links operations", () => {
+    const resolved = resolveScopeGrants(["saves:write"]);
+    expect(resolved).toEqual(
+      new Set([
+        "saves:read",
+        "saves:write",
+        "saves:create",
+        "links:read",
+        "links:write",
+      ])
+    );
+  });
+
+  it("resolves projects:write to projects read and write", () => {
+    const resolved = resolveScopeGrants(["projects:write"]);
+    expect(resolved).toEqual(new Set(["projects:read", "projects:write"]));
+  });
+
+  it("resolves saves:read legacy to saves:read only", () => {
+    const resolved = resolveScopeGrants(["saves:read"]);
+    expect(resolved).toEqual(new Set(["saves:read"]));
+  });
+
+  it("combines multiple tiers additively", () => {
+    const resolved = resolveScopeGrants(["capture", "read"]);
+    expect(resolved.has("saves:create")).toBe(true);
+    expect(resolved.has("saves:read")).toBe(true);
+    expect(resolved.has("projects:read")).toBe(true);
+    expect(resolved.has("links:read")).toBe(true);
+    expect(resolved.has("users:read")).toBe(true);
+    expect(resolved.has("keys:read")).toBe(true);
+  });
+
+  it("combines saves:write and projects:write", () => {
+    const resolved = resolveScopeGrants(["saves:write", "projects:write"]);
+    expect(resolved).toEqual(
+      new Set([
+        "saves:read",
+        "saves:write",
+        "saves:create",
+        "links:read",
+        "links:write",
+        "projects:read",
+        "projects:write",
+      ])
+    );
+  });
+
+  it("drops unrecognized scopes to prevent privilege escalation", () => {
+    const resolved = resolveScopeGrants(["analytics:read"]);
+    expect(resolved.size).toBe(0);
+  });
+
+  it("drops unrecognized scopes while resolving recognized ones", () => {
+    const resolved = resolveScopeGrants(["capture", "analytics:read"]);
+    expect(resolved.has("saves:create")).toBe(true);
+    expect(resolved.has("analytics:read")).toBe(false);
+    expect(resolved.size).toBe(1);
+  });
+
+  it("returns empty set for empty scopes array", () => {
+    const resolved = resolveScopeGrants([]);
+    expect(resolved.size).toBe(0);
+  });
+
+  it("handles duplicate tiers correctly", () => {
+    const resolved = resolveScopeGrants(["read", "read"]);
+    expect(resolved).toEqual(
+      new Set([
+        "saves:read",
+        "projects:read",
+        "links:read",
+        "users:read",
+        "keys:read",
+      ])
+    );
+  });
+});
+
+describe("checkScopeAccess", () => {
+  it("full scope satisfies any required scope", () => {
+    expect(checkScopeAccess(["full"], "saves:create")).toBe(true);
+    expect(checkScopeAccess(["full"], "saves:read")).toBe(true);
+    expect(checkScopeAccess(["full"], "keys:manage")).toBe(true);
+    expect(checkScopeAccess(["full"], "projects:write")).toBe(true);
+  });
+
+  it("* scope satisfies any required scope (backward compat)", () => {
+    expect(checkScopeAccess(["*"], "saves:create")).toBe(true);
+    expect(checkScopeAccess(["*"], "keys:manage")).toBe(true);
+  });
+
+  it("capture scope satisfies saves:create", () => {
+    expect(checkScopeAccess(["capture"], "saves:create")).toBe(true);
+  });
+
+  it("capture scope rejects saves:read", () => {
+    expect(checkScopeAccess(["capture"], "saves:read")).toBe(false);
+  });
+
+  it("capture scope rejects keys:manage", () => {
+    expect(checkScopeAccess(["capture"], "keys:manage")).toBe(false);
+  });
+
+  it("read scope satisfies saves:read", () => {
+    expect(checkScopeAccess(["read"], "saves:read")).toBe(true);
+  });
+
+  it("read scope satisfies projects:read", () => {
+    expect(checkScopeAccess(["read"], "projects:read")).toBe(true);
+  });
+
+  it("read scope rejects saves:write", () => {
+    expect(checkScopeAccess(["read"], "saves:write")).toBe(false);
+  });
+
+  it("read scope rejects saves:create", () => {
+    expect(checkScopeAccess(["read"], "saves:create")).toBe(false);
+  });
+
+  it("saves:write scope satisfies saves:read (implicit read from write)", () => {
+    expect(checkScopeAccess(["saves:write"], "saves:read")).toBe(true);
+  });
+
+  it("saves:write scope satisfies saves:create", () => {
+    expect(checkScopeAccess(["saves:write"], "saves:create")).toBe(true);
+  });
+
+  it("saves:write scope rejects projects:read", () => {
+    expect(checkScopeAccess(["saves:write"], "projects:read")).toBe(false);
+  });
+
+  it("saves:write scope rejects keys:manage", () => {
+    expect(checkScopeAccess(["saves:write"], "keys:manage")).toBe(false);
+  });
+
+  it("projects:write scope satisfies projects:read", () => {
+    expect(checkScopeAccess(["projects:write"], "projects:read")).toBe(true);
+  });
+
+  it("projects:write scope rejects saves:read", () => {
+    expect(checkScopeAccess(["projects:write"], "saves:read")).toBe(false);
+  });
+
+  it("combined tiers work correctly", () => {
+    const scopes = ["saves:write", "projects:write"];
+    expect(checkScopeAccess(scopes, "saves:read")).toBe(true);
+    expect(checkScopeAccess(scopes, "saves:write")).toBe(true);
+    expect(checkScopeAccess(scopes, "saves:create")).toBe(true);
+    expect(checkScopeAccess(scopes, "projects:read")).toBe(true);
+    expect(checkScopeAccess(scopes, "projects:write")).toBe(true);
+    expect(checkScopeAccess(scopes, "keys:manage")).toBe(false);
+  });
+
+  it("empty scopes rejects everything", () => {
+    expect(checkScopeAccess([], "saves:read")).toBe(false);
+  });
+
+  it("unrecognized scope is dropped (no privilege escalation)", () => {
+    expect(checkScopeAccess(["analytics:read"], "analytics:read")).toBe(false);
+    expect(checkScopeAccess(["analytics:read"], "saves:read")).toBe(false);
+  });
+
+  it("saves:read legacy satisfies saves:read", () => {
+    expect(checkScopeAccess(["saves:read"], "saves:read")).toBe(true);
+  });
+
+  it("saves:read legacy rejects projects:read (narrower than read tier)", () => {
+    expect(checkScopeAccess(["saves:read"], "projects:read")).toBe(false);
+  });
+});

--- a/backend/shared/middleware/test/wrapper.test.ts
+++ b/backend/shared/middleware/test/wrapper.test.ts
@@ -268,10 +268,14 @@ describe("Handler Wrapper", () => {
       expect(result.statusCode).toBe(403);
       const body = JSON.parse(result.body);
       expect(body.error.code).toBe("SCOPE_INSUFFICIENT");
+      expect(body.error.message).toBe(
+        "API key lacks required scope: saves:write"
+      );
       expect(body.error.details).toEqual({
-        requiredScope: "saves:write",
-        keyScopes: ["saves:read"],
+        required_scope: "saves:write",
+        granted_scopes: ["saves:read"],
       });
+      expect(body.error.allowedActions).toEqual(["request-api-key-with-scope"]);
     });
 
     it("should include request ID in response headers", async () => {

--- a/backend/shared/types/src/api.ts
+++ b/backend/shared/types/src/api.ts
@@ -92,6 +92,39 @@ export interface PaginatedResponse<T> {
 }
 
 /**
+ * Named API key permission tiers (Story 3.2.6, AC15).
+ * Includes legacy values `*` and `saves:read` for backward compatibility.
+ */
+export type ApiKeyScope =
+  | "full"
+  | "capture"
+  | "read"
+  | "saves:write"
+  | "projects:write"
+  | "*"
+  | "saves:read";
+
+/**
+ * Granular operation permissions required by handlers (Story 3.2.6, AC16).
+ * Handlers declare their `requiredScope` using these values.
+ * Tier-to-operation mapping is in `@ai-learning-hub/middleware` scope-resolver.
+ */
+export type OperationScope =
+  | "saves:read"
+  | "saves:write"
+  | "saves:create"
+  | "projects:read"
+  | "projects:write"
+  | "links:read"
+  | "links:write"
+  | "users:read"
+  | "users:write"
+  | "keys:read"
+  | "keys:manage"
+  | "invites:manage"
+  | "*";
+
+/**
  * Lambda handler context with authentication info
  */
 export interface AuthContext {
@@ -99,7 +132,7 @@ export interface AuthContext {
   roles: string[];
   isApiKey: boolean;
   apiKeyId?: string;
-  scopes?: string[];
+  scopes?: ApiKeyScope[];
 }
 
 /**

--- a/backend/shared/types/src/index.ts
+++ b/backend/shared/types/src/index.ts
@@ -26,6 +26,8 @@ export {
   type PaginationOptions,
   type PaginationParams,
   type PaginatedResponse,
+  type ApiKeyScope,
+  type OperationScope,
   type AgentIdentity,
   type AuthContext,
   type RequestContext,

--- a/backend/shared/validation/src/schemas.ts
+++ b/backend/shared/validation/src/schemas.ts
@@ -162,17 +162,29 @@ export const userIdSchema = z
   .describe("User identifier from Clerk");
 
 /**
- * API Key scope schema
+ * API Key scope schema (Story 3.2.6, AC1).
+ * 5 named permission tiers + 2 legacy values for backward compatibility.
  */
-export const apiKeyScopeSchema = z.enum(["*", "saves:write", "saves:read"]);
+export const apiKeyScopeSchema = z.enum([
+  "full",
+  "capture",
+  "read",
+  "saves:write",
+  "projects:write",
+  "*",
+  "saves:read",
+]);
 
 /**
- * API Key scopes array (duplicates are automatically removed)
+ * API Key scopes array (Story 3.2.6, AC12).
+ * Normalizes `*` to `full` on creation, deduplicates.
  */
 export const apiKeyScopesSchema = z
   .array(apiKeyScopeSchema)
   .min(1)
-  .transform((scopes) => Array.from(new Set(scopes)))
+  .transform((scopes) =>
+    Array.from(new Set(scopes.map((s) => (s === "*" ? "full" : s))))
+  )
   .describe("API key permission scopes");
 
 /**

--- a/backend/shared/validation/test/schemas.test.ts
+++ b/backend/shared/validation/test/schemas.test.ts
@@ -310,30 +310,94 @@ describe("Validation Schemas", () => {
     });
   });
 
-  describe("apiKeyScopeSchema", () => {
-    it("should accept valid scopes", () => {
-      const scopes = ["*", "saves:write", "saves:read"];
-      for (const scope of scopes) {
+  describe("apiKeyScopeSchema (Story 3.2.6, AC20)", () => {
+    it("should accept all 5 named tiers", () => {
+      const tiers = [
+        "full",
+        "capture",
+        "read",
+        "saves:write",
+        "projects:write",
+      ];
+      for (const scope of tiers) {
         const result = apiKeyScopeSchema.safeParse(scope);
-        expect(result.success).toBe(true);
+        expect(result.success, `${scope} should be accepted`).toBe(true);
       }
     });
 
-    it("should reject invalid scope", () => {
-      const result = apiKeyScopeSchema.safeParse("invalid:scope");
-      expect(result.success).toBe(false);
+    it("should accept legacy values * and saves:read (backward compat)", () => {
+      expect(apiKeyScopeSchema.safeParse("*").success).toBe(true);
+      expect(apiKeyScopeSchema.safeParse("saves:read").success).toBe(true);
+    });
+
+    it("should reject invalid scope values", () => {
+      expect(apiKeyScopeSchema.safeParse("admin").success).toBe(false);
+      expect(apiKeyScopeSchema.safeParse("delete:all").success).toBe(false);
+      expect(apiKeyScopeSchema.safeParse("").success).toBe(false);
+      expect(apiKeyScopeSchema.safeParse("saves:delete").success).toBe(false);
     });
   });
 
-  describe("apiKeyScopesSchema", () => {
-    it("should accept valid scopes array", () => {
+  describe("apiKeyScopesSchema (Story 3.2.6, AC12/AC20)", () => {
+    it("should accept valid scopes array with named tiers", () => {
+      expect(apiKeyScopesSchema.safeParse(["full"]).success).toBe(true);
+      expect(apiKeyScopesSchema.safeParse(["capture"]).success).toBe(true);
+      expect(apiKeyScopesSchema.safeParse(["read"]).success).toBe(true);
+    });
+
+    it("should accept * (backward compat)", () => {
       const result = apiKeyScopesSchema.safeParse(["*"]);
       expect(result.success).toBe(true);
+    });
+
+    it("should normalize * to full (AC12)", () => {
+      const result = apiKeyScopesSchema.safeParse(["*"]);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(["full"]);
+      }
+    });
+
+    it("should deduplicate after normalization (AC12)", () => {
+      const result = apiKeyScopesSchema.safeParse(["*", "full"]);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(["full"]);
+      }
+    });
+
+    it("should accept combined tiers", () => {
+      const result = apiKeyScopesSchema.safeParse([
+        "saves:write",
+        "projects:write",
+      ]);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(["saves:write", "projects:write"]);
+      }
+    });
+
+    it("should deduplicate duplicate tiers", () => {
+      const result = apiKeyScopesSchema.safeParse(["read", "read", "capture"]);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(["read", "capture"]);
+      }
     });
 
     it("should reject empty array", () => {
       const result = apiKeyScopesSchema.safeParse([]);
       expect(result.success).toBe(false);
+    });
+
+    it("should reject array with invalid scope", () => {
+      expect(apiKeyScopesSchema.safeParse(["admin"]).success).toBe(false);
+      expect(apiKeyScopesSchema.safeParse(["delete:all"]).success).toBe(false);
+    });
+
+    it("should require minimum 1 scope", () => {
+      expect(apiKeyScopesSchema.safeParse([]).success).toBe(false);
+      expect(apiKeyScopesSchema.safeParse(["capture"]).success).toBe(true);
     });
   });
 

--- a/backend/test-utils/mock-wrapper.ts
+++ b/backend/test-utils/mock-wrapper.ts
@@ -8,6 +8,26 @@
  */
 import { vi } from "vitest";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
+// Import directly from scope-resolver source (not @ai-learning-hub/middleware barrel)
+// so vi.mock("@ai-learning-hub/middleware") in handler tests does not intercept it.
+import { checkScopeAccess } from "../shared/middleware/src/scope-resolver.js";
+
+/**
+ * Parse raw scopes from authorizer context (array or JSON string).
+ * Mirrors real middleware parsing in auth.ts.
+ */
+function parseScopes(raw: unknown): string[] | undefined {
+  if (Array.isArray(raw)) return raw;
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
 
 /** Shape of a mock logger matching @ai-learning-hub/logging Logger */
 export interface MockLogger {
@@ -206,30 +226,17 @@ export function mockMiddlewareModule(
           }
         }
 
-        // Simulate scope enforcement for API key auth (AC15)
-        // Match real middleware: check isApiKey field (boolean or string "true")
+        // Simulate scope enforcement for API key auth (Story 3.2.6)
+        // Uses real checkScopeAccess from scope-resolver (imported directly)
         if (opts.requiredScope) {
           const authorizer = event.requestContext?.authorizer;
           if (
             authorizer?.isApiKey === true ||
             authorizer?.isApiKey === "true"
           ) {
-            const rawScopes = authorizer.scopes;
-            let scopes: string[] = [];
-            if (Array.isArray(rawScopes)) {
-              scopes = rawScopes;
-            } else if (typeof rawScopes === "string") {
-              try {
-                const parsed = JSON.parse(rawScopes);
-                scopes = Array.isArray(parsed) ? parsed : [];
-              } catch {
-                scopes = [];
-              }
-            }
-            if (
-              !scopes.includes("*") &&
-              !scopes.includes(opts.requiredScope as string)
-            ) {
+            const scopes = parseScopes(authorizer.scopes) ?? [];
+            const required = opts.requiredScope as string;
+            if (!checkScopeAccess(scopes, required)) {
               return {
                 statusCode: 403,
                 headers: {
@@ -239,8 +246,13 @@ export function mockMiddlewareModule(
                 body: JSON.stringify({
                   error: {
                     code: "SCOPE_INSUFFICIENT",
-                    message: "API key lacks required scope",
+                    message: `API key lacks required scope: ${required}`,
                     requestId: "test-req-id",
+                    details: {
+                      required_scope: required,
+                      granted_scopes: scopes,
+                    },
+                    allowedActions: ["request-api-key-with-scope"],
                   },
                 }),
               };
@@ -251,25 +263,11 @@ export function mockMiddlewareModule(
         const authorizer = event.requestContext?.authorizer;
         let auth = null;
         if (authorizer) {
-          // Parse scopes: may be an array (from test code) or a JSON string
-          // (from API Gateway). Mirrors real middleware behavior.
-          const rawScopes = authorizer.scopes;
-          let scopes: string[] | undefined;
-          if (Array.isArray(rawScopes)) {
-            scopes = rawScopes;
-          } else if (typeof rawScopes === "string") {
-            try {
-              const parsed = JSON.parse(rawScopes);
-              scopes = Array.isArray(parsed) ? parsed : undefined;
-            } catch {
-              scopes = undefined;
-            }
-          }
+          const scopes = parseScopes(authorizer.scopes);
 
           auth = {
             userId: authorizer.userId as string,
             roles: [(authorizer.role as string) || "user"],
-            // Match real middleware: check isApiKey field (boolean or string "true")
             isApiKey:
               authorizer.isApiKey === true || authorizer.isApiKey === "true",
             ...(scopes ? { scopes } : {}),

--- a/backend/test/handler-integration.test.ts
+++ b/backend/test/handler-integration.test.ts
@@ -8,7 +8,11 @@
  * - AC16: Rate limit exceeded → 429 with Retry-After header
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { AppError, ErrorCode } from "@ai-learning-hub/types";
+import {
+  AppError,
+  ErrorCode,
+  type OperationScope,
+} from "@ai-learning-hub/types";
 import {
   createMockEvent,
   createMockContext,
@@ -240,7 +244,7 @@ describe("Scope Enforcement Integration (AC15)", () => {
     // Wrap with requiredScope
     const wrappedHandler = wrapHandler(innerHandler, {
       requireAuth: true,
-      requiredScope: "admin:manage",
+      requiredScope: "keys:manage",
     });
 
     // API key with only saves:write scope
@@ -271,7 +275,7 @@ describe("Scope Enforcement Integration (AC15)", () => {
 
     const wrappedHandler = wrapHandler(innerHandler, {
       requireAuth: true,
-      requiredScope: "admin:manage",
+      requiredScope: "keys:manage",
     });
 
     // API key with wildcard scope
@@ -299,7 +303,7 @@ describe("Scope Enforcement Integration (AC15)", () => {
 
     const wrappedHandler = wrapHandler(innerHandler, {
       requireAuth: true,
-      requiredScope: "admin:manage",
+      requiredScope: "keys:manage",
     });
 
     // JWT auth (no scopes needed)
@@ -314,5 +318,239 @@ describe("Scope Enforcement Integration (AC15)", () => {
 
     // JWT auth skips scope checks
     expect(result.statusCode).toBe(200);
+  });
+});
+
+/**
+ * Story 3.2.6 — Hierarchical Scope Enforcement Integration (AC21)
+ *
+ * Tests the full wrapHandler chain with scope tier resolution.
+ * Verifies that named permission tiers resolve correctly through middleware.
+ */
+describe("Hierarchical Scope Enforcement Integration (Story 3.2.6, AC21)", () => {
+  it("capture key satisfies saves:create required scope", async () => {
+    const { wrapHandler } = await import("@ai-learning-hub/middleware");
+    const innerHandler = vi.fn().mockResolvedValue({
+      statusCode: 201,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ data: { id: "save_01" } }),
+    });
+    const wrappedHandler = wrapHandler(innerHandler, {
+      requireAuth: true,
+      requiredScope: "saves:create",
+    });
+    const event = createMockEvent({
+      method: "POST",
+      path: "/saves",
+      userId: "user_1",
+      authMethod: "api-key",
+      scopes: ["capture"],
+    });
+
+    const result = await wrappedHandler(event, createMockContext());
+    expect(result.statusCode).toBe(201);
+  });
+
+  it("capture key rejected for saves:read → 403 with correct error details", async () => {
+    const { wrapHandler } = await import("@ai-learning-hub/middleware");
+    const innerHandler = vi.fn().mockResolvedValue({ statusCode: 200 });
+    const wrappedHandler = wrapHandler(innerHandler, {
+      requireAuth: true,
+      requiredScope: "saves:read",
+    });
+    const event = createMockEvent({
+      method: "GET",
+      path: "/saves",
+      userId: "user_1",
+      authMethod: "api-key",
+      scopes: ["capture"],
+    });
+
+    const result = await wrappedHandler(event, createMockContext());
+    expect(result.statusCode).toBe(403);
+    const body = JSON.parse(result.body);
+    expect(body.error.code).toBe("SCOPE_INSUFFICIENT");
+    expect(body.error.message).toBe("API key lacks required scope: saves:read");
+    expect(body.error.details.required_scope).toBe("saves:read");
+    expect(body.error.details.granted_scopes).toEqual(["capture"]);
+    expect(body.error.allowedActions).toEqual(["request-api-key-with-scope"]);
+  });
+
+  it("read key satisfies saves:read", async () => {
+    const { wrapHandler } = await import("@ai-learning-hub/middleware");
+    const innerHandler = vi.fn().mockResolvedValue({
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ data: [] }),
+    });
+    const wrappedHandler = wrapHandler(innerHandler, {
+      requireAuth: true,
+      requiredScope: "saves:read",
+    });
+    const event = createMockEvent({
+      method: "GET",
+      path: "/saves",
+      userId: "user_1",
+      authMethod: "api-key",
+      scopes: ["read"],
+    });
+
+    const result = await wrappedHandler(event, createMockContext());
+    expect(result.statusCode).toBe(200);
+  });
+
+  it("read key rejected for saves:write", async () => {
+    const { wrapHandler } = await import("@ai-learning-hub/middleware");
+    const innerHandler = vi.fn().mockResolvedValue({ statusCode: 200 });
+    const wrappedHandler = wrapHandler(innerHandler, {
+      requireAuth: true,
+      requiredScope: "saves:write",
+    });
+    const event = createMockEvent({
+      method: "PATCH",
+      path: "/saves/01",
+      userId: "user_1",
+      authMethod: "api-key",
+      scopes: ["read"],
+    });
+
+    const result = await wrappedHandler(event, createMockContext());
+    expect(result.statusCode).toBe(403);
+  });
+
+  it("saves:write key satisfies both saves:read and saves:write", async () => {
+    const { wrapHandler } = await import("@ai-learning-hub/middleware");
+    const innerHandler = vi.fn().mockResolvedValue({
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ data: {} }),
+    });
+
+    for (const requiredScope of [
+      "saves:read",
+      "saves:write",
+    ] as OperationScope[]) {
+      const wrappedHandler = wrapHandler(innerHandler, {
+        requireAuth: true,
+        requiredScope,
+      });
+      const event = createMockEvent({
+        method: "GET",
+        path: "/saves",
+        userId: "user_1",
+        authMethod: "api-key",
+        scopes: ["saves:write"],
+      });
+      const result = await wrappedHandler(event, createMockContext());
+      expect(result.statusCode).toBe(200);
+    }
+  });
+
+  it("full key satisfies any required scope", async () => {
+    const { wrapHandler } = await import("@ai-learning-hub/middleware");
+    const innerHandler = vi.fn().mockResolvedValue({
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ data: {} }),
+    });
+
+    for (const requiredScope of [
+      "saves:create",
+      "saves:read",
+      "keys:manage",
+      "projects:write",
+    ] as OperationScope[]) {
+      const wrappedHandler = wrapHandler(innerHandler, {
+        requireAuth: true,
+        requiredScope,
+      });
+      const event = createMockEvent({
+        method: "POST",
+        path: "/test",
+        userId: "user_1",
+        authMethod: "api-key",
+        scopes: ["full"],
+      });
+      const result = await wrappedHandler(event, createMockContext());
+      expect(result.statusCode).toBe(200);
+    }
+  });
+
+  it("* key satisfies any required scope (backward compat)", async () => {
+    const { wrapHandler } = await import("@ai-learning-hub/middleware");
+    const innerHandler = vi.fn().mockResolvedValue({
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ data: {} }),
+    });
+    const wrappedHandler = wrapHandler(innerHandler, {
+      requireAuth: true,
+      requiredScope: "keys:manage",
+    });
+    const event = createMockEvent({
+      method: "POST",
+      path: "/test",
+      userId: "user_1",
+      authMethod: "api-key",
+      scopes: ["*"],
+    });
+    const result = await wrappedHandler(event, createMockContext());
+    expect(result.statusCode).toBe(200);
+  });
+
+  it("combined saves:write + projects:write satisfies both domain scopes", async () => {
+    const { wrapHandler } = await import("@ai-learning-hub/middleware");
+    const innerHandler = vi.fn().mockResolvedValue({
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ data: {} }),
+    });
+
+    for (const requiredScope of [
+      "saves:read",
+      "saves:write",
+      "projects:read",
+      "projects:write",
+    ] as OperationScope[]) {
+      const wrappedHandler = wrapHandler(innerHandler, {
+        requireAuth: true,
+        requiredScope,
+      });
+      const event = createMockEvent({
+        method: "POST",
+        path: "/test",
+        userId: "user_1",
+        authMethod: "api-key",
+        scopes: ["saves:write", "projects:write"],
+      });
+      const result = await wrappedHandler(event, createMockContext());
+      expect(result.statusCode, `${requiredScope} should be satisfied`).toBe(
+        200
+      );
+    }
+  });
+
+  it("error response includes required_scope, granted_scopes, allowedActions", async () => {
+    const { wrapHandler } = await import("@ai-learning-hub/middleware");
+    const innerHandler = vi.fn().mockResolvedValue({ statusCode: 200 });
+    const wrappedHandler = wrapHandler(innerHandler, {
+      requireAuth: true,
+      requiredScope: "keys:manage",
+    });
+    const event = createMockEvent({
+      method: "POST",
+      path: "/users/api-keys",
+      userId: "user_1",
+      authMethod: "api-key",
+      scopes: ["read"],
+    });
+
+    const result = await wrappedHandler(event, createMockContext());
+    expect(result.statusCode).toBe(403);
+    const body = JSON.parse(result.body);
+    expect(body.error.code).toBe("SCOPE_INSUFFICIENT");
+    expect(body.error.details.required_scope).toBe("keys:manage");
+    expect(body.error.details.granted_scopes).toEqual(["read"]);
+    expect(body.error.allowedActions).toEqual(["request-api-key-with-scope"]);
   });
 });

--- a/docs/progress/epic-3.2-auto-run.md
+++ b/docs/progress/epic-3.2-auto-run.md
@@ -1,9 +1,9 @@
 ---
 epic_id: Epic-3.2
-status: done
-scope: ["3.2.1", "3.2.2", "3.2.3", "3.2.4", "3.2.5"]
+status: in-progress
+scope: ["3.2.1", "3.2.2", "3.2.3", "3.2.4", "3.2.5", "3.2.6"]
 started: 2026-02-25T12:00:00Z
-last_updated: 2026-02-27T02:16:00Z
+last_updated: 2026-02-27T14:00:00Z
 stories:
   "3.2.1":
     {
@@ -54,6 +54,13 @@ stories:
       startedAt: "2026-02-26T23:30:00Z",
       completedAt: "2026-02-27T02:16:00Z",
       reviewRounds: 1,
+    }
+  "3.2.6":
+    {
+      status: in-progress,
+      issue: 239,
+      branch: story-3-2-6-impl-scoped-api-key-permissions,
+      startedAt: "2026-02-27T14:00:00Z",
     }
 ---
 


### PR DESCRIPTION
## Summary
- Implement 5 named API key permission tiers (`full`, `capture`, `read`, `saves:write`, `projects:write`) with hierarchical scope resolution
- Add `scope-resolver.ts` module with `SCOPE_GRANTS` map and `checkScopeAccess()` for tier-to-operation permission mapping
- Enhance `SCOPE_INSUFFICIENT` (403) errors with `required_scope`, `granted_scopes`, and `allowedActions` for machine-actionable agent responses
- Add `ApiKeyScope` and `OperationScope` types with runtime validation to prevent privilege escalation
- Normalize `*` → `full` on key creation; backward compat preserved for existing keys

## Changes
- **New:** `backend/shared/middleware/src/scope-resolver.ts` — core scope resolution logic (41 tests, 100% coverage)
- **Modified:** `auth.ts` — `requireScope()` uses hierarchical resolution + runtime scope validation
- **Modified:** `wrapper.ts` — delegates to `requireScope()`/`requireRole()` (DRY fix)
- **Modified:** `schemas.ts` — expanded `apiKeyScopeSchema` with 5 named tiers + normalization transform
- **Modified:** `api.ts` — `ApiKeyScope`, `OperationScope` types; `AuthContext.scopes` typed
- **Modified:** `mock-wrapper.ts` — imports real `checkScopeAccess` instead of duplicating SCOPE_GRANTS
- **Tests:** 360 tests pass across 20 files; 21/21 ACs verified

## Test plan
- [x] 41 unit tests for scope-resolver (all tiers, combinations, backward compat, edge cases)
- [x] 7 unit tests for requireScope with hierarchy (AC19)
- [x] Comprehensive Zod schema validation tests (AC20)
- [x] 9 integration tests through full wrapHandler chain (AC21)
- [x] Lint: 0 errors, Type-check: 0 errors
- [x] Adversarial code review + dedup scan completed, findings fixed

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)