### PR TITLE
chore: enforce story YAML frontmatter + AC format for auto-epic compatibility

### DIFF
--- a/.claude/dedup-findings-3.2.4.md
+++ b/.claude/dedup-findings-3.2.4.md
@@ -1,0 +1,176 @@
+# Story 3.2.4 Dedup Scan Findings - Round 1
+
+**Scanner:** Agent (Fresh Context)
+**Date:** 2026-02-26
+**Branch:** main (post-merge scan)
+**Domain:** backend/shared/middleware/src/**/\*.ts + related packages
+**Handlers scanned:\*\* 11 middleware source files, 12 Lambda handler files, 6 shared packages
+
+## Files Analyzed
+
+### Middleware package (primary scan target)
+
+- `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/agent-identity.ts` (NEW)
+- `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/rate-limit-headers.ts` (NEW)
+- `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/wrapper.ts` (MODIFIED)
+- `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/index.ts` (MODIFIED)
+- `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/error-handler.ts`
+- `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/auth.ts`
+- `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/idempotency.ts`
+- `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/concurrency.ts`
+- `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/event-history.ts`
+- `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/authorizer-policy.ts`
+- `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/ssm.ts`
+
+### Related packages
+
+- `/Users/stephen/Documents/ai-learning-hub/backend/shared/types/src/api.ts` (AgentIdentity type)
+- `/Users/stephen/Documents/ai-learning-hub/backend/shared/types/src/events.ts` (ActorType type)
+- `/Users/stephen/Documents/ai-learning-hub/backend/shared/validation/src/event-context.ts` (NEW)
+- `/Users/stephen/Documents/ai-learning-hub/backend/shared/db/src/rate-limiter.ts` (RateLimitResult type)
+- `/Users/stephen/Documents/ai-learning-hub/backend/test-utils/mock-wrapper.ts` (MODIFIED)
+
+### Lambda handlers (cross-reference for duplication)
+
+- All 12 handler files in `backend/functions/*/handler.ts`
+
+## Critical Issues (Must Fix)
+
+1. **[Semantic Divergence] mock-wrapper.ts agent identity extraction skips validation**
+   - **Files:**
+     - `/Users/stephen/Documents/ai-learning-hub/backend/test-utils/mock-wrapper.ts`:281-294
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/agent-identity.ts`:27-55
+   - **Shared export:** `@ai-learning-hub/middleware`, `extractAgentIdentity`
+   - **Problem:** The mock-wrapper re-implements agent identity extraction inline (lines 281-294) instead of using `extractAgentIdentity`. The mock version does a simple header lookup and truthy check:
+     ```typescript
+     // mock-wrapper.ts:281-294
+     const agentIdHeader =
+       event.headers?.["x-agent-id"] ??
+       event.headers?.["X-Agent-ID"] ??
+       null;
+     // ...
+     agentId: agentIdHeader,
+     actorType: agentIdHeader ? "agent" : "human",
+     ```
+     The real `extractAgentIdentity` performs regex validation (`/^[a-zA-Z0-9_\-.]{1,128}$/`) and throws `VALIDATION_ERROR` for invalid agent IDs. The mock version silently accepts any string (including `"agent with spaces"`, `"agent<script>"`, or strings longer than 128 characters). This means handler tests using mock-wrapper will pass with invalid agent IDs that would be rejected in production.
+   - **Impact:** Handler tests that pass an invalid `X-Agent-ID` header will not see the 400 VALIDATION_ERROR that production would return. Any handler test relying on agent identity behavior is testing against a less strict contract than production enforces.
+   - **Fix:** Import and call `extractAgentIdentity` from `@ai-learning-hub/middleware` (or from the source file directly) in the mock-wrapper. Wrap in try/catch to match mock-wrapper's error handling pattern. Alternatively, since mock-wrapper is for unit testing convenience, document the intentional simplification with a comment explaining the semantic gap.
+
+## Important Issues (Should Fix)
+
+2. **[Duplicate Code] X-Agent-ID echo header logic repeated 3 times in wrapper.ts**
+   - **Files:**
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/wrapper.ts`:274-279 (rate-limit 429 early return)
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/wrapper.ts`:417-426 (success path)
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/wrapper.ts`:452-456 (catch block)
+   - **Shared export:** None -- needs extraction
+   - **Problem:** The pattern of conditionally adding `X-Agent-ID` to a response is written 3 separate times within wrapper.ts:
+     ```typescript
+     // Pattern 1 (line 275): rate limit 429 early return
+     if (agentIdentity.agentId) {
+       (errorResponse.headers as Record<string, string>)["X-Agent-ID"] =
+         agentIdentity.agentId;
+     }
+     // Pattern 2 (line 418): success path -- uses spread
+     if (agentIdentity.agentId) {
+       finalResult = {
+         ...finalResult,
+         headers: {
+           ...(finalResult.headers ?? {}),
+           "X-Agent-ID": agentIdentity.agentId,
+         },
+       };
+     }
+     // Pattern 3 (line 453): catch block -- uses mutation
+     if (agentIdentity.agentId) {
+       (errorResponse.headers as Record<string, string>)["X-Agent-ID"] =
+         agentIdentity.agentId;
+     }
+     ```
+     Additionally, patterns 1 and 3 use direct mutation while pattern 2 uses immutable spread. This style inconsistency increases the risk of one path being updated while others are missed.
+   - **Impact:** If the agent-ID echo logic changes (e.g., adding a header prefix or sanitization), all 3 locations must be updated in sync. The style inconsistency (mutation vs spread) makes this harder to maintain.
+   - **Fix:** Extract a helper function in `rate-limit-headers.ts` or a new `response-decoration.ts`:
+     ```typescript
+     export function addAgentIdHeader(
+       response: APIGatewayProxyResult,
+       agentId: string | null
+     ): APIGatewayProxyResult {
+       if (!agentId) return response;
+       return {
+         ...response,
+         headers: { ...(response.headers ?? {}), "X-Agent-ID": agentId },
+       };
+     }
+     ```
+     Then call it once at each return point, or better yet, consolidate the response decoration into a single "decorate response" step that runs before every `return` in wrapper.ts.
+
+3. **[Duplicate Code] Rate limit header decoration logic repeated 3 times in wrapper.ts**
+   - **Files:**
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/wrapper.ts`:256-273 (rate-limit 429 early return, uses `buildRateLimitHeaders` + manual merge)
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/wrapper.ts`:409-414 (success path, uses `addRateLimitHeaders`)
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/wrapper.ts`:441-449 (catch block, uses `buildRateLimitHeaders` + manual merge)
+   - **Shared export:** `addRateLimitHeaders` exists in `rate-limit-headers.ts` but is only used for path 2
+   - **Problem:** The 429 early-return path (line 256-273) and the catch block (lines 441-449) manually call `buildRateLimitHeaders` and merge headers, while the success path uses the dedicated `addRateLimitHeaders` function. This inconsistency means there are two different code patterns for the same operation in the same file. The dedicated `addRateLimitHeaders` function exists specifically to centralize this logic, but 2 of 3 call sites don't use it.
+   - **Impact:** If `addRateLimitHeaders` behavior changes (e.g., adding a new header), the manual-merge paths at lines 256-273 and 441-449 would drift.
+   - **Fix:** Use `addRateLimitHeaders` at all 3 locations. The function already handles the spread-merge pattern cleanly. For the 429 early return, this would be:
+     ```typescript
+     let errorResponse = handleError(error, requestId, logger);
+     errorResponse = addRateLimitHeaders(
+       errorResponse,
+       result,
+       options.rateLimit.windowSeconds
+     );
+     ```
+
+4. **[Duplicate Pattern] Inline `enforceRateLimit` calls in 6 handler files -- coexists with new middleware-based rate limiting**
+   - **Files:**
+     - `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves/handler.ts`:78-86
+     - `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-delete/handler.ts`:51-59
+     - `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-update/handler.ts`:50-58
+     - `/Users/stephen/Documents/ai-learning-hub/backend/functions/saves-restore/handler.ts`:48-56
+     - `/Users/stephen/Documents/ai-learning-hub/backend/functions/validate-invite/handler.ts`:75 (approx)
+     - `/Users/stephen/Documents/ai-learning-hub/backend/functions/api-keys/handler.ts`:51 (approx)
+     - `/Users/stephen/Documents/ai-learning-hub/backend/functions/invite-codes/handler.ts`:37 (approx)
+   - **Shared export:** `@ai-learning-hub/middleware` now provides `WrapperOptions.rateLimit` via `RateLimitMiddlewareConfig`
+   - **Problem:** Story 3.2.4 introduced a new middleware-based rate limiting approach via `wrapHandler` options (`options.rateLimit`), which automatically adds X-RateLimit-\* transparency headers. However, all 7 existing handler files still use the old pattern: calling `enforceRateLimit` directly inside the handler body. The old pattern does NOT return rate limit transparency headers (X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset) and does not expose `rateLimitResult` in the handler context. The saves-domain handlers all share an identical 8-line block:
+     ```typescript
+     await enforceRateLimit(
+       client,
+       USERS_TABLE_CONFIG.tableName,
+       { ...SAVES_WRITE_RATE_LIMIT, identifier: userId },
+       logger
+     );
+     ```
+   - **Impact:** This is a known migration gap -- Story 3.2.4 built the infrastructure, and Story 3.2.7 (retrofit) is expected to migrate existing handlers. However, until migration happens, there are two parallel rate-limiting patterns in the codebase, which is confusing for new developers. The old pattern lacks transparency headers. Also, the 8-line `enforceRateLimit` block is duplicated verbatim across 4 saves-domain handlers.
+   - **Fix:** Not a Story 3.2.4 bug -- this is expected to be addressed in the Story 3.2.7 retrofit. No immediate action required, but documenting here for completeness. When migrated, each handler can replace the inline `enforceRateLimit` call with a `rateLimit` option in `wrapHandler`, eliminating duplication and gaining transparency headers automatically.
+
+## Minor Issues (Nice to Have)
+
+5. **[Similar Pattern] `makeEvent` test factory duplicated across 5 middleware test files**
+   - **Files:**
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/test/agent-identity.test.ts`:8
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/test/concurrency.test.ts`:6
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/test/rate-limit-integration.test.ts`:54
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/test/idempotency-concurrency.integration.test.ts`:32
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/test/idempotency.test.ts`:44
+   - **Problem:** Each middleware test file defines its own `makeEvent()` factory function with a near-identical APIGatewayProxyEvent skeleton. The rate-limit-integration test version includes a full `requestContext.authorizer` object; the agent-identity test version has a minimal authorizer. The core shape (15+ fields of the APIGatewayProxyEvent identity block) is identical in all 5.
+   - **Impact:** Low. Test factory duplication is common and each test may need slightly different defaults. However, `backend/test-utils/mock-wrapper.ts` already exports `createMockEvent()` which serves the same purpose.
+   - **Fix:** Consider importing `createMockEvent` from `@ai-learning-hub/test-utils` in middleware tests, or extracting a shared `makeEvent` factory in a `backend/shared/middleware/test/helpers.ts` file. This is a nice-to-have, not a blocker.
+
+6. **[Style Inconsistency] Response header mutation vs immutable spread in wrapper.ts**
+   - **Files:**
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/wrapper.ts`:270-273 (mutation: `errorResponse.headers = { ...errorResponse.headers, ...rlHeaders }`)
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/wrapper.ts`:419-426 (immutable: `finalResult = { ...finalResult, headers: { ... } }`)
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/wrapper.ts`:399-406 (immutable: idempotency status header uses spread)
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/wrapper.ts`:435-438 (mutation: idempotency status in catch block uses direct assignment)
+   - **Problem:** The try block uses immutable spread pattern for response decoration, while the catch block uses direct property mutation on `errorResponse.headers`. This mixed style within a single function makes the code harder to reason about.
+   - **Impact:** No functional bug, but inconsistent style increases cognitive load and risk of accidental mutation bugs.
+   - **Fix:** Standardize on immutable spread throughout, or (if performance is a concern in the catch path) document why mutation is acceptable there.
+
+## Summary
+
+- **Total findings:** 6
+- **Critical:** 1 (mock-wrapper agent identity semantic divergence)
+- **Important:** 3 (X-Agent-ID echo 3x duplication, rate limit header decoration 3x duplication, old vs new rate limiting pattern coexistence)
+- **Minor:** 2 (test factory duplication, style inconsistency)
+- **Recommendation:** FIX REQUIRED -- Critical issue #1 means handler tests using mock-wrapper may pass with invalid agent IDs that production would reject. Important issues #2 and #3 are within-file duplication in wrapper.ts that should be consolidated to prevent policy drift.

--- a/.claude/dedup-findings-3.2.6.md
+++ b/.claude/dedup-findings-3.2.6.md
@@ -1,0 +1,30 @@
+# Story 3.2.6 Dedup Scan Findings
+
+**Date:** 2026-02-27 | **Branch:** story-3-2-6-impl-scoped-api-key-permissions
+
+## Critical Issues: None
+
+## Important Issues (Should Fix)
+
+### 1. wrapper.ts inlines scope-checking logic instead of calling requireScope()
+- **Files:** wrapper.ts:199-213, auth.ts:118-136
+- **Fix:** Replace inline logic with `requireScope(auth, options.requiredScope)` (one line)
+
+### 2. mock-wrapper.ts reimplements SCOPE_GRANTS map and resolveScopeGrants
+- **Files:** mock-wrapper.ts:230-261, scope-resolver.ts:13-62
+- **Fix:** Import checkScopeAccess from scope-resolver sub-module directly
+
+### 3. mock-wrapper.ts has two copies of rawScopes parsing
+- **Files:** mock-wrapper.ts:217-228, mock-wrapper.ts:290-301
+- **Fix:** Extract local parseScopes() helper
+
+### 4. wrapper.ts inlines role-checking logic instead of calling requireRole()
+- **Files:** wrapper.ts:190-197, auth.ts:101-112
+- **Fix:** Replace with `requireRole(auth!, options.requiredRoles)`
+
+## Minor Issues
+
+### 5. ApiKeyScope values defined in three locations (types, validation, scope-resolver)
+### 6. isApiKey boolean-or-string coercion repeated in 3 places
+
+## Summary: 0 critical, 4 important, 2 minor. PROCEED.

--- a/.claude/docs/api-patterns.md
+++ b/.claude/docs/api-patterns.md
@@ -8,24 +8,48 @@ REST conventions and error handling. See ADR-008 in `_bmad-output/planning-artif
 - Methods: GET (read), POST (create), PUT/PATCH (update), DELETE (delete).
 - All API calls scoped to authenticated user (JWT or API key). No Lambda-to-Lambda direct invoke; use API Gateway or EventBridge.
 
-## Error Response Shape (ADR-008)
+## Error Response Shape (ADR-008 + Epic 3.2)
 
 All Lambda responses use this shape via shared middleware:
 
 ```json
 {
-  "statusCode": 400 | 401 | 403 | 404 | 429 | 500,
+  "statusCode": 400 | 401 | 403 | 404 | 409 | 428 | 429 | 500,
   "body": {
     "error": {
-      "code": "VALIDATION_ERROR | NOT_FOUND | RATE_LIMITED | ...",
+      "code": "VALIDATION_ERROR | NOT_FOUND | RATE_LIMITED | VERSION_CONFLICT | SCOPE_INSUFFICIENT | ...",
       "message": "Human readable message",
-      "requestId": "correlation-id-from-x-ray"
+      "requestId": "correlation-id-from-x-ray",
+      "details": { "field_errors": [...] },
+      "currentState": "optional for state-machine errors",
+      "allowedActions": ["optional", "for state/conflict errors"],
+      "requiredConditions": ["optional", "for precondition errors"]
     }
   }
 }
 ```
 
-Error codes align with HTTP status; `requestId` is the correlation ID (X-Ray).
+- Error codes align with HTTP status; `requestId` is the correlation ID (X-Ray).
+- **Field-level validation (3.2.2):** When `code` is `VALIDATION_ERROR`, `details.field_errors` (or `details`) can include `{ field, message, code, constraint, allowed_values }` per `FieldValidationError` from `@ai-learning-hub/types`.
+- **Agent-native errors:** `VERSION_CONFLICT` (409), `PRECONDITION_REQUIRED` (428), `IDEMPOTENCY_KEY_CONFLICT` (409), `INVALID_STATE_TRANSITION` (409), `SCOPE_INSUFFICIENT` (403). State/conflict errors should include `currentState` and `allowedActions` when applicable.
+
+## Success Response Envelope (Epic 3.2)
+
+All successful list and single-resource responses use the envelope from `@ai-learning-hub/types`:
+
+- **Shape:** `{ data, meta?, links? }`.
+- **meta:** `cursor` (opaque pagination token), `total`, `cursorReset`, `truncated`, `rateLimit` (limit, remaining, reset), `actions` (for action discoverability).
+- **links:** `self`, `next` (for paginated lists).
+- Handlers use `createSuccessResponse(data, requestId, { meta, links })` from `@ai-learning-hub/middleware`; the wrapper adds rate-limit headers when configured.
+
+## Agent-Native API (Epic 3.2)
+
+- **Idempotency:** Mutating operations support `Idempotency-Key` header. Middleware checks/stores results in the idempotency table; replay cached response on retry. See `extractIdempotencyKey`, `checkIdempotency`, `storeIdempotencyResult` in `@ai-learning-hub/middleware`.
+- **Optimistic concurrency:** Handlers that support it use `If-Match: <version>` and `ctx.expectedVersion`. Conflict returns `VERSION_CONFLICT` (409) with current version in details. See `extractIfMatch` and version helpers in `@ai-learning-hub/db`.
+- **Agent identity:** `X-Agent-ID` header is extracted by middleware; `ctx.agentId` and `ctx.actorType` (`human` | `agent`) are available. Recorded in event history.
+- **Rate limit transparency:** Responses include `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` when rate-limit middleware is active. Same values appear in `meta.rateLimit` in the envelope.
+- **Cursor pagination:** List endpoints use opaque cursors (encode/decode via `@ai-learning-hub/db`). No offset/page numbers; use `cursor` query param and `meta.cursor` / `links.next` in the response.
+- **Scoped API keys:** Handlers declare `requiredScope` in `wrapHandler` options (e.g. `*` or `saves:write`). Insufficient scope returns `403` with `SCOPE_INSUFFICIENT` and `required_scope` / `granted_scopes` in details. See `@ai-learning-hub/middleware` scope-resolver.
 
 ## Logging Contract (every log line)
 
@@ -37,13 +61,13 @@ Error codes align with HTTP status; `requestId` is the correlation ID (X-Ray).
 Lambdas use `@ai-learning-hub/middleware`:
 
 - **Auth:** Verify JWT or API key; reject 401 if invalid.
-- **Error handler:** Catch errors, map to ADR-008 shape, log with correlation ID.
-- **Wrapper:** Composes auth + error handling around handler.
+- **Error handler:** Catch errors, map to ADR-008 shape (including details, currentState, allowedActions), log with correlation ID.
+- **Wrapper:** Composes auth, optional idempotency/concurrency/rate-limit, agent identity, error handling, and response envelope/headers around handler.
 
-All handlers must use the wrapper; do not return raw responses.
+All API handlers must use `wrapHandler`; do not return raw responses. Authorizers do not use the wrapper (they use `createLogger()` from `@ai-learning-hub/logging`).
 
 ## Rules
 
 - **No Lambda-to-Lambda:** Call APIs via HTTP or emit events (EventBridge). Never `lambda.invoke()`.
-- **Shared middleware:** Use `@ai-learning-hub/middleware` for auth and error handling.
-- **Structured errors:** Use `AppError` and error codes from `@ai-learning-hub/types`; middleware formats them.
+- **Shared middleware:** Use `@ai-learning-hub/middleware` for auth, error handling, idempotency, concurrency, agent identity, and rate-limit headers.
+- **Structured errors:** Use `AppError` and error codes from `@ai-learning-hub/types`; use `AppError.build().withState().withConditions().create()` for state-machine/precondition errors; middleware formats them.

--- a/.claude/docs/database-schema.md
+++ b/.claude/docs/database-schema.md
@@ -1,18 +1,20 @@
 # Database Schema Summary
 
-7 DynamoDB tables, 10 GSIs. Full detail: `_bmad-output/planning-artifacts/architecture.md` (canonical path: see .claude/docs/README.md).
+9 DynamoDB tables, 10 GSIs. Full detail: `_bmad-output/planning-artifacts/architecture.md` (canonical path: see .claude/docs/README.md).
 
 ## Tables and Keys
 
-| #   | Table        | PK                      | SK                                                   | Notes                        |
-| --- | ------------ | ----------------------- | ---------------------------------------------------- | ---------------------------- |
-| 1   | users        | USER#&lt;clerkId&gt;    | PROFILE or APIKEY#&lt;keyId&gt;                      | Profiles + API keys          |
-| 2   | saves        | USER#&lt;userId&gt;     | SAVE#&lt;saveId&gt;                                  | urlHash links to content     |
-| 3   | projects     | USER#&lt;userId&gt;     | PROJECT#&lt;projectId&gt; or FOLDER#&lt;folderId&gt; | Folders same table           |
-| 4   | links        | USER#&lt;userId&gt;     | LINK#&lt;projectId&gt;#&lt;saveId&gt;                | Project ↔ Save               |
-| 5   | content      | CONTENT#&lt;urlHash&gt; | META                                                 | Global; not user-partitioned |
-| 6   | search-index | USER#&lt;userId&gt;     | INDEX#&lt;sourceType&gt;#&lt;sourceId&gt;            | Processed search substrate   |
-| 7   | invite-codes | CODE#&lt;code&gt;       | META                                                 | Lookup by code               |
+| #   | Table        | PK                                         | SK                                                   | Notes                               |
+| --- | ------------ | ------------------------------------------ | ---------------------------------------------------- | ----------------------------------- |
+| 1   | users        | USER#&lt;clerkId&gt;                       | PROFILE or APIKEY#&lt;keyId&gt;                      | Profiles + API keys                 |
+| 2   | saves        | USER#&lt;userId&gt;                        | SAVE#&lt;saveId&gt;                                  | urlHash links to content            |
+| 3   | projects     | USER#&lt;userId&gt;                        | PROJECT#&lt;projectId&gt; or FOLDER#&lt;folderId&gt; | Folders same table                  |
+| 4   | links        | USER#&lt;userId&gt;                        | LINK#&lt;projectId&gt;#&lt;saveId&gt;                | Project ↔ Save                      |
+| 5   | content      | CONTENT#&lt;urlHash&gt;                    | META                                                 | Global; not user-partitioned        |
+| 6   | search-index | USER#&lt;userId&gt;                        | INDEX#&lt;sourceType&gt;#&lt;sourceId&gt;            | Processed search substrate          |
+| 7   | invite-codes | CODE#&lt;code&gt;                          | META                                                 | Lookup by code                      |
+| 8   | idempotency  | pk (IDEMP#&lt;userId&gt;#&lt;key&gt;)      | — (partition key only)                               | Story 3.2.1; TTL expiresAt          |
+| 9   | events       | EVENTS#&lt;entityType&gt;#&lt;entityId&gt; | EVENT#&lt;timestamp&gt;#&lt;eventId&gt;              | Story 3.2.3; event history; TTL ttl |
 
 ## GSIs (10 total)
 

--- a/.claude/review-findings-3.2.3.md
+++ b/.claude/review-findings-3.2.3.md
@@ -1,0 +1,191 @@
+# Story 3.2.3 Code Review Findings - Round 1
+
+**Reviewer:** Agent (Fresh Context)
+**Date:** 2026-02-26
+**Branch:** story-3-2-3-event-history-infrastructure
+
+## Critical Issues (Must Fix)
+
+1. **AC5 / AC8 deviation: Response envelope missing `hasMore` field**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/event-history.ts`, lines 79-84
+   - **Problem:** The story's AC5 specifies the response envelope must include `{ data, meta: { count, nextCursor, hasMore } }`. The implementation returns `{ data, meta: { cursor, total } }` -- it uses `cursor` instead of `nextCursor`, uses `total` instead of `count`, and completely omits `hasMore`. The AC8 test requirements for `createEventHistoryHandler()` also explicitly require `hasMore=false` for empty results.
+   - **Impact:** Consumers (agents) relying on `hasMore` to know whether to paginate will get `undefined`. This is a contract violation against the story's acceptance criteria. The underlying `queryItems` helper already returns `hasMore` from the `PaginatedResponse<T>` type, but `queryEntityEvents()` discards it.
+   - **Fix:** In `event-history.ts`, change the meta object to include `hasMore`. In `queryEntityEvents()` in `db/src/events.ts`, propagate the `hasMore` boolean from the `queryItems` result. Update `EventHistoryResponse` type to include `hasMore: boolean`. Example:
+     ```typescript
+     return createSuccessResponse(result.events, requestId, {
+       meta: {
+         cursor: result.nextCursor,
+         total: result.events.length,
+         hasMore: result.nextCursor !== null, // or propagate from queryItems
+       },
+     });
+     ```
+
+2. **AC3 deviation: Validation uses hand-rolled checks instead of Zod schema**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/db/src/events.ts`, lines 70-100
+   - **Problem:** AC3 states "Validates required fields via Zod schema before writing" and AC8 test spec says "Validates required fields via Zod -- rejects missing ...". The implementation uses a hand-rolled `validateRecordEventParams()` function with manual string checks instead of a Zod schema. The project has `@ai-learning-hub/validation` with Zod schemas as a shared library pattern (per CLAUDE.md).
+   - **Impact:** Inconsistency with the codebase's established validation pattern. Zod provides type-safe parsing, better error messages, and composability. The hand-rolled validation is functionally correct but violates the explicit AC.
+   - **Fix:** Replace the hand-rolled validation with a Zod schema:
+     ```typescript
+     import { z } from "zod";
+     const RecordEventParamsSchema = z.object({
+       entityType: z.enum([
+         "save",
+         "project",
+         "tutorial",
+         "link",
+         "user",
+         "apiKey",
+       ]),
+       entityId: z.string().min(1),
+       userId: z.string().min(1),
+       eventType: z.string().min(1),
+       actorType: z.enum(["human", "agent"]),
+       actorId: z.string().nullable().optional(),
+       changes: z.any().nullable().optional(),
+       context: z.any().nullable().optional(),
+       requestId: z.string().min(1),
+     });
+     ```
+
+3. **Response leaks DynamoDB internal fields (PK, SK, ttl) to API consumers**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/event-history.ts`, lines 71-84
+   - **Problem:** The handler returns `result.events` directly from `queryEntityEvents()`, which returns `EntityEvent[]` containing `PK`, `SK`, and `ttl` fields. The types file defines `PublicEntityEvent = Omit<EntityEvent, "PK" | "SK" | "ttl">` specifically for stripping these fields, but it is never used. The story's response examples in Dev Notes (lines 405-438) show responses WITHOUT PK/SK/ttl.
+   - **Impact:** DynamoDB internal key structure is leaked to API consumers. This exposes implementation details (key patterns like `EVENTS#save#...`) and unnecessary data (epoch TTL). This is a data leakage issue.
+   - **Fix:** Map events to `PublicEntityEvent` before returning:
+     ```typescript
+     const publicEvents = result.events.map(({ PK, SK, ttl, ...rest }) => rest);
+     return createSuccessResponse(publicEvents, requestId, { ... });
+     ```
+
+## Important Issues (Should Fix)
+
+4. **`parseInt` of invalid `limit` param produces NaN, passed unchecked to DynamoDB**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/event-history.ts`, line 69
+   - **Problem:** `parseInt("abc", 10)` returns `NaN`. This `NaN` is passed to `queryEntityEvents()` which then passes it to `Math.min(NaN, 200)` which returns `NaN`, then to `queryItems` which sets `Limit: NaN` on the DynamoDB command. DynamoDB will reject this with a `SerializationException`.
+   - **Impact:** Invalid `limit` query parameter causes an unhandled DynamoDB error that returns as a generic 500 `INTERNAL_ERROR` instead of a user-friendly 400 `VALIDATION_ERROR`.
+   - **Fix:** Validate the parsed limit in `event-history.ts`:
+     ```typescript
+     let limit: number | undefined;
+     if (limitParam) {
+       limit = parseInt(limitParam, 10);
+       if (isNaN(limit) || limit < 1) {
+         throw new AppError(
+           ErrorCode.VALIDATION_ERROR,
+           "Invalid query parameter",
+           {
+             fields: [
+               {
+                 field: "limit",
+                 message: "Must be a positive integer",
+                 code: "invalid_type",
+               },
+             ],
+           }
+         );
+       }
+     }
+     ```
+
+5. **Test for WARN-level logging on DynamoDB failure actually asserts a throw, contradicting AC3**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/db/test/events.test.ts`, lines 173-179
+   - **Problem:** AC3 states "`recordEvent()` is non-critical. Callers MUST wrap in try/catch and log failures at WARN level without re-throwing." AC8 test spec says "Logs at WARN level on DynamoDB write failure (does NOT throw)". But the test at line 173 asserts that `recordEvent` _throws_ on DynamoDB failure (`rejects.toThrow("Database operation failed")`). The comment at line 176 acknowledges this: "recordEvent itself throws AppError because putItem wraps errors". This means `recordEvent()` DOES throw, which contradicts the fire-and-forget design specified in AC3.
+   - **Impact:** The function's behavior violates its own documented contract. Every caller must add try/catch, and if a caller forgets, the primary operation fails because an event couldn't be recorded. The AC explicitly says recordEvent should handle errors internally.
+   - **Fix:** Either (a) wrap the `putItem` call inside `recordEvent` in try/catch, log WARN, and return a partial result or null on failure, OR (b) accept the current design (callers handle errors) and update the test name and AC documentation to match. Option (a) is safer and matches the AC more closely:
+     ```typescript
+     try {
+       await putItem(client, EVENTS_TABLE_CONFIG, event, {}, log);
+     } catch (err) {
+       log.warn("Event recording failed (fire-and-forget)", err as Error, {
+         eventId,
+         entityType: params.entityType,
+         entityId: params.entityId,
+       });
+       return event; // return the event object even on write failure
+     }
+     ```
+
+6. **Negative `limit` values are not rejected**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/db/src/events.ts`, lines 259-262
+   - **Problem:** `Math.min(-5, 200)` returns `-5`, which would be passed as `Limit: -5` to DynamoDB. DynamoDB requires Limit to be a positive integer and will reject this.
+   - **Impact:** A caller passing `limit: -1` or `limit: 0` will get a DynamoDB error surfaced as a 500 instead of a clear validation error.
+   - **Fix:** Clamp the limit to at least 1: `const limit = Math.max(1, Math.min(options?.limit ?? DEFAULT_QUERY_LIMIT, MAX_QUERY_LIMIT));`
+
+7. **Cursor is base64 not base64url as specified in AC4**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/db/src/events.ts` (implicitly via `queryItems` in helpers.ts)
+   - **Problem:** AC4 specifies "decodes opaque base64url cursor" and "base64url-encoded LastEvaluatedKey". The existing `helpers.ts` cursor implementation (lines 197-211) uses plain `base64` encoding (`Buffer.from(...).toString("base64")`) not `base64url`. The `+`, `/`, and `=` characters in base64 are not URL-safe and can cause issues in query strings without percent-encoding.
+   - **Impact:** Cursors with `+` or `/` characters may be corrupted when passed as query parameters without URL encoding. In practice, DynamoDB keys that are simple strings rarely produce these characters, but it is a latent bug.
+   - **Fix:** This is a pre-existing issue in `helpers.ts`, not introduced by this story. Consider noting it for a follow-up, or the event history handler could URL-encode/decode the cursor at the middleware layer.
+
+8. **Missing test: soft-deleted entities (AC8 requirement)**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/test/event-history.test.ts`
+   - **Problem:** AC8 explicitly lists "Works for soft-deleted entities (entityExistsFn returns true)" as a required test scenario for `createEventHistoryHandler()`. No such test exists. AC5 also emphasizes "The function MUST return true for both active AND soft-deleted entities."
+   - **Impact:** A key contract requirement (event history accessible for deleted entities) has no test coverage.
+   - **Fix:** Add a test case:
+     ```typescript
+     it("should return events for soft-deleted entities when entityExistsFn returns true", async () => {
+       mockEntityExistsFn.mockResolvedValueOnce(true); // soft-deleted but still returns true
+       mockQueryEntityEvents.mockResolvedValueOnce({ events: [...], nextCursor: null });
+       const result = await handler(makeCtx());
+       expect(result).toHaveProperty("statusCode", 200);
+     });
+     ```
+
+9. **Missing test: VALIDATION_ERROR for non-ISO `since` parameter (AC8 requirement)**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/test/event-history.test.ts`
+   - **Problem:** AC8 lists "Returns 400 VALIDATION_ERROR for non-ISO `since` parameter" as a required test scenario for `createEventHistoryHandler()`. The handler delegates this to `queryEntityEvents()` which does validate, but there is no test in the middleware test file verifying the handler propagates this error correctly.
+   - **Impact:** Missing coverage for an explicitly required test scenario.
+   - **Fix:** Add a test that passes an invalid `since` and asserts the error propagates.
+
+10. **`EventHistoryResponse.events` returns `EntityEvent[]` but `nextCursor` type mismatch with `PaginatedResponse`**
+    - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/types/src/events.ts`, line 93
+    - **Problem:** `EventHistoryResponse` defines `nextCursor: string | null` but the underlying `PaginatedResponse` from `queryItems` defines `nextCursor?: string` (optional, not nullable). In `queryEntityEvents()` line 291, `result.nextCursor ?? null` converts `undefined` to `null`, which is correct. However, the dual pagination types (`PaginatedResponse` vs `EventHistoryResponse`) with subtly different nullability semantics is confusing.
+    - **Impact:** Minor type confusion for future maintainers. Not a runtime bug since the `?? null` coercion is applied.
+    - **Fix:** Consider documenting the intentional divergence, or aligning both types.
+
+## Minor Issues (Nice to Have)
+
+11. **Redundant `as` casts on already-validated types**
+    - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/db/src/events.ts`, lines 190, 192, 197
+    - **Problem:** Lines like `params.entityType as EventEntityType` and `params.actorType as "human" | "agent"` cast types that have already been validated. After validation passes, the types are already narrowed. These casts add noise.
+    - **Impact:** Code readability. No runtime impact.
+    - **Fix:** Remove the `as` casts, or restructure validation to use Zod parse which returns properly typed output.
+
+12. **Test uses `expect/try/catch` anti-pattern instead of proper assertion**
+    - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/test/event-history.test.ts`, lines 78-84, 88-96, 98-109
+    - **Problem:** Multiple tests do `await expect(handler(ctx)).rejects.toThrow(AppError)` then immediately call `handler(ctx)` AGAIN inside a `try/catch` to check the error code. This calls the handler twice per test, is fragile (second call may have different mock state), and is unnecessarily complex.
+    - **Impact:** Test reliability. The second handler invocation at line 103 actually needs a fresh `mockEntityExistsFn.mockResolvedValueOnce(false)` to avoid passing (which is done, but it is error-prone).
+    - **Fix:** Use a single invocation pattern:
+      ```typescript
+      await expect(handler(ctx)).rejects.toMatchObject({
+        code: ErrorCode.VALIDATION_ERROR,
+        message: "Missing entity ID in path",
+      });
+      ```
+
+13. **`VALID_ENTITY_TYPES` array duplicates the `EventEntityType` union type definition**
+    - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/db/src/events.ts`, lines 53-60
+    - **Problem:** The valid entity types are defined as a TypeScript union in `types/src/events.ts` AND as a runtime array in `db/src/events.ts`. If a new entity type is added to the union but not the array (or vice versa), validation will silently diverge from the type system.
+    - **Impact:** Maintainability risk. Adding a new entity type requires updating two places.
+    - **Fix:** Derive one from the other. Define the array as `const VALID_ENTITY_TYPES = ["save", "project", ...] as const` in types, then derive the union: `type EventEntityType = (typeof VALID_ENTITY_TYPES)[number]`. This is another argument for using Zod enums.
+
+14. **`truncateChanges` measures bytes with `JSON.stringify().length` which counts UTF-16 code units, not bytes**
+    - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/db/src/events.ts`, lines 129-130
+    - **Problem:** `JSON.stringify(changes).length` returns the number of UTF-16 code units, not bytes. For ASCII content this is equivalent, but multi-byte Unicode characters (emoji, CJK) would have `length` undercount actual byte size. The comment says "bytes" but it measures characters.
+    - **Impact:** Edge case. For typical event diffs with field names and values in ASCII/Latin, this is fine. Emoji-heavy content could exceed 10KB in bytes while appearing under 10KB in character count.
+    - **Fix:** Either use `Buffer.byteLength(serialized, 'utf-8')` for accurate byte measurement, or change the comment to say "characters" instead of "bytes". Low priority.
+
+15. **Events table CDK output missing ARN export**
+    - **File:** `/Users/stephen/Documents/ai-learning-hub/infra/lib/stacks/core/tables.stack.ts`, lines 287-291
+    - **Problem:** Story Task 5.2 says "Export eventsTable and its grantReadWriteData() method from the tables stack so API stacks can grant permissions." The `eventsTable` property is exposed on the stack class (line 19), but the CfnOutput only exports the table name, not the ARN. Other stacks may need the ARN for IAM policy construction.
+    - **Impact:** Low -- CDK cross-stack references via the public property handle this for most use cases. But for non-CDK consumers or CloudFormation-only references, the ARN output would be useful. Existing tables also only export names, so this is consistent.
+    - **Fix:** Optional. Add `AiLearningHub-EventsTableArn` output if needed by downstream stories.
+
+## Summary
+
+- **Total findings:** 15
+- **Critical:** 3 (missing `hasMore` in envelope, no Zod validation per AC, PK/SK/ttl leaked to API)
+- **Important:** 7 (NaN limit, fire-and-forget contract violation, negative limit, base64 vs base64url, missing tests for soft-delete and invalid since, type mismatch)
+- **Minor:** 5 (redundant casts, test anti-pattern, duplicate entity type definitions, byte vs character measurement, missing ARN export)
+
+- **Recommendation:** **CONCERNS** -- Fix critical issues #1 (missing `hasMore`), #3 (PK/SK/ttl leak), and #5 (fire-and-forget semantics), plus important issue #4 (NaN limit handling) before merging. Issue #2 (Zod vs hand-rolled validation) is an explicit AC requirement but functionally equivalent -- discuss with product owner whether to enforce. The remaining issues are improvements that can be addressed in this PR or deferred.

--- a/.claude/review-findings-3.2.4.md
+++ b/.claude/review-findings-3.2.4.md
@@ -1,0 +1,95 @@
+# Story 3.2.4 Code Review Findings - Round 1
+
+**Reviewer:** Agent (Fresh Context)
+**Date:** 2026-02-26
+**Branch:** story-3-2-4-agent-identity-context-rate-limit
+
+## Critical Issues (Must Fix)
+
+1. **Per-route CORS configs missing X-Agent-ID allowHeader and exposeHeaders (AC13/AC14 violation)**
+   - **Files:**
+     - `/Users/stephen/Documents/ai-learning-hub/infra/lib/stacks/api/saves-routes.stack.ts`:66-78
+     - `/Users/stephen/Documents/ai-learning-hub/infra/lib/stacks/api/auth-routes.stack.ts`:69-81
+   - **Problem:** Both route stacks define their own local `corsOptions` objects with hardcoded `allowHeaders` lists (lines 69-76 in each). These per-route CORS configs do NOT inherit from the global `defaultCorsPreflightOptions` set in `api-gateway.stack.ts` (the auth-routes comment at line 66-68 explicitly explains this: "imported APIs do NOT inherit the original RestApi's defaultCorsPreflightOptions"). The story added `X-Agent-ID` to the global CORS `allowHeaders` and added `exposeHeaders` in `api-gateway.stack.ts`, but did NOT update the per-route CORS configs. As a result, browser-based agents hitting `/saves`, `/saves/{saveId}`, `/auth/validate-invite`, `/users/me`, `/users/api-keys`, `/users/api-keys/{id}`, and `/users/invite-codes` will get CORS preflight responses that:
+     - Do NOT include `X-Agent-ID` in `Access-Control-Allow-Headers` (browsers will reject the request)
+     - Do NOT include ANY `Access-Control-Expose-Headers` (browsers cannot read `X-RateLimit-*`, `X-Agent-ID`, `Retry-After`, etc. from JavaScript)
+     - Are also missing `Idempotency-Key` and `If-Match` from Story 3.2.1 (pre-existing gap, but AC13 says to fix "any per-route corsOptions definitions")
+   - **Impact:** All browser-based agent clients sending `X-Agent-ID` will fail CORS preflight on every route except the root. The rate limit transparency headers will be invisible to browser JavaScript. AC13 and AC14 are not met for per-route resources.
+   - **Fix:** Update the `corsOptions` object in both `saves-routes.stack.ts` and `auth-routes.stack.ts` to include:
+     ```typescript
+     allowHeaders: [
+       "Content-Type",
+       "Authorization",
+       "x-api-key",
+       "X-Amz-Date",
+       "X-Api-Key",
+       "X-Amz-Security-Token",
+       "Idempotency-Key",  // Story 3.2.1
+       "If-Match",         // Story 3.2.1
+       "X-Agent-ID",       // Story 3.2.4
+     ],
+     exposeHeaders: [
+       "X-Request-Id",
+       "X-RateLimit-Limit",
+       "X-RateLimit-Remaining",
+       "X-RateLimit-Reset",
+       "X-Agent-ID",
+       "X-Idempotent-Replayed",
+       "X-Idempotency-Status",
+       "Retry-After",
+     ],
+     ```
+     Alternatively, consider extracting a shared CORS config constant to avoid this divergence in the future.
+
+## Important Issues (Should Fix)
+
+2. **X-Agent-ID echo logic duplicated 3 times with inconsistent mutation style in wrapper.ts**
+   - **Files:**
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/wrapper.ts`:270-278 (rate-limit 429 early return -- immutable spread)
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/wrapper.ts`:417-425 (success path -- immutable spread)
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/wrapper.ts`:450-453 (catch block -- direct mutation via cast)
+   - **Problem:** The logic for conditionally adding `X-Agent-ID` to a response is written three separate times. Two paths use immutable spread (`{ ...response, headers: { ...response.headers, "X-Agent-ID": ... } }`), while the catch block at line 450-453 uses direct mutation: `(errorResponse.headers as Record<string, string>)["X-Agent-ID"] = agentIdentity.agentId`. The direct mutation relies on the assumption that `errorResponse.headers` is a mutable object (which happens to be true because `handleError` creates a fresh object, but this is an implicit coupling). If any response decoration logic changes (e.g., adding sanitization, prefixing, or conditional logic), all 3 sites must be updated in sync. The same inconsistency exists for the rate limit header decoration (lines 440-447 use `addRateLimitHeaders` then mutate `errorResponse.headers`, while lines 408-414 use the function directly).
+   - **Impact:** Maintenance risk. The mixed mutation/spread style makes it easy to introduce bugs when modifying one path but not another. The catch-block mutation pattern bypasses the immutability guarantees of the try-block pattern.
+   - **Fix:** Extract a helper function like `addAgentIdHeader(response, agentId)` that returns a new response object, and use it at all 3 call sites. Consider also consolidating all post-handler response decoration (rate limit headers + agent ID echo) into a single function called at every return point.
+
+3. **`calculateRateLimitReset` returns current time at exact window boundaries (zero remaining)**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/rate-limit-headers.ts`:32-37
+   - **Problem:** When a request arrives at exactly a window boundary (e.g., `T=13:00:00.000Z` for a 1-hour window), `Math.ceil(now / windowMs)` does not round up because the division is exact. This means `calculateRateLimitReset` returns the current timestamp as the reset time, implying "the window resets now" -- which means `X-RateLimit-Reset` points to the present or past. An agent receiving this response would interpret it as "the window has just reset" and could immediately send another burst of requests, even though the counter reflects the old (full) window. The rate-limiter's `getWindowKey` function uses `Math.floor` for the window start and a different boundary calculation, so the two functions may disagree about which window a boundary-exact request belongs to. The test at line 32-34 of `rate-limit-headers.test.ts` asserts this behavior, so it passes, but the semantic is potentially confusing for API consumers.
+   - **Impact:** At exact window boundaries, agents see `X-RateLimit-Reset` equal to the current time, which is a degenerate case. In practice this rarely happens (millisecond precision alignment), but it is a logic gap that could cause agent self-throttling algorithms to behave incorrectly at boundaries.
+   - **Fix:** Consider adding 1 window to the reset when `now` is exactly on a boundary: `const windowEnd = (now % windowMs === 0) ? now + windowMs : Math.ceil(now / windowMs) * windowMs;`. This ensures the reset always points to a future time. Alternatively, document the boundary behavior in the function's JSDoc so downstream consumers are aware.
+
+4. **Rate limit 429 early-return path runs `Retry-After` header through two separate paths**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/src/wrapper.ts`:254-279
+   - **Problem:** When rate limit is exceeded, the code at line 254-261 creates an `AppError` with `retryAfter` in details, then calls `handleError` at line 263. Inside `handleError` -> `createErrorResponse` (error-handler.ts line 48-49), the `Retry-After` header is set from `bodyDetails.retryAfter`. Then at line 264, `addRateLimitHeaders` is called, which internally calls `buildRateLimitHeaders`, which also adds `Retry-After` from `result.retryAfterSeconds` (rate-limit-headers.ts line 52-54). The second set overwrites the first via spread, and both values happen to be the same (`result.retryAfterSeconds`), so there is no functional bug. However, this double-path for the same header is fragile -- if one source changes its format (e.g., to ISO 8601), the other would silently override it.
+   - **Impact:** No current bug, but the redundancy creates a maintenance trap. A developer modifying the `Retry-After` format in one location might not realize it is set in two independent code paths for this specific flow.
+   - **Fix:** Either (a) remove `retryAfter` from the `AppError` details for the 429 case in wrapper.ts (so `createErrorResponse` does not emit `Retry-After`), letting `addRateLimitHeaders` be the sole source, or (b) skip `Retry-After` in `buildRateLimitHeaders` when `addRateLimitHeaders` is called (add a flag or separate function). Option (a) is simpler but would change the error body `details.retryAfter`; option (b) is cleaner but more work.
+
+## Minor Issues (Nice to Have)
+
+5. **`makeEvent` test factory duplicated across middleware test files instead of using shared `createMockEvent`**
+   - **Files:**
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/test/agent-identity.test.ts`:8-52
+     - `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/test/rate-limit-integration.test.ts`:54-105
+   - **Problem:** Both new test files define their own `makeEvent()` factory with a full `APIGatewayProxyEvent` skeleton (15+ fields of the identity block). The shared `createMockEvent` function in `/Users/stephen/Documents/ai-learning-hub/backend/test-utils/mock-wrapper.ts`:74-140 serves the same purpose and is already used by handler tests. Using the shared factory would reduce code and ensure consistent test event shapes.
+   - **Impact:** Low. Test duplication is common practice, but 50+ lines of identical boilerplate per test file adds up. Changes to the `APIGatewayProxyEvent` mock shape require updating every copy.
+   - **Fix:** Import `createMockEvent` from `backend/test-utils/mock-wrapper.ts` and pass custom headers via the options parameter (would need to extend `MockEventOptions` to accept custom headers).
+
+6. **`eventContextSchema` does not validate that `trigger` and `source` are non-empty strings when present**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/validation/src/event-context.ts`:14-15
+   - **Problem:** `trigger: z.string().max(100).optional()` and `source: z.string().max(200).optional()` accept empty strings (`""`). While the fields are optional (can be omitted), when present, an empty string is likely a client bug. The AC5 spec says "z.string().max(100).optional()" which technically matches the implementation, but the `X-Agent-ID` header validates a minimum length of 1 character -- applying the same principle here would be consistent.
+   - **Impact:** Low. Empty-string context values would be stored in event history records but provide no useful information. Not a correctness issue since the schema matches the AC exactly.
+   - **Fix:** Consider adding `.min(1)` to `trigger`, `source`, and `upstream_ref` to reject empty strings when present. This would be a stricter interpretation of the AC but more defensive.
+
+7. **No test for `X-Agent-ID` echo on idempotent-replay responses**
+   - **File:** `/Users/stephen/Documents/ai-learning-hub/backend/shared/middleware/test/rate-limit-integration.test.ts`
+   - **Problem:** The integration tests verify `X-Agent-ID` echo on success responses, error responses, and rate-limited 429 responses. However, there is no test for the case where `options.idempotent` is true and the handler returns a cached idempotent replay (lines 303-306 in wrapper.ts: `return cachedResponse`). The idempotent-replay path returns early BEFORE the X-Agent-ID echo logic at line 417-425 executes, meaning idempotent-replay responses would NOT include the `X-Agent-ID` echo header.
+   - **Impact:** Agents sending `X-Agent-ID` on idempotent requests that hit the replay cache will not see their agent ID echoed back. This is arguably acceptable (the response is a replay), but it is an inconsistency with AC4 ("ALL responses include an X-Agent-ID response header"). The same gap exists for the rate limit headers on idempotent replays.
+   - **Fix:** Either (a) document that idempotent replays do not include `X-Agent-ID` echo (acceptable tradeoff), or (b) add `X-Agent-ID` decoration to the idempotent-replay early-return path at lines 303-306 in wrapper.ts.
+
+## Summary
+
+- **Total findings:** 7
+- **Critical:** 1
+- **Important:** 3
+- **Minor:** 3
+- **Recommendation:** FIX REQUIRED -- Critical #1 blocks browser-based agent clients from sending `X-Agent-ID` or reading rate limit headers on all per-route resources (`/saves`, `/auth/*`, `/users/*`). This is a straightforward CORS config update in two CDK stack files. Important issues #2-#4 are code quality and correctness concerns that reduce maintenance risk.

--- a/.claude/review-findings-3.2.6.md
+++ b/.claude/review-findings-3.2.6.md
@@ -1,0 +1,40 @@
+# Story 3.2.6 Code Review Findings - Round 1
+
+**Date:** 2026-02-27 | **Branch:** story-3-2-6-impl-scoped-api-key-permissions
+
+## Critical Issues
+
+### R1: Unsafe `as ApiKeyScope[]` type assertions bypass runtime validation
+- auth.ts:47,51 - casts raw authorizer values without validation
+- Fix: Filter parsed scopes against known valid values
+
+### R2: SCOPE_GRANTS uses Record<string,...> instead of Record<ApiKeyScope,...>
+- scope-resolver.ts:13 - loses compile-time exhaustiveness checking
+- Fix: Type as Record<ApiKeyScope,...> with satisfies
+
+## Important Issues
+
+### R3: WrapperOptions.requiredScope remains string instead of OperationScope (AC16 incomplete)
+- wrapper.ts:81 - should be OperationScope per AC16
+- Fix: Change type to OperationScope
+
+### R4: Duplicated SCOPE_GRANTS in mock-wrapper.ts (same as dedup finding #2)
+- mock-wrapper.ts:230-250 - full copy of SCOPE_GRANTS
+- Fix: Import from scope-resolver directly
+
+### R5: requireScope accepts string instead of OperationScope
+- auth.ts:118 - should accept OperationScope per AC16
+- Fix: Change parameter type
+
+### R6: allowedActions placement relies on implicit handleError promotion
+- auth.ts:128-134, wrapper.ts:203-210 - implicit coupling
+- Fix: Add comments documenting the promotion pattern
+
+## Minor Issues
+
+### R7: OperationScope includes users:write but no test verifies it
+### R8: Missing test for empty requiredScope string
+### R9: Story touches lists files not modified (docs only)
+### R10: No Object.freeze() on SCOPE_GRANTS
+
+## Summary: 2 critical, 4 important, 4 minor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,12 +13,14 @@ cd infra && cdk deploy  # Deploy infrastructure
 ## Project Structure
 
 ```
-/frontend            # React + Vite PWA
-/backend             # Lambda function handlers
-/infra               # AWS CDK stacks (15+)
-/shared              # @ai-learning-hub/* packages
-/.claude/docs/       # Detailed docs (load on-demand)
-/.claude/commands/   # Custom slash commands
+/frontend                        # React + Vite PWA
+/backend                         # Lambda function handlers
+  /backend/shared/               # @ai-learning-hub/* packages (logging, middleware, db, validation, types, events)
+/infra                           # AWS CDK stacks (15+)
+/.claude/docs/                   # Detailed docs (load on-demand)
+/.claude/commands/               # Custom slash commands
+/_bmad-output/planning-artifacts/ # Canonical epics & story list (epics.md), PRD, architecture — do not edit for product docs
+/docs/progress/                  # Epic progress, completion reports, story-level progress (epic-N.md, docs/stories/N.M/progress.md)
 ```
 
 ## Tech Stack
@@ -41,6 +43,7 @@ All Lambdas MUST import from `@ai-learning-hub/*`:
 - `@ai-learning-hub/db` - DynamoDB client + query helpers
 - `@ai-learning-hub/validation` - Zod schemas
 - `@ai-learning-hub/types` - Shared TypeScript types
+- `@ai-learning-hub/events` - EventBridge client + emit helpers (use when publishing domain events)
 
 ### API-First Design
 
@@ -48,12 +51,39 @@ All Lambdas MUST import from `@ai-learning-hub/*`:
 - All async via EventBridge + Step Functions
 - Standardized error responses (ADR-008)
 
+### Agent-Native / Agentic-Friendly API (Epic 3.2)
+
+APIs are designed so AI agents can call them safely and recover from failures. All list and mutation endpoints must follow these patterns:
+
+- **Idempotency:** Mutations accept `Idempotency-Key` header; duplicate requests replay the same response (no double side effects).
+- **Optimistic concurrency:** Where applicable, use `If-Match: <version>`; conflicts return 409 with `currentState` / `allowedActions` so the agent knows what to do next.
+- **Error contract:** Every error includes `code`, `message`, `requestId`; state/conflict errors include `currentState`, `allowedActions`, and optionally `requiredConditions`. Field validation errors include `field`, `constraint`, `allowed_values`.
+- **Response envelope:** Success responses use `{ data, meta?, links? }` with `meta.cursor`, `meta.rateLimit`, `links.self` / `links.next` for lists.
+- **Cursor pagination only:** No offset/page numbers; use opaque cursors and `links.next`.
+- **Agent identity:** Support `X-Agent-ID`; record `actorType` (human | agent) in event history.
+- **Rate limit transparency:** Responses expose `X-RateLimit-*` (and `meta.rateLimit`) so agents can back off.
+- **Scoped API keys:** Enforce `requiredScope` per endpoint; return 403 with `required_scope` / `granted_scopes` when insufficient.
+- **Action discoverability:** Where implemented, single-resource GETs include `meta.actions`; `GET /actions` catalogs what the API supports so agents can discover operations before calling them.
+
+Details: `.claude/docs/api-patterns.md`.
+
 ### DynamoDB Keys
 
 - User tables: `PK=USER#{userId}`, `SK=<entity>#<id>`
 - Content table: `PK=CONTENT#{urlHash}`
 
 ## Commands
+
+### Development Lifecycle (BMAD)
+
+- `/bmad-bmm-create-story` - Create next story file from epics with full context analysis
+- `/bmad-bmm-dev-story` - Implement a single story (TDD, hooks-enforced)
+- `/bmad-bmm-code-review` - Adversarial code review with auto-fix
+- `/bmad-bmm-auto-epic` - Autonomous epic implementation (stories + review loops + checkpoints)
+- `/bmad-bmm-sprint-planning` - Initialize/update sprint-status.yaml
+- `/bmad-bmm-sprint-status` - View sprint status and surface risks
+
+### Project Utilities
 
 - `/project-start-story` - Start story/task work with branch + issue + PR workflow (enforces habit)
 - `/project-fix-github-issue N` - Fix issue #N
@@ -107,13 +137,22 @@ For **story/task work** (epic implementation, BMAD stories, features, bugs), use
 - Read progress.md before starting work
 - Update progress.md after completing work
 
+## Greenfield Project Rules
+
+This project has never been deployed. There are zero users and zero live environments.
+
+- When retrofitting or refactoring, **delete the old approach entirely** — no compatibility shims, deprecated wrappers, or re-exports
+- Never warn about "breaking changes" related to existing users — there are no consumers to break
+- Never preserve dead code "in case we revert" — git history exists for that
+- Old tests for removed behavior should be deleted or rewritten, not kept alongside new ones
+- No `@deprecated` annotations — delete the code instead
+
 ## Current Status
 
-Phase: Planning Complete, Ready for Epic 1
+Phase: Implementation in progress
 
-- PRD: 81 FRs, 28 NFRs documented
-- Architecture: 16 ADRs finalized
-- Epics: 11 epics defined, stories pending
+- PRD: 81 FRs, 28 NFRs documented. Architecture: 16 ADRs finalized. Epics: 11 defined.
+- Epic 1 (Foundation), Epic 2 (Auth), Epic 3 (Saves), and Epic 3.2 (Agent-Native API) are largely complete. Story 3.2.10 (action discoverability) in progress; Epics 4+ not yet started.
 
 ## Key Docs
 

--- a/_bmad/bmm/workflows/4-implementation/create-story/checklist.md
+++ b/_bmad/bmm/workflows/4-implementation/create-story/checklist.md
@@ -70,6 +70,39 @@ You will systematically re-do the entire story creation process, but with a crit
 
 **Note:** If running in fresh context, user should provide the story file path being reviewed. If running from create-story workflow, the validation framework will automatically discover the checklist and story file.
 
+### **Step 1.5: Structural Format Validation (Auto-Epic Compatibility)**
+
+**CRITICAL: These format checks ensure the story file is machine-parseable by the auto-epic orchestrator. Format failures here will cause orchestrator FATAL STOPs or incorrect behavior.**
+
+#### **1.5.1 YAML Frontmatter Validation**
+
+The story file MUST begin with a valid YAML frontmatter block (`---` delimiters). Verify:
+
+- [ ] File starts with `---` on line 1
+- [ ] Frontmatter contains `id` field (quoted string, dot notation, e.g., `"3.2.7"`)
+- [ ] Frontmatter contains `title` field (quoted string, non-empty)
+- [ ] Frontmatter contains `status` field (value: `ready-for-dev`)
+- [ ] Frontmatter contains `depends_on` field (YAML array of story ID strings, or empty `[]`)
+- [ ] Frontmatter contains `touches` field (YAML array of file/directory path strings, or empty `[]`)
+- [ ] Frontmatter contains `risk` field (value: `low`, `medium`, or `high`)
+- [ ] Frontmatter ends with closing `---`
+
+**If any frontmatter field is missing or malformed, this is a CRITICAL finding that must be fixed.**
+
+#### **1.5.2 Acceptance Criteria Format Validation**
+
+ACs must follow the flat numbered list format for reliable machine parsing. Verify:
+
+- [ ] Story contains a `## Acceptance Criteria` heading
+- [ ] ACs are a single flat numbered list (no sub-headings like `### Group Name` within the AC section)
+- [ ] Each AC follows the format: `N. **ACN: Short name** — Description`
+- [ ] ACs are numbered sequentially starting at 1
+- [ ] At least 2 concrete, testable ACs are present
+- [ ] No BDD Given/When/Then format (use direct requirement statements instead)
+- [ ] Each AC is self-contained and testable — not a vague placeholder
+
+**If ACs use sub-headings, BDD format, or inconsistent numbering, this is a CRITICAL finding that must be fixed.**
+
 ### **Step 2: Exhaustive Source Document Analysis**
 
 **🔥 CRITICAL: Treat this like YOU are creating the story from scratch to PREVENT DISASTERS!**

--- a/_bmad/bmm/workflows/4-implementation/create-story/instructions.xml
+++ b/_bmad/bmm/workflows/4-implementation/create-story/instructions.xml
@@ -190,7 +190,16 @@
     original documents <!-- Extract specific story requirements -->
     <action>Extract our story ({{epic_num}}-{{story_num}}) details:</action> **STORY FOUNDATION:** - User story statement
     (As a, I want, so that) - Detailed acceptance criteria (already BDD formatted) - Technical requirements specific to this story -
-    Business context and value - Success criteria <!-- Previous story analysis for context continuity -->
+    Business context and value - Success criteria
+
+    <!-- Extract YAML frontmatter metadata from epics analysis -->
+    <critical>YAML FRONTMATTER EXTRACTION - Required by auto-epic orchestrator for machine parsing</critical>
+    <action>Extract and store these values for the YAML frontmatter block:
+      - depends_on: Array of story IDs this story depends on (e.g., ["3.2.1", "3.2.2"]). Use empty array [] if none.
+      - touches: Array of file/directory paths this story will create or modify (e.g., [backend/functions/saves/handler.ts, infra/lib/stacks/api/saves-routes.stack.ts]). Derive from epics content, architecture analysis, and story requirements. Be specific — list actual file paths, not directories when known.
+      - risk: low | medium | high — based on scope, dependency count, and architectural impact.
+    </action>
+    <!-- Previous story analysis for context continuity -->
     <check if="story_num > 1">
       <action>Load previous story file: {{story_dir}}/{{epic_num}}-{{previous_story_num}}-*.md</action> **PREVIOUS STORY INTELLIGENCE:** -
     Dev notes and learnings from previous story - Review feedback and corrections needed - Files that were created/modified and their
@@ -261,11 +270,42 @@
 
     <action>Initialize from template.md:
     {default_output_file}</action>
+
+    <!-- YAML FRONTMATTER - MANDATORY for auto-epic orchestrator compatibility -->
+    <critical>YAML FRONTMATTER IS REQUIRED. The story file MUST begin with a valid YAML frontmatter block
+    delimited by --- lines. The auto-epic orchestrator (Phase 1.2) parses this block to extract story
+    metadata for dependency analysis, integration checkpoints, and readiness validation.</critical>
+    <action>Populate the YAML frontmatter with:
+      - id: "{{epic_num}}.{{story_num}}" (quoted string, dot notation)
+      - title: "{{story_title}}" (quoted string)
+      - status: ready-for-dev
+      - depends_on: {{depends_on_yaml}} (YAML array of story IDs from Step 2, e.g., ["3.2.1", "3.2.2"] or [] if none)
+      - touches: {{touches_yaml}} (YAML array of file paths from Step 2)
+      - risk: {{risk_level}} (low | medium | high)
+    </action>
+
     <template-output file="{default_output_file}">story_header</template-output>
 
     <!-- Story foundation from epics analysis -->
     <template-output
       file="{default_output_file}">story_requirements</template-output>
+
+    <!-- ACCEPTANCE CRITERIA FORMAT - MANDATORY for auto-epic AC verification -->
+    <critical>AC FORMAT ENFORCEMENT. All acceptance criteria MUST use this exact format:
+      - Single flat numbered list under the ## Acceptance Criteria heading
+      - Each AC is one numbered item with a bold label and em-dash description:
+        N. **ACN: Short descriptive name** — Concrete, testable criterion with expected behavior.
+      - Do NOT use sub-headings (### ...) to group ACs — grouping breaks machine parsing
+      - Do NOT use BDD Given/When/Then format — use direct requirement statements
+      - Each AC must be a single, self-contained, testable requirement
+      - Number ACs sequentially starting at 1 (AC1, AC2, AC3, ...)
+      - Keep each AC to 1-3 sentences — precise and actionable, not verbose paragraphs
+    </critical>
+    <action>Format all acceptance criteria as:
+      1. **AC1: Name** — Description of the testable requirement.
+      2. **AC2: Name** — Description of the testable requirement.
+      ...
+    </action>
 
     <!-- Developer context section - MOST IMPORTANT PART -->
     <template-output file="{default_output_file}">

--- a/_bmad/bmm/workflows/4-implementation/create-story/template.md
+++ b/_bmad/bmm/workflows/4-implementation/create-story/template.md
@@ -1,8 +1,13 @@
+---
+id: "{{epic_num}}.{{story_num}}"
+title: "{{story_title}}"
+status: ready-for-dev
+depends_on: {{depends_on_yaml}}
+touches: {{touches_yaml}}
+risk: {{risk_level}}
+---
+
 # Story {{epic_num}}.{{story_num}}: {{story_title}}
-
-Status: ready-for-dev
-
-<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
 ## Story
 
@@ -12,7 +17,10 @@ so that {{benefit}}.
 
 ## Acceptance Criteria
 
-1. [Add acceptance criteria from epics/PRD]
+<!-- AC format: flat numbered list, one AC per item, bold label, dash-separated description -->
+<!-- Example: 1. **AC1: Descriptive name** — Concrete, testable criterion with expected behavior. -->
+
+1. **AC1: {{ac_name}}** — {{ac_description}}
 
 ## Tasks / Subtasks
 

--- a/docs/epic-1-code-review-findings.md
+++ b/docs/epic-1-code-review-findings.md
@@ -1,0 +1,191 @@
+# Epic 1: Project Foundation & Developer Experience — Code Review Findings
+
+**Scope:** Monorepo layout, shared packages (`@ai-learning-hub/*`), Lambda layer usage, `.claude/` (docs, commands, hooks, agents), CI/CD, infra (DynamoDB, S3, observability), and any app or infra code added or touched for Epic 1.
+
+**Goal:** Improve clarity, consistency, and maintainability without changing behavior.
+
+---
+
+## 1. Dead or redundant code
+
+### 1.1 Unused re-export file: `backend/functions/invite-codes/schemas.ts`
+
+**Location:** `backend/functions/invite-codes/schemas.ts` (entire file).
+
+**What’s wrong:** The file only re-exports `paginationQuerySchema` from `@ai-learning-hub/validation`. The handler imports `paginationQuerySchema` directly from `@ai-learning-hub/validation`; nothing imports from `invite-codes/schemas.ts`.
+
+**Suggested change:** Remove `backend/functions/invite-codes/schemas.ts`. Keep the handler importing `paginationQuerySchema` (and `validateQueryParams`) from `@ai-learning-hub/validation`. If the “three-file pattern” (handler, test, schemas) is required for consistency, keep the file but document that it exists for pattern consistency and have the handler import from `./schemas.js` so the re-export is used.
+
+**Priority:** Low.
+
+---
+
+### 1.2 Session artifacts in `.claude/` root
+
+**Location:** `.claude/review-findings-*.md`, `.claude/dedup-findings-*.md` (e.g. `review-findings-3.2.3.md`, `dedup-findings-3.2.4.md`).
+
+**What’s wrong:** These look like session/epic-specific review or dedup outputs. Keeping them in the root of `.claude/` mixes long-term docs (e.g. `docs/`, `commands/`, `hooks/`) with one-off artifacts and can confuse what is canonical.
+
+**Suggested change:** Either (a) move such artifacts into a subfolder (e.g. `.claude/artifacts/` or `docs/review-artifacts/`) and add a one-line note in `.claude/docs/README.md`, or (b) add a short note in `.claude/docs/README.md` that `review-findings-*.md` and `dedup-findings-*.md` are ephemeral session outputs and may be archived or deleted.
+
+**Priority:** Low.
+
+---
+
+## 2. Naming and consistency
+
+### 2.1 Duplicate `AUTHORIZER_CACHE_TTL` constant
+
+**Location:**
+
+- `backend/functions/jwt-authorizer/handler.ts` (e.g. around line 34): `export const AUTHORIZER_CACHE_TTL = 300;`
+- `backend/functions/api-key-authorizer/handler.ts` (e.g. around line 38): `export const AUTHORIZER_CACHE_TTL = 300;`
+
+**What’s wrong:** The same constant and value are defined in two authorizer handlers. CDK or other consumers must import from one of them; if both are used, the concept is duplicated and could drift.
+
+**Suggested change:** Move to a single source of truth. Options: (1) Add a small shared constant module (e.g. `backend/shared/middleware/src/authorizer-constants.ts` or `backend/shared/constants.ts`) exporting `AUTHORIZER_CACHE_TTL = 300` and have both authorizers and infra import it; or (2) Export it from `@ai-learning-hub/middleware` (e.g. alongside `getClerkSecretKey`) and use it in both authorizers and in CDK when setting `resultsCacheTtl`.
+
+**Priority:** Medium.
+
+---
+
+### 2.2 Two names for the same validation error shape
+
+**Location:**
+
+- `backend/shared/validation/src/validator.ts`: `ValidationErrorDetail` (interface) and `formatZodErrors` return type.
+- `backend/shared/validation/src/index.ts`: exports `ValidationErrorDetail` and `type ValidationErrorDetail as FieldValidationError`.
+- `backend/shared/types/src/api.ts`: `FieldValidationError` interface that “mirrors ValidationErrorDetail”.
+
+**What’s wrong:** The same structure is exposed as `ValidationErrorDetail` (validation) and `FieldValidationError` (types). Two names for one concept can cause confusion and unnecessary type imports.
+
+**Suggested change:** Standardize on one name. Prefer keeping the shape in one place (e.g. `@ai-learning-hub/validation` as `ValidationErrorDetail`) and re-exporting or referencing it from `@ai-learning-hub/types` as a type alias (e.g. `export type { ValidationErrorDetail as FieldValidationError } from '@ai-learning-hub/validation'`) so API/ADR-008 code can use `FieldValidationError` from types while implementation stays in validation. Alternatively, define the interface only in `@ai-learning-hub/types` and have validation use/import it. Document the chosen convention in `.claude/docs/api-patterns.md` or the validation package README.
+
+**Priority:** Medium.
+
+---
+
+## 3. Use of standardized components and patterns
+
+### 3.1 Logger usage: authorizers vs wrapped handlers
+
+**Location:**
+
+- `backend/functions/jwt-authorizer/handler.ts`: `createLogger()` used at runtime.
+- `backend/functions/api-key-authorizer/handler.ts`: `createLogger()` used at runtime.
+- All other API handlers (e.g. `saves-get`, `saves-list`, `api-keys`, `invite-codes`, `users-me`): use `logger` from `ctx` (from `wrapHandler`).
+
+**What’s wrong:** Nothing is broken; authorizers cannot use `wrapHandler`, so they correctly use `createLogger()`. The split can surprise maintainers (“why do some files use `createLogger` and others `ctx.logger`?”).
+
+**Suggested change:** Add a short subsection to `.claude/docs/api-patterns.md` or `testing-guide.md`: “Logging: API handlers use `ctx.logger` from `wrapHandler`. Authorizers (JWT, API Key) do not use `wrapHandler` and must call `createLogger()` from `@ai-learning-hub/logging` once per invocation.” No code change required.
+
+**Priority:** Low.
+
+---
+
+### 3.2 Envelope/pagination built manually in saves-list
+
+**Location:** `backend/functions/saves-list/handler.ts` (roughly lines 224–258): builds `EnvelopeMeta`, `links.self` / `links.next`, and calls `createSuccessResponse(page.map(toPublicSave), requestId, { meta, links })`.
+
+**What’s wrong:** Pagination and envelope building are implemented inline. `@ai-learning-hub/db` already exposes `buildPaginatedResponse`; middleware/types define envelope and rate-limit meta. The list handler uses in-memory filtering/sorting then manual cursor slicing and link building, so it may not map 1:1 to `buildPaginatedResponse` (which is item-based). The pattern is still slightly inconsistent with “use shared helpers where possible.”
+
+**Suggested change:** Prefer leaving behavior as-is unless a refactor is planned. If you later introduce a shared “build list envelope” helper (e.g. in middleware or db) that accepts `items`, `nextCursor`, `total`, `links`, and optional `truncated`/`cursorReset`, consider using it here and in other list endpoints (e.g. invite-codes, api-keys) for consistency. Optional follow-up; not required for Epic 1.
+
+**Priority:** Low.
+
+---
+
+## 4. Opportunities for new shared components
+
+### 4.1 Shared authorizer cache TTL (same as 2.1)
+
+**Location:** Same as finding 2.1.
+
+**Suggested change:** Introduce a single shared constant (e.g. in `@ai-learning-hub/middleware` or a small `backend/shared/constants` package) for `AUTHORIZER_CACHE_TTL` and use it in both authorizers and in CDK when configuring `resultsCacheTtl`. This is both a naming consistency win and a small shared component.
+
+**Priority:** Medium.
+
+---
+
+### 4.2 Optional: shared path param schema for API key ID
+
+**Location:** `backend/functions/api-keys/handler.ts`: inline `deletePathSchema` for `DELETE /users/api-keys/:id` (e.g. `z.object({ id: z.string().min(1).max(128) })`).
+
+**What’s wrong:** Only one handler uses it. The project already has `saveIdPathSchema` in `@ai-learning-hub/validation` for save IDs. Having a single “resource id path” schema in validation would be a small, reusable abstraction if more “:id” path params appear (e.g. folder, project).
+
+**Suggested change:** Low priority. If you add more “:id” path params with the same rules (non-empty string, max length), add something like `resourceIdPathSchema` or `apiKeyIdPathSchema` in `backend/shared/validation/src/schemas.ts` and use it in the api-keys handler. Otherwise, leave the inline schema as-is.
+
+**Priority:** Low.
+
+---
+
+## 5. Clarity and efficiency
+
+### 5.1 TODO in authorizers about wiring cache TTL
+
+**Location:**
+
+- `backend/functions/jwt-authorizer/handler.ts`: comment “TODO: Wire into API Gateway TokenAuthorizer in the API story.”
+- `backend/functions/api-key-authorizer/handler.ts`: comment “TODO: Wire into API Gateway RequestAuthorizer in the API story.”
+
+**What’s wrong:** If the API Gateway authorizers are already wired in CDK (e.g. `AuthStack` / `ApiGatewayStack` use `resultsCacheTtl`), the TODOs are obsolete and misleading.
+
+**Suggested change:** If already wired: remove the TODO and replace with a one-line comment that the value is used by CDK for `resultsCacheTtl`. If not yet wired: keep the TODO or replace it with “Intended for use by CDK when configuring authorizer resultsCacheTtl” so the intent is clear.
+
+**Priority:** Low.
+
+---
+
+### 5.2 Observability stack placeholder comments
+
+**Location:** `infra/lib/stacks/observability/observability.stack.ts` (e.g. lines 59–72): “Future: CloudWatch Dashboards” and “Future: CloudWatch Alarms” with bullet lists.
+
+**What’s wrong:** Placeholder comments are fine; they document intent. No change strictly required.
+
+**Suggested change:** Optional: add a short “Observability roadmap” note in `.claude/docs/observability.md` or in the stack file that NFR-O2/O4/O5 (dashboards, alarms) will be implemented in a later story and reference this stack. Keeps the stack file as the single place for “what’s next” for observability.
+
+**Priority:** Low.
+
+---
+
+### 5.3 Long comment in saves-delete handler
+
+**Location:** `backend/functions/saves-delete/handler.ts` (lines 63–68): NOTE explaining why `returnValues: "ALL_OLD"` is used instead of `NONE` (to get `normalizedUrl`/`urlHash` for the event in one round-trip).
+
+**What’s wrong:** Nothing; the comment is useful and explains a non-obvious trade-off.
+
+**Suggested change:** None. Optionally add a one-line reference to the story/AC (e.g. “Story 3.3, Task 3”) at the start of the NOTE so future readers can trace the requirement.
+
+**Priority:** Low (optional polish).
+
+---
+
+## Summary table
+
+| #   | Category               | Location (summary)                                | Priority |
+| --- | ---------------------- | ------------------------------------------------- | -------- |
+| 1.1 | Dead/redundant code    | `invite-codes/schemas.ts` unused re-export        | Low      |
+| 1.2 | Dead/redundant code    | `.claude/` review/dedup artifacts                 | Low      |
+| 2.1 | Naming and consistency | Duplicate `AUTHORIZER_CACHE_TTL`                  | Medium   |
+| 2.2 | Naming and consistency | `ValidationErrorDetail` vs `FieldValidationError` | Medium   |
+| 3.1 | Standardized patterns  | Document logger usage (authorizers vs handlers)   | Low      |
+| 3.2 | Standardized patterns  | saves-list envelope (optional shared helper)      | Low      |
+| 4.1 | New shared component   | Shared `AUTHORIZER_CACHE_TTL` (same as 2.1)       | Medium   |
+| 4.2 | New shared component   | Optional `apiKeyIdPathSchema`                     | Low      |
+| 5.1 | Clarity                | TODO in authorizers (wire cache TTL)              | Low      |
+| 5.2 | Clarity                | Observability stack “Future” comments             | Low      |
+| 5.3 | Clarity                | saves-delete NOTE (keep; optional story ref)      | Low      |
+
+---
+
+## What was checked and found OK
+
+- **Handlers:** All scanned handler files use `@ai-learning-hub/db`, `@ai-learning-hub/logging` (via `ctx.logger` or `createLogger` in authorizers), `@ai-learning-hub/validation`, and `@ai-learning-hub/middleware`; no direct DynamoDB SDK or console.\* in handlers; all API handlers use `wrapHandler`.
+- **Shared packages:** Exports from `logging`, `middleware`, `db`, `validation`, `types`, and `events` are used; no obvious dead public API in the scope of this review.
+- **Infra:** Tables, buckets, observability, auth, API Gateway, and route stacks follow a consistent naming and dependency order; table names use environment prefix; no hardcoded account/region in app code.
+- **CI/CD:** Pipeline stages (lint, type-check, unit tests, CDK synth, integration/contract placeholders, security scan, deploy dev/E2E/deploy prod) are consistent with Epic 1; placeholders are clearly marked.
+- **.claude/:** Docs, commands, and hooks are structured and referenced from READMEs; hooks mirror the rules in `.cursor/rules` as intended.
+
+---
+
+_Generated from a full pass over Epic 1 deliverables and dependent code. Prioritization favors consistency with shared packages and existing patterns; refactors that only move code without improving clarity or reuse were avoided._

--- a/project-context.md
+++ b/project-context.md
@@ -1,0 +1,21 @@
+# Project Context
+
+## Deployment Status: Pre-Launch Greenfield
+
+This project has **never been deployed to production**. There are zero users, zero live environments, and zero legacy consumers. Every piece of code in this repo is pre-launch work in progress.
+
+### What This Means for Implementation
+
+- **No backward compatibility required.** There is no deployed API, schema, or interface to preserve.
+- **No legacy code to protect.** If a pattern, approach, or implementation is being replaced, **delete the old code entirely**. Do not leave deprecated functions, compatibility shims, re-exports, or "just in case" wrappers.
+- **Retrofits are full replacements.** When a story involves retrofitting, refactoring, or changing an earlier approach, treat it as a clean rewrite of the affected areas. Eliminate all traces of the previous approach.
+- **No cruft tolerance.** Dead code, unused exports, orphaned types, backward-compat aliases, and TODO-remove comments are bugs, not safety nets. Remove them.
+- **Tests should reflect current design only.** When an approach changes, update or delete old tests — do not keep tests for removed behavior.
+
+### Anti-Patterns to Avoid
+
+- Keeping old implementations "in case we need to revert" — we don't, that's what git history is for
+- Adding `@deprecated` annotations instead of deleting code
+- Creating adapter layers between old and new approaches
+- Preserving unused DB indexes, API endpoints, or event handlers from a previous design
+- Warning about "breaking changes" when there are no consumers to break


### PR DESCRIPTION
## Summary

- **Create-story template**: Added mandatory YAML frontmatter block (`id`, `title`, `status`, `depends_on`, `touches`, `risk`) and standardized AC format (`N. **ACN: Name** — Description`)
- **Create-story instructions**: Added frontmatter extraction in Step 2 and AC format enforcement in Step 5 so auto-epic Phase 1.2 and Phase 2.2 can reliably machine-parse story files
- **Create-story checklist**: Added Step 1.5 structural format validation (8 frontmatter checks + 7 AC format checks) flagged as CRITICAL
- **project-context.md**: New file — greenfield project rules (no legacy, no backward compat, eliminate cruft on retrofits)
- **CLAUDE.md**: Updated commands (added BMAD lifecycle commands), greenfield rules, project structure, agent-native API patterns, current status
- **Archived**: review/dedup findings from prior epic runs

## Test plan

- [ ] Run `/bmad-bmm-create-story` for next story and verify output has YAML frontmatter + flat AC format
- [ ] Run `/bmad-bmm-auto-epic` and verify Phase 1.2 parses frontmatter without warnings
- [ ] Verify Phase 1.2a readiness validation passes with new AC format
- [ ] Verify Phase 2.2 AC verification extracts individual ACs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)