### PR TITLE
feat: Smoke Test Retrofit & Coverage for Epic 3.2 (Story 3.2.11)

### DIFF
--- a/_bmad-output/implementation-artifacts/3-2-11-smoke-test-epic-3-2-coverage.md
+++ b/_bmad-output/implementation-artifacts/3-2-11-smoke-test-epic-3-2-coverage.md
@@ -1,0 +1,334 @@
+---
+id: "3.2.11"
+title: "Smoke Test Retrofit & Coverage for Epic 3.2"
+status: ready-for-dev
+depends_on:
+  - "3.2.7"
+  - "3.2.8"
+  - "3.2.9"
+  - "3.2.10"
+touches:
+  - scripts/smoke-test/scenarios/saves-crud.ts
+  - scripts/smoke-test/scenarios/saves-validation.ts
+  - scripts/smoke-test/scenarios/api-key-auth.ts
+  - scripts/smoke-test/scenarios/user-profile.ts
+  - scripts/smoke-test/scenarios/eventbridge-verify.ts
+  - scripts/smoke-test/scenarios/ops-endpoints.ts
+  - scripts/smoke-test/scenarios/discovery-endpoints.ts
+  - scripts/smoke-test/scenarios/command-endpoints.ts
+  - scripts/smoke-test/scenarios/batch-operations.ts
+  - scripts/smoke-test/scenarios/agent-native-behaviors.ts
+  - scripts/smoke-test/scenarios/index.ts
+  - scripts/smoke-test/phases.ts
+  - scripts/smoke-test/helpers.ts
+risk: medium
+---
+
+# Story 3.2.11: Smoke Test Retrofit & Coverage for Epic 3.2
+
+Status: ready-for-dev
+
+## Story
+
+As a **developer deploying the API after Epic 3.2**,
+I want **every smoke test scenario to reflect the current API surface — including mandatory idempotency headers, optimistic concurrency, cursor pagination, scope enforcement, new endpoints, and agent-native behaviors**,
+so that **I can deploy confidently knowing the full suite passes and the deployed code matches what we designed**.
+
+## Context
+
+Epic 3.2 introduced middleware changes that affect **every mutation endpoint** in the existing smoke tests:
+
+| Middleware change | Effect | Failure if missing |
+|---|---|---|
+| `idempotent: true` on all mutations | `Idempotency-Key` header mandatory | 400 VALIDATION_ERROR |
+| `requireVersion: true` on PATCH /saves/:saveId, PATCH /users/me, POST /users/me/update, POST /saves/:saveId/update-metadata | `If-Match` header mandatory | 428 PRECONDITION_REQUIRED |
+| `requiredScope` on all handlers | API keys without matching scope get rejected | 403 SCOPE_INSUFFICIENT |
+| GET /saves list → cursor pagination | Response shape changed from `{ data: { items, hasMore } }` to `{ data: [...], meta: { cursor, total }, links: { self, next } }` | Assertion failures |
+
+Additionally, 9 new routes were added that have zero smoke test coverage.
+
+## Acceptance Criteria
+
+### Part A: Retrofit Existing Scenarios
+
+#### Saves CRUD (Phase 2: SC1–SC8)
+
+1. **AC1: SC1 sends Idempotency-Key on create** — `POST /saves` includes `Idempotency-Key: <uuid>` header. Stores `data.version` from the 201 response for use by subsequent scenarios (avoids extra GET). Cleanup callback also sends `Idempotency-Key`.
+
+2. **AC2: SC3 uses cursor pagination shape** — `GET /saves` asserts `data` is a top-level array (not `data.items`). Validates `meta.cursor` is present (string or null) and `links.self` is present. Removes `data.hasMore` assertion. Still verifies created save appears in the array.
+
+3. **AC3: SC4 sends Idempotency-Key and If-Match on update** — `PATCH /saves/:saveId` uses the stored version from SC1 (or SC2 if SC1 doesn't store it) to send `If-Match: <version>` and includes `Idempotency-Key: <uuid>`. Asserts 200, title updated. Stores the new `data.version` for SC5+.
+
+4. **AC4: SC5 sends Idempotency-Key on delete** — `DELETE /saves/:saveId` includes `Idempotency-Key: <uuid>`. Asserts 204.
+
+5. **AC5: SC7 sends Idempotency-Key on restore** — `POST /saves/:saveId/restore` includes `Idempotency-Key: <uuid>`. Asserts 200, no deletedAt.
+
+#### Saves Validation (Phase 4: SV1–SV4)
+
+6. **AC6: SV4 sends all required headers before testing validation** — SV4 setup creates a save (with `Idempotency-Key`), stores `data.version`, then sends bad PATCH with `If-Match: <version>` and `Idempotency-Key: <uuid>` alongside the immutable `url` field. Asserts 400 VALIDATION_ERROR (confirming body validation runs after middleware). Cleanup delete sends `Idempotency-Key`.
+
+#### API Key Auth (Phase 1: AC5–AC8, AC13)
+
+7. **AC7: createKey helper sends Idempotency-Key** — The shared `createKey()` helper includes `Idempotency-Key: <uuid>` on each `POST /users/api-keys` attempt (fresh key per retry).
+
+8. **AC8: deleteKey helper sends Idempotency-Key** — The shared `deleteKey()` helper includes `Idempotency-Key: <uuid>` on `DELETE /users/api-keys/:id`.
+
+9. **AC9: AC6 scope test asserts 403 SCOPE_INSUFFICIENT** — AC6 creates an API key with `saves:write` scope, attempts `PATCH /users/me` (which requires `users:write`), and asserts **403 SCOPE_INSUFFICIENT** (not 200). Validates error body contains `required_scope === "users:write"` and `granted_scopes` array. This replaces the previous AC6 behavior which expected 200 because scope enforcement was not yet active.
+
+#### User Profile (Phase 1: AC11–AC12)
+
+10. **AC10: AC11 sends If-Match and Idempotency-Key on profile update** — `PATCH /users/me` first fetches profile to get `data.version`, sends `If-Match: <version>` and `Idempotency-Key: <uuid>`. The restore step in `finally` re-fetches version before restoring with fresh `If-Match` and `Idempotency-Key`.
+
+11. **AC11: AC12 sends required headers before testing validation** — Invalid `PATCH /users/me` fetches profile to get `data.version`, sends `If-Match: <version>` and `Idempotency-Key: <uuid>` alongside the invalid body field. Asserts 400 VALIDATION_ERROR (not 428).
+
+#### EventBridge (Phase 7: EB1–EB3)
+
+12. **AC12: EB scenarios send Idempotency-Key on mutations** — EB1 (POST /saves create) and EB3 (DELETE /saves) include `Idempotency-Key` headers. EB2 (GET) is unaffected. EB3 cleanup delete also sends `Idempotency-Key`.
+
+### Part B: New Endpoint Scenarios
+
+#### Ops Endpoints (Phase 1 — unauthenticated)
+
+13. **AC13: Health endpoint** — Scenario `OP1` sends `GET /health` with `auth: { type: "none" }`. Asserts 200, `data.status === "healthy"`, `data.timestamp` present, `data.version` present. Validates `links.self === "/health"`. Uses `assertResponseEnvelope()`.
+
+14. **AC14: Readiness endpoint** — Scenario `OP2` sends `GET /ready` with `auth: { type: "none" }`. Asserts 200, `data.ready === true`, `data.dependencies.dynamodb === "ok"`, `data.timestamp` present. Validates `links.self === "/ready"`. Uses `assertResponseEnvelope()`.
+
+#### Discovery Endpoints (Phase 1 — authenticated)
+
+15. **AC15: Actions catalog** — Scenario `DS1` sends `GET /actions` with JWT auth. Asserts 200, `data` is a non-empty array, each action has `actionId`, `method`, `urlPattern`, `description`. Validates at least one action with `actionId` starting with `"saves:"` and at least one starting with `"batch:"` exist.
+
+16. **AC16: Actions catalog entity filter** — `DS1` additionally sends `GET /actions?entity=saves` and verifies all returned actions have `entityType === "saves"`.
+
+17. **AC17: State graph** — Scenario `DS2` sends `GET /states/saves` with JWT auth. Asserts 200, response contains state graph data. Validates `links.self` present.
+
+#### Command Endpoints (Phase 2 — after saves CRUD)
+
+18. **AC18: Update-metadata command** — Scenario `CM1` creates its own save (with `Idempotency-Key`), then sends `POST /saves/{saveId}/update-metadata` with `{ title: "Updated via command" }`, `Idempotency-Key`, and `If-Match: <version>` (handler has `requireVersion: true`). Asserts 200. Cleans up save in `finally` (with `Idempotency-Key` on delete).
+
+19. **AC19: Event history** — Scenario `CM2` sends `GET /saves/{saveId}/events` for the save created/modified by CM1. Asserts 200, `data` is an array containing at least one event with `eventType` present.
+
+20. **AC20: User profile update command** — Scenario `CM3` sends `POST /users/me/update` with `{ displayName: "Smoke Test User" }`, `Idempotency-Key`, `If-Match: <version>` (fetched via GET /users/me), and JWT auth. Asserts 200, response contains updated profile. Restores original displayName in `finally` (re-fetching version, sending both headers).
+
+21. **AC21: API key revoke command** — Scenario `CM4` creates a temporary API key (with `Idempotency-Key`), then sends `POST /users/api-keys/{id}/revoke` with `Idempotency-Key`. Asserts 200. Verifies the revoked key returns 401 when used for `GET /users/me`. Cleanup is implicit (key is revoked).
+
+#### Batch Operations (Phase 3 — new phase)
+
+22. **AC22: Batch basic execution** — Scenario `BA1` sends `POST /batch` with JWT auth, `Idempotency-Key` (the batch handler itself has `idempotent: true`), and 2 operations: a `GET /actions` and a `GET /users/me`. Asserts 200, `data.results` has 2 entries, `data.summary.total === 2`, `data.summary.succeeded === 2`. (Uses only GETs to avoid complex per-operation cleanup.)
+
+23. **AC23: Batch partial failure** — Scenario `BA2` sends `POST /batch` with `Idempotency-Key` and 2 operations: one valid `GET /actions` and one `GET /saves/00000000000000000000000000` (should 404). Asserts 200, `data.summary.succeeded === 1`, `data.summary.failed === 1`. Validates per-operation `statusCode` in results.
+
+24. **AC24: Batch requires authentication** — Scenario `BA3` sends `POST /batch` with `auth: { type: "none" }` and no `Idempotency-Key`. Asserts 401 or 403.
+
+### Part C: Agent-Native Behavior Validation
+
+#### Response Envelope (Phase 1)
+
+25. **AC25: Response envelope on authenticated endpoints** — Scenario `AN1` sends `GET /users/me` with JWT auth. Verifies response contains `data` (object), `links` (object with `self`), and optionally `meta`. Uses `assertResponseEnvelope()`.
+
+#### Idempotency (Phase 2)
+
+26. **AC26: Idempotency replay** — Scenario `AN2` generates a UUID, sends `POST /saves` twice with that same `Idempotency-Key` and identical body. Asserts both responses return 201 with the same `data.saveId`. Asserts second response has `X-Idempotent-Replayed: true` header. Cleans up save (with `Idempotency-Key` on delete).
+
+#### Optimistic Concurrency (Phase 2)
+
+27. **AC27: If-Match conflict → 409** — Scenario `AN3` creates a save (with `Idempotency-Key`), obtains `data.version`, sends `PATCH /saves/:saveId` with `If-Match: 999` (stale version), `Idempotency-Key`, and `{ title: "Should Fail" }`. Asserts 409 `VERSION_CONFLICT`. Validates error body contains `currentVersion` (number). Cleans up save (with `Idempotency-Key` on delete).
+
+28. **AC28: Missing If-Match → 428** — Scenario `AN4` creates a save (with `Idempotency-Key`), sends `PATCH /saves/:saveId` with `Idempotency-Key` but **no** `If-Match` header and `{ title: "Should Fail" }`. Asserts 428 `PRECONDITION_REQUIRED`. Cleans up save.
+
+#### Scope Enforcement (Phase 1)
+
+29. **AC29: Insufficient scope → 403** — Scenario `AN5` creates an API key with `["saves:read"]` scope (via `createKey` with `Idempotency-Key`), attempts `POST /saves` (requires `saves:create`) with that key and `Idempotency-Key`. Asserts 403 `SCOPE_INSUFFICIENT`. Validates error body contains `required_scope` and `granted_scopes`. Cleans up API key (with `Idempotency-Key` on delete).
+
+#### Rate Limiting (Phase 1)
+
+30. **AC30: Rate limit headers present** — Scenario `AN6` sends `GET /users/me` with JWT auth. Asserts `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers are present.
+
+#### Cursor Pagination (Phase 2)
+
+31. **AC31: Cursor pagination mechanics** — Scenario `AN7` creates 2 saves (with `Idempotency-Key`), sends `GET /saves?limit=1`. Asserts `data` array has exactly 1 element, `meta.cursor` is a non-null string, `links.next` is a non-null string containing `cursor=`. Follows `links.next` and asserts `data` is non-empty. Cleans up both saves (with `Idempotency-Key` on delete).
+
+#### X-Agent-ID Header (Phase 1)
+
+32. **AC32: X-Agent-ID accepted** — Scenario `AN8` sends `GET /users/me` with JWT auth and `X-Agent-ID: smoke-test-agent` header. Asserts 200. (Header acceptance is verified; recording is an EventBridge concern.)
+
+### Part D: Infrastructure
+
+33. **AC33: Shared createSave helper with retry-on-429** — `helpers.ts` adds `createSave(auth, opts?)` that handles `Idempotency-Key`, retry-on-429 (matching `createKey` pattern), and returns `{ saveId, version, url }`. Used by AN2, AN3, AN4, AN5, AN7, CM1, and SV4 setup.
+
+34. **AC34: Shared deleteSave helper** — `helpers.ts` adds `deleteSave(saveId, auth)` that sends `Idempotency-Key` and handles 404 gracefully (already deleted). Used by all cleanup callbacks.
+
+35. **AC35: Assertion helpers** — `helpers.ts` adds:
+    - `assertResponseEnvelope(body)` — validates `data` exists, `links.self` exists
+    - `assertCursorPagination(body)` — validates `data` is array, `meta.cursor` present, `links.self` present
+    - `idempotencyKey()` — returns `{ "Idempotency-Key": crypto.randomUUID() }`
+
+36. **AC36: Phase registry updated** — `phases.ts` adds:
+    - Phase 1: ops (OP1–OP2), discovery (DS1–DS2), agent-native cross-cutting (AN1, AN5, AN6, AN8)
+    - Phase 2: command (CM1–CM4), agent-native saves-dependent (AN2, AN3, AN4, AN7)
+    - Phase 3: batch (BA1–BA3) — claims reserved phase
+
+37. **AC37: scenarios/index.ts re-exports** — All new scenario arrays re-exported.
+
+38. **AC38: Self-cleaning** — All scenarios that create resources use try/finally or cleanup callbacks with `Idempotency-Key` on delete. Environment unchanged after full run.
+
+39. **AC39: Full suite passes** — `npm run smoke-test` runs all phases — existing (retrofitted) + new — all pass.
+
+## Tasks / Subtasks
+
+### Task 1: Shared helpers and utilities
+
+- [ ] 1.1 Add `idempotencyKey()` to `helpers.ts` — returns `{ "Idempotency-Key": crypto.randomUUID() }`
+- [ ] 1.2 Add `createSave(auth, opts?)` to `helpers.ts` — POST /saves with Idempotency-Key, retry-on-429, returns `{ saveId, version, url }`
+- [ ] 1.3 Add `deleteSave(saveId, auth)` to `helpers.ts` — DELETE with Idempotency-Key, 404-safe
+- [ ] 1.4 Add `assertResponseEnvelope(body)` — validates `data` and `links.self`
+- [ ] 1.5 Add `assertCursorPagination(body)` — validates `data` array, `meta.cursor`, `links.self`
+- [ ] 1.6 Add `assertHealthShape(body)` — validates health response fields
+- [ ] 1.7 Add `assertReadinessShape(body)` — validates readiness response fields
+
+### Task 2: Retrofit saves-crud.ts (SC1–SC8)
+
+- [ ] 2.1 SC1: Add Idempotency-Key header, store `data.version` in module state
+- [ ] 2.2 SC1: Cleanup callback sends Idempotency-Key via `deleteSave` helper
+- [ ] 2.3 SC3: Rewrite assertions for cursor pagination shape (`data[]`, `meta.cursor`, `links.self`)
+- [ ] 2.4 SC4: Use stored version for `If-Match`, add `Idempotency-Key`, store new version
+- [ ] 2.5 SC5: Add `Idempotency-Key` header
+- [ ] 2.6 SC7: Add `Idempotency-Key` header
+
+### Task 3: Retrofit saves-validation.ts (SV1–SV4)
+
+- [ ] 3.1 SV4: Use `createSave` helper for setup (gets Idempotency-Key + version)
+- [ ] 3.2 SV4: Send `If-Match` + `Idempotency-Key` on bad PATCH
+- [ ] 3.3 SV4: Use `deleteSave` helper for cleanup
+
+### Task 4: Retrofit api-key-auth.ts (AC5–AC8, AC13)
+
+- [ ] 4.1 `createKey()`: Add Idempotency-Key to POST /users/api-keys (fresh per retry)
+- [ ] 4.2 `deleteKey()`: Add Idempotency-Key to DELETE /users/api-keys/:id
+- [ ] 4.3 AC6: Rewrite to assert 403 SCOPE_INSUFFICIENT with `required_scope` and `granted_scopes`
+
+### Task 5: Retrofit user-profile.ts (AC11–AC12)
+
+- [ ] 5.1 AC11: Fetch version before PATCH, send If-Match + Idempotency-Key
+- [ ] 5.2 AC11: Restore step re-fetches version, sends both headers
+- [ ] 5.3 AC12: Fetch version before invalid PATCH, send If-Match + Idempotency-Key
+
+### Task 6: Retrofit eventbridge-verify.ts (EB1–EB3)
+
+- [ ] 6.1 EB1: Add Idempotency-Key to POST /saves
+- [ ] 6.2 EB3: Add Idempotency-Key to DELETE /saves
+- [ ] 6.3 EB cleanup: Use `deleteSave` helper
+
+### Task 7: New ops endpoint scenarios (OP1–OP2)
+
+- [ ] 7.1 Create `scenarios/ops-endpoints.ts`
+- [ ] 7.2 Implement OP1 — GET /health, no auth, assertResponseEnvelope (AC13)
+- [ ] 7.3 Implement OP2 — GET /ready, no auth, assertResponseEnvelope (AC14)
+
+### Task 8: New discovery endpoint scenarios (DS1–DS2)
+
+- [ ] 8.1 Create `scenarios/discovery-endpoints.ts`
+- [ ] 8.2 Implement DS1 — GET /actions, verify catalog + entity filter (AC15, AC16)
+- [ ] 8.3 Implement DS2 — GET /states/saves (AC17)
+
+### Task 9: New command endpoint scenarios (CM1–CM4)
+
+- [ ] 9.1 Create `scenarios/command-endpoints.ts`
+- [ ] 9.2 Implement CM1 — POST /saves/{id}/update-metadata, self-contained (AC18)
+- [ ] 9.3 Implement CM2 — GET /saves/{id}/events, uses CM1's save (AC19)
+- [ ] 9.4 Implement CM3 — POST /users/me/update (AC20)
+- [ ] 9.5 Implement CM4 — POST /users/api-keys/{id}/revoke (AC21)
+
+### Task 10: New batch operation scenarios (BA1–BA3)
+
+- [ ] 10.1 Create `scenarios/batch-operations.ts`
+- [ ] 10.2 Implement BA1 — batch with 2 GETs, outer Idempotency-Key (AC22)
+- [ ] 10.3 Implement BA2 — partial failure (AC23)
+- [ ] 10.4 Implement BA3 — unauthenticated rejection (AC24)
+
+### Task 11: New agent-native behavior scenarios (AN1–AN8)
+
+- [ ] 11.1 Create `scenarios/agent-native-behaviors.ts`
+- [ ] 11.2 Implement AN1 — response envelope (AC25)
+- [ ] 11.3 Implement AN2 — idempotency replay with X-Idempotent-Replayed (AC26)
+- [ ] 11.4 Implement AN3 — If-Match conflict → 409 VERSION_CONFLICT (AC27)
+- [ ] 11.5 Implement AN4 — missing If-Match → 428 PRECONDITION_REQUIRED (AC28)
+- [ ] 11.6 Implement AN5 — insufficient scope → 403 SCOPE_INSUFFICIENT (AC29)
+- [ ] 11.7 Implement AN6 — rate limit headers (AC30)
+- [ ] 11.8 Implement AN7 — cursor pagination mechanics (AC31)
+- [ ] 11.9 Implement AN8 — X-Agent-ID passthrough (AC32)
+- [ ] 11.10 Wire cleanup for AN2, AN3, AN4, AN5, AN7
+
+### Task 12: Phase registry and index wiring
+
+- [ ] 12.1 Update `scenarios/index.ts` — re-export all new scenario arrays
+- [ ] 12.2 Update `phases.ts` — Phase 1 adds ops/discovery/AN1,AN5,AN6,AN8; Phase 2 adds command/AN2,AN3,AN4,AN7; Phase 3 claims batch
+- [ ] 12.3 Verify `--phase=3` runs only batch scenarios
+
+### Task 13: Manual deploy verification
+
+- [ ] 13.1 Run `npm run smoke-test -- --phase=1` — verify OP1, OP2, DS1, DS2, AN1, AN5, AN6, AN8 pass alongside retrofitted AC5–AC13, AC11–AC12
+- [ ] 13.2 Run `npm run smoke-test -- --phase=2` — verify retrofitted SC1–SC8, CM1–CM4, AN2, AN3, AN4, AN7 pass
+- [ ] 13.3 Run `npm run smoke-test -- --phase=3` — verify BA1–BA3 pass
+- [ ] 13.4 Run `npm run smoke-test -- --phase=4` — verify retrofitted SV1–SV4 pass
+- [ ] 13.5 Run `npm run smoke-test` (full) — all scenarios pass end-to-end
+
+## Dev Notes
+
+### Architecture context
+
+- Smoke tests run via `tsx` against the deployed API Gateway — no build step, no mocks
+- All scenarios use `SmokeClient` from `client.ts` and assertion helpers from `helpers.ts`
+- Route-registry-bridge loads ROUTE_REGISTRY from compiled `infra/dist/` — AC9/AC10 automatically cover all new routes for connectivity/CORS
+- `crypto.randomUUID()` available in Node 19+ — sufficient for idempotency keys
+
+### Breaking changes from Epic 3.2
+
+| Middleware change | Affected existing scenarios | Fix |
+|---|---|---|
+| `idempotent: true` → Idempotency-Key mandatory (400) | SC1, SC4, SC5, SC7, SV4, AC5–AC8, AC13, AC11, EB1, EB3 | Add `Idempotency-Key: <uuid>` to all mutation requests |
+| `requireVersion: true` → If-Match mandatory (428) | SC4, SV4, AC11, AC12 | Fetch version first, send `If-Match: <version>` |
+| `requiredScope` enforced → 403 SCOPE_INSUFFICIENT | AC6 (saves:write key → PATCH /users/me requires users:write) | Rewrite AC6 to assert 403 + error body |
+| List response → cursor pagination | SC3 | Assert `data[]` + `meta.cursor` + `links.self` |
+
+### Endpoint inventory for new scenarios
+
+| Endpoint | Method | Auth | Idempotent | RequireVersion | Phase |
+|---|---|---|---|---|---|
+| /health | GET | none | no | no | 1 |
+| /ready | GET | none | no | no | 1 |
+| /actions | GET | jwt | no | no | 1 |
+| /states/saves | GET | jwt | no | no | 1 |
+| /saves/{id}/update-metadata | POST | jwt-or-apikey | yes | yes | 2 |
+| /saves/{id}/events | GET | jwt-or-apikey | no | no | 2 |
+| /users/me/update | POST | jwt-or-apikey | yes | yes | 2 |
+| /users/api-keys/{id}/revoke | POST | jwt-or-apikey | yes | no | 2 |
+| /batch | POST | jwt | yes | no | 3 |
+
+### Design decisions
+
+- **CM1 is self-contained:** Creates its own save rather than coupling to SC1's module state. CM2 reuses CM1's save. Cleanup in `finally`.
+- **BA1 uses only GETs in batch:** Avoids per-operation save creation/cleanup complexity. Validates batch mechanics without side effects.
+- **AC6 now tests 403:** Scope enforcement is active post-3.2. The old 200 assertion was wrong — `saves:write` cannot access `users:write` endpoints. This is the correct deployed behavior.
+- **AN4 (428) separate from AN3 (409):** Tests distinct failure modes — missing header vs stale version. Both are agent-native recovery scenarios.
+- **AN5 scope test in Phase 1:** Uses API key auth (Phase 1 dependency only), doesn't need saves.
+- **Shared helpers `createSave`/`deleteSave`:** Centralizes Idempotency-Key injection and retry-on-429 logic. All scenarios use these instead of raw client calls for mutations.
+- **Version stored from create response:** `INITIAL_VERSION = 1`. Create response includes `data.version`. Avoids extra GET-before-PATCH round trips.
+
+### Constraints
+
+- All scenarios must respect `SMOKE_TEST_SKIP` and throw `ScenarioSkipped` if prerequisites fail
+- All saves mutations need retry-on-429 (Epic 3.2 added `savesWriteRateLimit`)
+- Full suite must complete in <60 seconds
+- AC6 (scope test) generates a `saves:write` key and a `saves:read` key — both need cleanup
+
+### References
+
+- [Source: docs/smoke-test-architecture.md — full system design]
+- [Source: scripts/smoke-test/phases.ts — phase registry]
+- [Source: scripts/smoke-test/helpers.ts — assertion helpers]
+- [Source: infra/config/route-registry.ts — all routes including Epic 3.2]
+- [Source: backend/shared/middleware/src/idempotency.ts — Idempotency-Key extraction, X-Idempotent-Replayed header]
+- [Source: backend/shared/middleware/src/concurrency.ts — If-Match extraction, 428 PRECONDITION_REQUIRED]
+- [Source: backend/shared/middleware/src/auth.ts — requireScope, 403 SCOPE_INSUFFICIENT]
+- [Source: backend/shared/db/src/version-helpers.ts — VersionConflictError, 409 VERSION_CONFLICT]
+- [Source: backend/shared/types/src/entities.ts — INITIAL_VERSION = 1]

--- a/scripts/smoke-test/helpers.ts
+++ b/scripts/smoke-test/helpers.ts
@@ -2,7 +2,13 @@
  * smoke-test/helpers.ts
  * Shared assertion helpers for the smoke-test runner.
  * Inlined here (not imported from backend) so the script runs without build steps.
+ *
+ * Story 3.2.11: Added idempotencyKey(), createSave(), deleteSave(),
+ * assertResponseEnvelope(), assertCursorPagination().
  */
+
+import crypto from "node:crypto";
+import { getClient } from "./client.js";
 
 /**
  * Assert that a response body matches ADR-008 error shape:
@@ -118,4 +124,114 @@ export function jwtAuth(): { type: "jwt"; token: string } {
  */
 export function randomInvalidKey(): string {
   return `invalid-key-${Math.random().toString(36).slice(2, 14)}`;
+}
+
+/**
+ * Return an object with a fresh Idempotency-Key header.
+ * Spread into the `headers` option of client requests.
+ */
+export function idempotencyKey(): { "Idempotency-Key": string } {
+  return { "Idempotency-Key": crypto.randomUUID() };
+}
+
+/** Simple sleep helper */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Create a save with Idempotency-Key and retry-on-429.
+ * Returns { saveId, version, url }.
+ */
+export async function createSave(
+  auth: { type: "jwt"; token: string } | { type: "apikey"; key: string },
+  opts?: { url?: string }
+): Promise<{ saveId: string; version: number; url: string }> {
+  const url =
+    opts?.url ??
+    `https://example.com/smoke-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const maxRetries = 3;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const res = await getClient().post(
+      "/saves",
+      { url },
+      { auth, headers: idempotencyKey() }
+    );
+    if (res.status === 429) {
+      if (attempt === maxRetries) {
+        throw new Error(`POST /saves still 429 after ${maxRetries} retries`);
+      }
+      const delayMs = 2000 * (attempt + 1);
+      console.log(
+        `    ⏳ Rate limited (429) on save creation, retrying in ${delayMs / 1000}s...`
+      );
+      await sleep(delayMs);
+      continue;
+    }
+    assertStatus(res.status, 201, "createSave: POST /saves");
+    const data = (res.body as { data: { saveId: string; version: number } })
+      .data;
+    return { saveId: data.saveId, version: data.version ?? 1, url };
+  }
+  throw new Error("createSave: unexpected fallthrough");
+}
+
+/**
+ * Delete a save with Idempotency-Key. 404 is treated as success (already deleted).
+ */
+export async function deleteSave(
+  saveId: string,
+  auth: { type: "jwt"; token: string } | { type: "apikey"; key: string }
+): Promise<void> {
+  const res = await getClient().delete(`/saves/${saveId}`, {
+    auth,
+    headers: idempotencyKey(),
+  });
+  if (res.status !== 204 && res.status !== 404) {
+    throw new Error(`deleteSave: expected 204 or 404, got ${res.status}`);
+  }
+}
+
+/**
+ * Assert that a response body matches the standard response envelope:
+ * { data: ..., links: { self: string } }
+ */
+export function assertResponseEnvelope(body: unknown): void {
+  const b = body as Record<string, unknown>;
+  if (b?.data === undefined) {
+    throw new Error(
+      `Response envelope missing "data": ${JSON.stringify(body)}`
+    );
+  }
+  const links = b?.links as Record<string, unknown> | undefined;
+  if (!links?.self) {
+    throw new Error(
+      `Response envelope missing "links.self": ${JSON.stringify(body)}`
+    );
+  }
+}
+
+/**
+ * Assert cursor pagination shape:
+ * { data: [...], meta: { cursor }, links: { self } }
+ */
+export function assertCursorPagination(body: unknown): void {
+  const b = body as Record<string, unknown>;
+  if (!Array.isArray(b?.data)) {
+    throw new Error(
+      `Cursor pagination: "data" is not an array: ${JSON.stringify(body)}`
+    );
+  }
+  const meta = b?.meta as Record<string, unknown> | undefined;
+  if (!meta || !("cursor" in meta)) {
+    throw new Error(
+      `Cursor pagination: missing "meta.cursor": ${JSON.stringify(body)}`
+    );
+  }
+  const links = b?.links as Record<string, unknown> | undefined;
+  if (!links?.self) {
+    throw new Error(
+      `Cursor pagination: missing "links.self": ${JSON.stringify(body)}`
+    );
+  }
 }

--- a/scripts/smoke-test/phases.ts
+++ b/scripts/smoke-test/phases.ts
@@ -3,11 +3,13 @@
  * Phase registry for grouped scenario execution.
  *
  * Story 3.1.6: Introduces phase-based grouping with --phase=N and --up-to=N support.
+ * Story 3.2.11: Added ops, discovery, agent-native to Phase 1; command to Phase 2;
+ * batch to Phase 3.
  *
  * Phase numbering:
- *   Phase 1: Infrastructure & Auth (existing AC1–AC14)
- *   Phase 2: Saves CRUD Lifecycle (SC1–SC8)
- *   Phase 3: (reserved for future)
+ *   Phase 1: Infrastructure & Auth (existing AC1–AC14, + OP1–OP2, DS1–DS2, AN1, AN5, AN6, AN8)
+ *   Phase 2: Saves CRUD Lifecycle (SC1–SC8, + CM1–CM4, AN2, AN3, AN4, AN7)
+ *   Phase 3: Batch Operations (BA1–BA3)
  *   Phase 4: Saves Validation Errors (SV1–SV4)
  *   Phases 5–6: (reserved for future)
  *   Phase 7: EventBridge Verification (EB1–EB3)
@@ -44,6 +46,22 @@ import {
   eventBridgeVerifyScenarios,
   initEventBridgeCleanup,
 } from "./scenarios/eventbridge-verify.js";
+import { opsEndpointScenarios } from "./scenarios/ops-endpoints.js";
+import { discoveryEndpointScenarios } from "./scenarios/discovery-endpoints.js";
+import { commandEndpointScenarios } from "./scenarios/command-endpoints.js";
+import { batchOperationScenarios } from "./scenarios/batch-operations.js";
+import { agentNativeBehaviorScenarios } from "./scenarios/agent-native-behaviors.js";
+
+// Split agent-native scenarios by phase dependency:
+// Phase 1 (no saves dependency): AN1, AN5, AN6, AN8
+// Phase 2 (saves-dependent): AN2, AN3, AN4, AN7
+const phase1AgentNativeIds = new Set(["AN1", "AN5", "AN6", "AN8"]);
+const phase1AgentNative = agentNativeBehaviorScenarios.filter((s) =>
+  phase1AgentNativeIds.has(s.id)
+);
+const phase2AgentNative = agentNativeBehaviorScenarios.filter(
+  (s) => !phase1AgentNativeIds.has(s.id)
+);
 
 export const phases: Phase[] = [
   {
@@ -55,6 +73,9 @@ export const phases: Phase[] = [
       ...routeConnectivityScenarios,
       ...userProfileScenarios,
       ...rateLimitingScenarios,
+      ...opsEndpointScenarios,
+      ...discoveryEndpointScenarios,
+      ...phase1AgentNative,
     ],
     init: (registerCleanup) => {
       initApiKeyCleanup(registerCleanup);
@@ -63,12 +84,20 @@ export const phases: Phase[] = [
   {
     id: 2,
     name: "Saves CRUD Lifecycle",
-    scenarios: [...savesCrudScenarios],
+    scenarios: [
+      ...savesCrudScenarios,
+      ...commandEndpointScenarios,
+      ...phase2AgentNative,
+    ],
     init: (registerCleanup) => {
       initSavesCrudCleanup(registerCleanup);
     },
   },
-  // Phase 3 reserved for future use
+  {
+    id: 3,
+    name: "Batch Operations",
+    scenarios: [...batchOperationScenarios],
+  },
   {
     id: 4,
     name: "Saves Validation Errors",

--- a/scripts/smoke-test/scenarios/agent-native-behaviors.ts
+++ b/scripts/smoke-test/scenarios/agent-native-behaviors.ts
@@ -1,0 +1,312 @@
+/**
+ * smoke-test/scenarios/agent-native-behaviors.ts
+ * Agent-native behavior validation scenarios (AN1–AN8).
+ *
+ * Story 3.2.11: Cross-cutting agent-native API behaviors introduced in Epic 3.2.
+ */
+
+import type { ScenarioDefinition } from "../types.js";
+import { getClient } from "../client.js";
+import {
+  assertStatus,
+  assertADR008,
+  assertResponseEnvelope,
+  assertCursorPagination,
+  assertHeader,
+  jwtAuth,
+  idempotencyKey,
+  createSave,
+  deleteSave,
+} from "../helpers.js";
+
+export const agentNativeBehaviorScenarios: ScenarioDefinition[] = [
+  // AN1: Response envelope on authenticated endpoints
+  {
+    id: "AN1",
+    name: "GET /users/me → response envelope (data, links.self)",
+    async run() {
+      const client = getClient();
+      const auth = jwtAuth();
+
+      const res = await client.get("/users/me", { auth });
+      assertStatus(res.status, 200, "AN1: GET /users/me");
+      assertResponseEnvelope(res.body);
+
+      return res.status;
+    },
+  },
+
+  // AN2: Idempotency replay
+  {
+    id: "AN2",
+    name: "POST /saves twice with same Idempotency-Key → same saveId + replayed header",
+    async run() {
+      const auth = jwtAuth();
+      const client = getClient();
+      const idemKey = { "Idempotency-Key": crypto.randomUUID() };
+      const url = `https://example.com/an2-${Date.now()}`;
+
+      const res1 = await client.post(
+        "/saves",
+        { url },
+        {
+          auth,
+          headers: idemKey,
+        }
+      );
+      assertStatus(res1.status, 201, "AN2: first POST /saves");
+      const saveId1 = (res1.body as { data: { saveId: string } }).data.saveId;
+
+      try {
+        const res2 = await client.post(
+          "/saves",
+          { url },
+          {
+            auth,
+            headers: idemKey,
+          }
+        );
+        assertStatus(res2.status, 201, "AN2: second POST /saves (replay)");
+        const saveId2 = (res2.body as { data: { saveId: string } }).data.saveId;
+
+        if (saveId1 !== saveId2) {
+          throw new Error(
+            `AN2: saveId mismatch on replay: "${saveId1}" vs "${saveId2}"`
+          );
+        }
+
+        assertHeader(
+          res2.headers,
+          "x-idempotent-replayed",
+          "AN2: X-Idempotent-Replayed header"
+        );
+
+        return res2.status;
+      } finally {
+        await deleteSave(saveId1, auth).catch(() => undefined);
+      }
+    },
+  },
+
+  // AN3: If-Match conflict → 409 VERSION_CONFLICT
+  {
+    id: "AN3",
+    name: "PATCH /saves/:saveId with stale If-Match → 409 VERSION_CONFLICT",
+    async run() {
+      const auth = jwtAuth();
+
+      const save = await createSave(auth);
+      try {
+        const client = getClient();
+        const res = await client.patch(
+          `/saves/${save.saveId}`,
+          { title: "Should Fail" },
+          {
+            auth,
+            headers: {
+              ...idempotencyKey(),
+              "If-Match": "999",
+            },
+          }
+        );
+        assertStatus(res.status, 409, "AN3: stale If-Match");
+        assertADR008(res.body, "VERSION_CONFLICT");
+
+        const err = (res.body as { error: { currentVersion?: number } }).error;
+        if (typeof err.currentVersion !== "number") {
+          throw new Error(
+            `AN3: expected currentVersion (number) in error body, got: ${JSON.stringify(err)}`
+          );
+        }
+
+        return res.status;
+      } finally {
+        await deleteSave(save.saveId, auth).catch(() => undefined);
+      }
+    },
+  },
+
+  // AN4: Missing If-Match → 428 PRECONDITION_REQUIRED
+  {
+    id: "AN4",
+    name: "PATCH /saves/:saveId without If-Match → 428 PRECONDITION_REQUIRED",
+    async run() {
+      const auth = jwtAuth();
+
+      const save = await createSave(auth);
+      try {
+        const client = getClient();
+        const res = await client.patch(
+          `/saves/${save.saveId}`,
+          { title: "Should Fail" },
+          {
+            auth,
+            headers: idempotencyKey(), // No If-Match
+          }
+        );
+        assertStatus(res.status, 428, "AN4: missing If-Match");
+        assertADR008(res.body, "PRECONDITION_REQUIRED");
+
+        return res.status;
+      } finally {
+        await deleteSave(save.saveId, auth).catch(() => undefined);
+      }
+    },
+  },
+
+  // AN5: Insufficient scope → 403 SCOPE_INSUFFICIENT
+  {
+    id: "AN5",
+    name: "saves:read API key → POST /saves → 403 SCOPE_INSUFFICIENT",
+    async run() {
+      const jwt = process.env.SMOKE_TEST_CLERK_JWT;
+      if (!jwt) throw new Error("SMOKE_TEST_CLERK_JWT is required for AN5");
+      const client = getClient();
+
+      // Create API key with saves:read only
+      const createKeyRes = await client.post(
+        "/users/api-keys",
+        { name: "smoke-scope-an5", scopes: ["saves:read"] },
+        { auth: { type: "jwt", token: jwt }, headers: idempotencyKey() }
+      );
+      assertStatus(createKeyRes.status, 201, "AN5: create API key");
+      const keyData = (createKeyRes.body as { data: Record<string, unknown> })
+        .data;
+      const keyId = String(keyData.id);
+      const keyValue = String(keyData.keyValue ?? keyData.key);
+
+      try {
+        // Attempt POST /saves (requires saves:create) with saves:read key
+        const res = await client.post(
+          "/saves",
+          { url: "https://example.com/an5-scope-test" },
+          {
+            auth: { type: "apikey", key: keyValue },
+            headers: idempotencyKey(),
+          }
+        );
+        assertStatus(res.status, 403, "AN5: insufficient scope");
+        assertADR008(res.body, "SCOPE_INSUFFICIENT");
+
+        const err = (res.body as { error: Record<string, unknown> }).error;
+        if (!err.required_scope) {
+          throw new Error(
+            `AN5: missing required_scope in error body: ${JSON.stringify(err)}`
+          );
+        }
+        if (!err.granted_scopes) {
+          throw new Error(
+            `AN5: missing granted_scopes in error body: ${JSON.stringify(err)}`
+          );
+        }
+
+        return res.status;
+      } finally {
+        // Cleanup API key
+        await client
+          .delete(`/users/api-keys/${keyId}`, {
+            auth: { type: "jwt", token: jwt },
+            headers: idempotencyKey(),
+          })
+          .catch(() => undefined);
+      }
+    },
+  },
+
+  // AN6: Rate limit headers present
+  {
+    id: "AN6",
+    name: "GET /users/me → X-RateLimit-* headers present",
+    async run() {
+      const client = getClient();
+      const auth = jwtAuth();
+
+      const res = await client.get("/users/me", { auth });
+      assertStatus(res.status, 200, "AN6: GET /users/me");
+
+      assertHeader(res.headers, "x-ratelimit-limit", "AN6: X-RateLimit-Limit");
+      assertHeader(
+        res.headers,
+        "x-ratelimit-remaining",
+        "AN6: X-RateLimit-Remaining"
+      );
+      assertHeader(res.headers, "x-ratelimit-reset", "AN6: X-RateLimit-Reset");
+
+      return res.status;
+    },
+  },
+
+  // AN7: Cursor pagination mechanics
+  {
+    id: "AN7",
+    name: "GET /saves?limit=1 → cursor pagination + follow links.next",
+    async run() {
+      const auth = jwtAuth();
+
+      // Create 2 saves so we can paginate
+      const save1 = await createSave(auth);
+      const save2 = await createSave(auth);
+
+      try {
+        const client = getClient();
+
+        // Page 1: limit=1
+        const res1 = await client.get("/saves?limit=1", { auth });
+        assertStatus(res1.status, 200, "AN7: GET /saves?limit=1");
+        assertCursorPagination(res1.body);
+
+        const body1 = res1.body as {
+          data: Array<{ saveId: string }>;
+          meta: { cursor: string | null };
+          links: { self: string; next?: string | null };
+        };
+        if (body1.data.length !== 1) {
+          throw new Error(
+            `AN7: expected 1 item with limit=1, got ${body1.data.length}`
+          );
+        }
+        if (typeof body1.meta.cursor !== "string" || !body1.meta.cursor) {
+          throw new Error(
+            `AN7: expected non-null cursor string, got ${JSON.stringify(body1.meta.cursor)}`
+          );
+        }
+        if (!body1.links.next || !body1.links.next.includes("cursor=")) {
+          throw new Error(
+            `AN7: expected links.next with cursor= param, got "${body1.links.next}"`
+          );
+        }
+
+        // Page 2: follow links.next
+        const res2 = await client.get(body1.links.next, { auth });
+        assertStatus(res2.status, 200, "AN7: follow links.next");
+        const body2 = res2.body as { data: Array<{ saveId: string }> };
+        if (!Array.isArray(body2.data) || body2.data.length === 0) {
+          throw new Error("AN7: following links.next returned empty data");
+        }
+
+        return res1.status;
+      } finally {
+        await deleteSave(save1.saveId, auth).catch(() => undefined);
+        await deleteSave(save2.saveId, auth).catch(() => undefined);
+      }
+    },
+  },
+
+  // AN8: X-Agent-ID accepted
+  {
+    id: "AN8",
+    name: "GET /users/me with X-Agent-ID → 200 accepted",
+    async run() {
+      const client = getClient();
+      const auth = jwtAuth();
+
+      const res = await client.get("/users/me", {
+        auth,
+        headers: { "X-Agent-ID": "smoke-test-agent" },
+      });
+      assertStatus(res.status, 200, "AN8: GET /users/me with X-Agent-ID");
+
+      return res.status;
+    },
+  },
+];

--- a/scripts/smoke-test/scenarios/api-key-auth.ts
+++ b/scripts/smoke-test/scenarios/api-key-auth.ts
@@ -9,6 +9,7 @@ import {
   assertStatus,
   assertUserProfileShape,
   randomInvalidKey,
+  idempotencyKey,
 } from "../helpers.js";
 import type { ScenarioDefinition, CleanupFn } from "../types.js";
 
@@ -39,7 +40,7 @@ async function createKey(
     const res = await getClient().post(
       "/users/api-keys",
       { name, scopes },
-      { auth: { type: "jwt", token: jwt } }
+      { auth: { type: "jwt", token: jwt }, headers: idempotencyKey() }
     );
 
     if (res.status === 429) {
@@ -78,6 +79,7 @@ async function createKey(
 async function deleteKey(id: string, jwt: string): Promise<number> {
   const res = await getClient().delete(`/users/api-keys/${id}`, {
     auth: { type: "jwt", token: jwt },
+    headers: idempotencyKey(),
   });
   return res.status;
 }
@@ -193,22 +195,45 @@ export const apiKeyScenarios: ScenarioDefinition[] = [
 
   {
     id: "AC6",
-    name: "Capture-scope API key → PATCH /users/me → 200 (no handler-level scope enforcement yet)",
+    name: "saves:write API key → PATCH /users/me → 403 SCOPE_INSUFFICIENT",
     async run() {
       const jwt = process.env.SMOKE_TEST_CLERK_JWT;
       if (!jwt) throw new Error("SMOKE_TEST_CLERK_JWT is required for AC6");
 
-      // NOTE: The users-me handler does not enforce scopes at the handler level.
-      // Scope enforcement (SCOPE_INSUFFICIENT) is a future story.
-      // For now, any valid API key can PATCH /users/me regardless of scopes.
-      const key = await createKey(jwt, ["saves:write"], "smoke-capture-key");
+      // Story 3.2.11: Scope enforcement is now active. saves:write cannot access
+      // PATCH /users/me which requires users:write.
+      const key = await createKey(jwt, ["saves:write"], "smoke-scope-key");
       try {
+        // Need to fetch version for If-Match since PATCH /users/me requires it,
+        // but we're using API key auth with wrong scope — the scope check happens
+        // before version check, so we still get 403.
         const res = await getClient().patch(
           "/users/me",
           { displayName: "Scope Test" },
-          { auth: { type: "apikey", key: key.keyValue } }
+          {
+            auth: { type: "apikey", key: key.keyValue },
+            headers: {
+              ...idempotencyKey(),
+              "If-Match": "1",
+            },
+          }
         );
-        assertStatus(res.status, 200, "PATCH /users/me with capture-scope key");
+        assertStatus(res.status, 403, "PATCH /users/me with saves:write key");
+        assertADR008(res.body, "SCOPE_INSUFFICIENT");
+
+        // Validate error body contains scope information
+        const err = (res.body as { error: Record<string, unknown> }).error;
+        if (!err.required_scope) {
+          throw new Error(
+            `AC6: missing required_scope in error body: ${JSON.stringify(res.body)}`
+          );
+        }
+        if (!err.granted_scopes) {
+          throw new Error(
+            `AC6: missing granted_scopes in error body: ${JSON.stringify(res.body)}`
+          );
+        }
+
         return res.status;
       } finally {
         await deleteKey(key.id, jwt).catch(() => undefined);

--- a/scripts/smoke-test/scenarios/batch-operations.ts
+++ b/scripts/smoke-test/scenarios/batch-operations.ts
@@ -1,0 +1,136 @@
+/**
+ * smoke-test/scenarios/batch-operations.ts
+ * Phase 3: Batch operation scenarios (BA1–BA3).
+ *
+ * Story 3.2.11: Tests POST /batch endpoint introduced in Epic 3.2.
+ */
+
+import type { ScenarioDefinition } from "../types.js";
+import { getClient } from "../client.js";
+import { assertStatus, jwtAuth, idempotencyKey } from "../helpers.js";
+
+export const batchOperationScenarios: ScenarioDefinition[] = [
+  // BA1: Batch basic execution — 2 GETs, both succeed
+  {
+    id: "BA1",
+    name: "POST /batch with 2 GETs → 200 + 2 succeeded",
+    async run() {
+      const client = getClient();
+      const auth = jwtAuth();
+
+      const res = await client.post(
+        "/batch",
+        {
+          operations: [
+            { method: "GET", path: "/actions" },
+            { method: "GET", path: "/users/me" },
+          ],
+        },
+        { auth, headers: idempotencyKey() }
+      );
+      assertStatus(res.status, 200, "BA1: POST /batch");
+
+      const body = res.body as {
+        data: {
+          results: Array<{ statusCode: number }>;
+          summary: { total: number; succeeded: number; failed: number };
+        };
+      };
+      if (body.data.results?.length !== 2) {
+        throw new Error(
+          `BA1: expected 2 results, got ${body.data.results?.length}`
+        );
+      }
+      if (body.data.summary?.total !== 2) {
+        throw new Error(
+          `BA1: expected summary.total 2, got ${body.data.summary?.total}`
+        );
+      }
+      if (body.data.summary?.succeeded !== 2) {
+        throw new Error(
+          `BA1: expected summary.succeeded 2, got ${body.data.summary?.succeeded}`
+        );
+      }
+
+      return res.status;
+    },
+  },
+
+  // BA2: Batch partial failure — 1 success + 1 404
+  {
+    id: "BA2",
+    name: "POST /batch with 1 valid + 1 404 → 200 + partial failure",
+    async run() {
+      const client = getClient();
+      const auth = jwtAuth();
+
+      const res = await client.post(
+        "/batch",
+        {
+          operations: [
+            { method: "GET", path: "/actions" },
+            { method: "GET", path: "/saves/00000000000000000000000000" },
+          ],
+        },
+        { auth, headers: idempotencyKey() }
+      );
+      assertStatus(res.status, 200, "BA2: POST /batch");
+
+      const body = res.body as {
+        data: {
+          results: Array<{ statusCode: number }>;
+          summary: { total: number; succeeded: number; failed: number };
+        };
+      };
+      if (body.data.summary?.succeeded !== 1) {
+        throw new Error(
+          `BA2: expected summary.succeeded 1, got ${body.data.summary?.succeeded}`
+        );
+      }
+      if (body.data.summary?.failed !== 1) {
+        throw new Error(
+          `BA2: expected summary.failed 1, got ${body.data.summary?.failed}`
+        );
+      }
+
+      // Validate per-operation statusCode
+      const statusCodes = body.data.results.map((r) => r.statusCode);
+      if (!statusCodes.includes(200)) {
+        throw new Error(
+          `BA2: no 200 status in results: ${JSON.stringify(statusCodes)}`
+        );
+      }
+      if (!statusCodes.includes(404)) {
+        throw new Error(
+          `BA2: no 404 status in results: ${JSON.stringify(statusCodes)}`
+        );
+      }
+
+      return res.status;
+    },
+  },
+
+  // BA3: Batch requires authentication
+  {
+    id: "BA3",
+    name: "POST /batch unauthenticated → 401 or 403",
+    async run() {
+      const client = getClient();
+
+      const res = await client.post(
+        "/batch",
+        {
+          operations: [{ method: "GET", path: "/actions" }],
+        },
+        { auth: { type: "none" } }
+      );
+      if (res.status !== 401 && res.status !== 403) {
+        throw new Error(
+          `BA3: expected 401 or 403, got ${res.status}: ${JSON.stringify(res.body)}`
+        );
+      }
+
+      return res.status;
+    },
+  },
+];

--- a/scripts/smoke-test/scenarios/command-endpoints.ts
+++ b/scripts/smoke-test/scenarios/command-endpoints.ts
@@ -1,0 +1,204 @@
+/**
+ * smoke-test/scenarios/command-endpoints.ts
+ * Phase 2: Command endpoint scenarios (CM1–CM4).
+ *
+ * Story 3.2.11: Tests command-pattern endpoints introduced in Epic 3.2.
+ */
+
+import type { ScenarioDefinition } from "../types.js";
+import { getClient } from "../client.js";
+import {
+  assertStatus,
+  jwtAuth,
+  idempotencyKey,
+  createSave,
+  deleteSave,
+} from "../helpers.js";
+
+// Module-level state shared between CM1 and CM2
+let cm1SaveId: string | null = null;
+
+export const commandEndpointScenarios: ScenarioDefinition[] = [
+  // CM1: POST /saves/{saveId}/update-metadata
+  {
+    id: "CM1",
+    name: "POST /saves/:saveId/update-metadata → 200 + title updated",
+    async run() {
+      const auth = jwtAuth();
+
+      // Create own save (self-contained)
+      const save = await createSave(auth);
+      cm1SaveId = save.saveId;
+
+      try {
+        const client = getClient();
+        const res = await client.post(
+          `/saves/${save.saveId}/update-metadata`,
+          { title: "Updated via command" },
+          {
+            auth,
+            headers: {
+              ...idempotencyKey(),
+              "If-Match": String(save.version),
+            },
+          }
+        );
+        assertStatus(
+          res.status,
+          200,
+          "CM1: POST /saves/:saveId/update-metadata"
+        );
+
+        return res.status;
+      } catch (err) {
+        // If CM1 fails, clean up save immediately
+        await deleteSave(save.saveId, auth).catch(() => undefined);
+        cm1SaveId = null;
+        throw err;
+      }
+    },
+  },
+
+  // CM2: GET /saves/{saveId}/events
+  {
+    id: "CM2",
+    name: "GET /saves/:saveId/events → 200 + event array with eventType",
+    async run() {
+      const auth = jwtAuth();
+      const saveId = cm1SaveId;
+      if (!saveId) throw new Error("CM2 requires CM1 (no saveId)");
+
+      try {
+        const client = getClient();
+        const res = await client.get(`/saves/${saveId}/events`, { auth });
+        assertStatus(res.status, 200, "CM2: GET /saves/:saveId/events");
+
+        const body = res.body as { data: Array<{ eventType: string }> };
+        if (!Array.isArray(body.data) || body.data.length === 0) {
+          throw new Error(
+            `CM2: expected non-empty event array, got ${JSON.stringify(body.data)}`
+          );
+        }
+        const hasEventType = body.data.some((e) => e.eventType);
+        if (!hasEventType) {
+          throw new Error("CM2: no event with eventType in response");
+        }
+
+        return res.status;
+      } finally {
+        // Cleanup CM1's save
+        await deleteSave(saveId, auth).catch(() => undefined);
+        cm1SaveId = null;
+      }
+    },
+  },
+
+  // CM3: POST /users/me/update
+  {
+    id: "CM3",
+    name: "POST /users/me/update → 200 + profile updated",
+    async run() {
+      const auth = jwtAuth();
+      const client = getClient();
+
+      // Fetch current profile for version + original displayName
+      const getRes = await client.get("/users/me", { auth });
+      assertStatus(getRes.status, 200, "CM3: GET /users/me");
+      const profileData = (getRes.body as Record<string, unknown>).data as
+        | Record<string, unknown>
+        | undefined;
+      const original = profileData?.displayName as string | undefined;
+      const version = profileData?.version as number | undefined;
+
+      try {
+        const res = await client.post(
+          "/users/me/update",
+          { displayName: "Smoke Test User" },
+          {
+            auth,
+            headers: {
+              ...idempotencyKey(),
+              ...(version != null ? { "If-Match": String(version) } : {}),
+            },
+          }
+        );
+        assertStatus(res.status, 200, "CM3: POST /users/me/update");
+
+        return res.status;
+      } finally {
+        // Restore original displayName
+        if (original) {
+          const refetch = await client
+            .get("/users/me", { auth })
+            .catch(() => null);
+          const newVersion = refetch
+            ? ((
+                (refetch.body as Record<string, unknown>).data as
+                  | Record<string, unknown>
+                  | undefined
+              )?.version as number | undefined)
+            : undefined;
+          await client
+            .post(
+              "/users/me/update",
+              { displayName: original },
+              {
+                auth,
+                headers: {
+                  ...idempotencyKey(),
+                  ...(newVersion != null
+                    ? { "If-Match": String(newVersion) }
+                    : {}),
+                },
+              }
+            )
+            .catch(() => undefined);
+        }
+      }
+    },
+  },
+
+  // CM4: POST /users/api-keys/{id}/revoke
+  {
+    id: "CM4",
+    name: "POST /users/api-keys/:id/revoke → 200 + revoked key returns 401",
+    async run() {
+      const jwt = process.env.SMOKE_TEST_CLERK_JWT;
+      if (!jwt) throw new Error("SMOKE_TEST_CLERK_JWT is required for CM4");
+      const auth = jwtAuth();
+      const client = getClient();
+
+      // Create a temporary API key
+      const createRes = await client.post(
+        "/users/api-keys",
+        { name: "smoke-revoke-cmd", scopes: ["*"] },
+        { auth, headers: idempotencyKey() }
+      );
+      assertStatus(createRes.status, 201, "CM4: create temp API key");
+      const keyData = (createRes.body as { data: Record<string, unknown> })
+        .data;
+      const keyId = String(keyData.id);
+      const keyValue = String(keyData.keyValue ?? keyData.key);
+
+      // Revoke via command endpoint
+      const revokeRes = await client.post(
+        `/users/api-keys/${keyId}/revoke`,
+        undefined,
+        { auth, headers: idempotencyKey() }
+      );
+      assertStatus(
+        revokeRes.status,
+        200,
+        "CM4: POST /users/api-keys/:id/revoke"
+      );
+
+      // Verify revoked key returns 401
+      const verifyRes = await client.get("/users/me", {
+        auth: { type: "apikey", key: keyValue },
+      });
+      assertStatus(verifyRes.status, 401, "CM4: revoked key → 401");
+
+      return revokeRes.status;
+    },
+  },
+];

--- a/scripts/smoke-test/scenarios/discovery-endpoints.ts
+++ b/scripts/smoke-test/scenarios/discovery-endpoints.ts
@@ -1,0 +1,104 @@
+/**
+ * smoke-test/scenarios/discovery-endpoints.ts
+ * Phase 1: Discovery endpoint scenarios (DS1–DS2).
+ *
+ * Story 3.2.11: Actions catalog and state graph — authenticated.
+ */
+
+import type { ScenarioDefinition } from "../types.js";
+import { getClient } from "../client.js";
+import { assertStatus, assertResponseEnvelope, jwtAuth } from "../helpers.js";
+
+export const discoveryEndpointScenarios: ScenarioDefinition[] = [
+  // DS1: GET /actions (+ entity filter)
+  {
+    id: "DS1",
+    name: "GET /actions → 200 + non-empty catalog with saves and batch actions",
+    async run() {
+      const client = getClient();
+      const auth = jwtAuth();
+
+      // Full catalog
+      const res = await client.get("/actions", { auth });
+      assertStatus(res.status, 200, "DS1: GET /actions");
+      assertResponseEnvelope(res.body);
+
+      const body = res.body as { data: Array<Record<string, unknown>> };
+      if (!Array.isArray(body.data) || body.data.length === 0) {
+        throw new Error(
+          `DS1: expected non-empty data array, got ${JSON.stringify(body.data)}`
+        );
+      }
+
+      // Each action must have required fields
+      for (const action of body.data) {
+        if (
+          !action.actionId ||
+          !action.method ||
+          !action.urlPattern ||
+          !action.description
+        ) {
+          throw new Error(
+            `DS1: action missing required fields: ${JSON.stringify(action)}`
+          );
+        }
+      }
+
+      // Must have at least one saves: action and one batch: action
+      const hasSaves = body.data.some((a) =>
+        String(a.actionId).startsWith("saves:")
+      );
+      const hasBatch = body.data.some((a) =>
+        String(a.actionId).startsWith("batch:")
+      );
+      if (!hasSaves) {
+        throw new Error("DS1: no action with actionId starting with 'saves:'");
+      }
+      if (!hasBatch) {
+        throw new Error("DS1: no action with actionId starting with 'batch:'");
+      }
+
+      // Entity filter: GET /actions?entity=saves
+      const filteredRes = await client.get("/actions?entity=saves", { auth });
+      assertStatus(filteredRes.status, 200, "DS1: GET /actions?entity=saves");
+      const filteredBody = filteredRes.body as {
+        data: Array<{ entityType?: string }>;
+      };
+      if (!Array.isArray(filteredBody.data) || filteredBody.data.length === 0) {
+        throw new Error("DS1: entity filter returned empty results");
+      }
+      for (const action of filteredBody.data) {
+        if (action.entityType !== "saves") {
+          throw new Error(
+            `DS1: entity filter returned non-saves action: ${JSON.stringify(action)}`
+          );
+        }
+      }
+
+      return res.status;
+    },
+  },
+
+  // DS2: GET /states/saves
+  {
+    id: "DS2",
+    name: "GET /states/saves → 200 + state graph data",
+    async run() {
+      const client = getClient();
+      const auth = jwtAuth();
+
+      const res = await client.get("/states/saves", { auth });
+      assertStatus(res.status, 200, "DS2: GET /states/saves");
+      assertResponseEnvelope(res.body);
+
+      const body = res.body as {
+        links: { self: string };
+      };
+      if (!body.links?.self) {
+        throw new Error("DS2: missing links.self in state graph response");
+      }
+
+      return res.status;
+    },
+  },
+];

--- a/scripts/smoke-test/scenarios/eventbridge-verify.ts
+++ b/scripts/smoke-test/scenarios/eventbridge-verify.ts
@@ -13,7 +13,13 @@
 import type { ScenarioDefinition, CleanupFn } from "../types.js";
 import { ScenarioSkipped } from "../types.js";
 import { getClient } from "../client.js";
-import { assertStatus, assertSaveShape, jwtAuth } from "../helpers.js";
+import {
+  assertStatus,
+  assertSaveShape,
+  jwtAuth,
+  idempotencyKey,
+  deleteSave,
+} from "../helpers.js";
 import { waitForLogEvent } from "../cloudwatch-helpers.js";
 
 // Module-level shared state for the EB1→EB2→EB3 chain
@@ -59,7 +65,14 @@ export const eventBridgeVerifyScenarios: ScenarioDefinition[] = [
       // Record time before API call to bound the CloudWatch query window
       const queryStartEpochMs = Date.now() - 30_000;
 
-      const res = await client.post("/saves", { url: uniqueUrl }, { auth });
+      const res = await client.post(
+        "/saves",
+        { url: uniqueUrl },
+        {
+          auth,
+          headers: idempotencyKey(),
+        }
+      );
       assertStatus(res.status, 201, "EB1: POST /saves");
       assertSaveShape(res.body);
 
@@ -69,7 +82,14 @@ export const eventBridgeVerifyScenarios: ScenarioDefinition[] = [
       // Flush: hit SavesCreateFunction again to thaw the Lambda context and let
       // the fire-and-forget PutEvents from the main request complete.
       const flushUrl = `https://example.com/eb-flush-${Date.now()}`;
-      const flushRes = await client.post("/saves", { url: flushUrl }, { auth });
+      const flushRes = await client.post(
+        "/saves",
+        { url: flushUrl },
+        {
+          auth,
+          headers: idempotencyKey(),
+        }
+      );
       if (flushRes.status === 201) {
         flushSaveId = (flushRes.body as { data: { saveId: string } }).data
           .saveId;
@@ -80,11 +100,10 @@ export const eventBridgeVerifyScenarios: ScenarioDefinition[] = [
       if (registerCleanupFn) {
         registerCleanupFn(async () => {
           const cleanupAuth = jwtAuth();
-          const cleanupClient = getClient();
           for (const id of [createdSaveId, flushSaveId]) {
             if (!id) continue;
             try {
-              await cleanupClient.delete(`/saves/${id}`, { auth: cleanupAuth });
+              await deleteSave(id, cleanupAuth);
             } catch {
               // Cleanup errors are non-fatal
             }
@@ -136,19 +155,39 @@ export const eventBridgeVerifyScenarios: ScenarioDefinition[] = [
       // Record time before update
       const updateStartEpochMs = Date.now() - 30_000;
 
+      // Fetch current version for If-Match
+      const getRes = await client.get(`/saves/${createdSaveId}`, { auth });
+      const saveVersion =
+        (getRes.body as { data: { version?: number } })?.data?.version ?? 1;
+
       const res = await client.patch(
         `/saves/${createdSaveId}`,
         { title: "EB2 Smoke" },
-        { auth }
+        {
+          auth,
+          headers: {
+            ...idempotencyKey(),
+            "If-Match": String(saveVersion),
+          },
+        }
       );
       assertStatus(res.status, 200, "EB2: PATCH /saves/:saveId");
 
       // Flush: hit SavesUpdateFunction again to thaw context
       if (flushSaveId) {
+        const flushGet = await client.get(`/saves/${flushSaveId}`, { auth });
+        const flushVersion =
+          (flushGet.body as { data: { version?: number } })?.data?.version ?? 1;
         await client.patch(
           `/saves/${flushSaveId}`,
           { title: "EB2 Flush" },
-          { auth }
+          {
+            auth,
+            headers: {
+              ...idempotencyKey(),
+              "If-Match": String(flushVersion),
+            },
+          }
         );
       }
 
@@ -190,12 +229,15 @@ export const eventBridgeVerifyScenarios: ScenarioDefinition[] = [
       // Record time before delete
       const deleteStartEpochMs = Date.now() - 30_000;
 
-      const res = await client.delete(`/saves/${createdSaveId}`, { auth });
+      const res = await client.delete(`/saves/${createdSaveId}`, {
+        auth,
+        headers: idempotencyKey(),
+      });
       assertStatus(res.status, 204, "EB3: DELETE /saves/:saveId");
 
       // Flush: hit SavesDeleteFunction again to thaw context
       if (flushSaveId) {
-        await client.delete(`/saves/${flushSaveId}`, { auth });
+        await deleteSave(flushSaveId, auth);
         flushSaveId = null; // already cleaned up
       }
 

--- a/scripts/smoke-test/scenarios/index.ts
+++ b/scripts/smoke-test/scenarios/index.ts
@@ -3,6 +3,7 @@
  * Aggregates all scenario definitions in execution order.
  *
  * Story 3.1.6: Added saves-crud and saves-validation exports.
+ * Story 3.2.11: Added ops, discovery, command, batch, agent-native exports.
  * Phase-grouped execution is handled by phases.ts; this file
  * re-exports individual scenario arrays for flexibility.
  */
@@ -14,6 +15,11 @@ export { userProfileScenarios } from "./user-profile.js";
 export { rateLimitingScenarios } from "./rate-limiting.js";
 export { savesCrudScenarios, initSavesCrudCleanup } from "./saves-crud.js";
 export { savesValidationScenarios } from "./saves-validation.js";
+export { opsEndpointScenarios } from "./ops-endpoints.js";
+export { discoveryEndpointScenarios } from "./discovery-endpoints.js";
+export { commandEndpointScenarios } from "./command-endpoints.js";
+export { batchOperationScenarios } from "./batch-operations.js";
+export { agentNativeBehaviorScenarios } from "./agent-native-behaviors.js";
 
 import { jwtAuthScenarios } from "./jwt-auth.js";
 import { apiKeyScenarios } from "./api-key-auth.js";
@@ -22,6 +28,11 @@ import { userProfileScenarios } from "./user-profile.js";
 import { rateLimitingScenarios } from "./rate-limiting.js";
 import { savesCrudScenarios } from "./saves-crud.js";
 import { savesValidationScenarios } from "./saves-validation.js";
+import { opsEndpointScenarios } from "./ops-endpoints.js";
+import { discoveryEndpointScenarios } from "./discovery-endpoints.js";
+import { commandEndpointScenarios } from "./command-endpoints.js";
+import { batchOperationScenarios } from "./batch-operations.js";
+import { agentNativeBehaviorScenarios } from "./agent-native-behaviors.js";
 
 /**
  * Flat list of all scenarios across all phases.
@@ -36,6 +47,11 @@ export const scenarios = [
   ...routeConnectivityScenarios,
   ...userProfileScenarios,
   ...rateLimitingScenarios,
+  ...opsEndpointScenarios,
+  ...discoveryEndpointScenarios,
+  ...agentNativeBehaviorScenarios,
   ...savesCrudScenarios,
+  ...commandEndpointScenarios,
   ...savesValidationScenarios,
+  ...batchOperationScenarios,
 ];

--- a/scripts/smoke-test/scenarios/ops-endpoints.ts
+++ b/scripts/smoke-test/scenarios/ops-endpoints.ts
@@ -1,0 +1,88 @@
+/**
+ * smoke-test/scenarios/ops-endpoints.ts
+ * Phase 1: Ops endpoint scenarios (OP1–OP2).
+ *
+ * Story 3.2.11: Health and readiness endpoints — unauthenticated.
+ */
+
+import type { ScenarioDefinition } from "../types.js";
+import { getClient } from "../client.js";
+import { assertStatus, assertResponseEnvelope } from "../helpers.js";
+
+export const opsEndpointScenarios: ScenarioDefinition[] = [
+  // OP1: GET /health
+  {
+    id: "OP1",
+    name: "GET /health → 200 + healthy status",
+    async run() {
+      const client = getClient();
+
+      const res = await client.get("/health", { auth: { type: "none" } });
+      assertStatus(res.status, 200, "OP1: GET /health");
+      assertResponseEnvelope(res.body);
+
+      const body = res.body as {
+        data: { status: string; timestamp: string; version: string };
+        links: { self: string };
+      };
+      if (body.data.status !== "healthy") {
+        throw new Error(
+          `OP1: expected status "healthy", got "${body.data.status}"`
+        );
+      }
+      if (!body.data.timestamp) {
+        throw new Error("OP1: missing data.timestamp");
+      }
+      if (!body.data.version) {
+        throw new Error("OP1: missing data.version");
+      }
+      if (body.links.self !== "/health") {
+        throw new Error(
+          `OP1: expected links.self "/health", got "${body.links.self}"`
+        );
+      }
+
+      return res.status;
+    },
+  },
+
+  // OP2: GET /ready
+  {
+    id: "OP2",
+    name: "GET /ready → 200 + ready with DynamoDB ok",
+    async run() {
+      const client = getClient();
+
+      const res = await client.get("/ready", { auth: { type: "none" } });
+      assertStatus(res.status, 200, "OP2: GET /ready");
+      assertResponseEnvelope(res.body);
+
+      const body = res.body as {
+        data: {
+          ready: boolean;
+          timestamp: string;
+          dependencies: { dynamodb: string };
+        };
+        links: { self: string };
+      };
+      if (body.data.ready !== true) {
+        throw new Error(`OP2: expected ready true, got ${body.data.ready}`);
+      }
+      if (body.data.dependencies?.dynamodb !== "ok") {
+        throw new Error(
+          `OP2: expected dynamodb "ok", got "${body.data.dependencies?.dynamodb}"`
+        );
+      }
+      if (!body.data.timestamp) {
+        throw new Error("OP2: missing data.timestamp");
+      }
+      if (body.links.self !== "/ready") {
+        throw new Error(
+          `OP2: expected links.self "/ready", got "${body.links.self}"`
+        );
+      }
+
+      return res.status;
+    },
+  },
+];

--- a/scripts/smoke-test/scenarios/saves-crud.ts
+++ b/scripts/smoke-test/scenarios/saves-crud.ts
@@ -13,7 +13,10 @@ import {
   assertStatus,
   assertADR008,
   assertSaveShape,
+  assertCursorPagination,
   jwtAuth,
+  idempotencyKey,
+  deleteSave,
 } from "../helpers.js";
 
 // ULID: 26 uppercase alphanumeric characters — aligned with the backend's
@@ -23,6 +26,7 @@ const ULID_RE = /^[0-9A-Z]{26}$/;
 // Module-level shared state for the lifecycle chain
 let createdSaveId: string | null = null;
 let createdSaveUrl: string | null = null;
+let createdSaveVersion: number = 1;
 let registerCleanupFn: ((fn: CleanupFn) => void) | null = null;
 
 /**
@@ -33,7 +37,7 @@ export function initSavesCrudCleanup(register: (fn: CleanupFn) => void): void {
 }
 
 export const savesCrudScenarios: ScenarioDefinition[] = [
-  // SC1: Create save
+  // SC1: Create save (Story 3.2.11: + Idempotency-Key, store version)
   {
     id: "SC1",
     name: "POST /saves — create with unique URL → 201 + save shape",
@@ -42,11 +46,19 @@ export const savesCrudScenarios: ScenarioDefinition[] = [
       const auth = jwtAuth();
       const uniqueUrl = `https://example.com/smoke-test-${Date.now()}`;
 
-      const res = await client.post("/saves", { url: uniqueUrl }, { auth });
+      const res = await client.post(
+        "/saves",
+        { url: uniqueUrl },
+        {
+          auth,
+          headers: idempotencyKey(),
+        }
+      );
       assertStatus(res.status, 201, "SC1: POST /saves");
       assertSaveShape(res.body);
 
-      const data = (res.body as { data: { saveId: string } }).data;
+      const data = (res.body as { data: { saveId: string; version: number } })
+        .data;
 
       // AC: saveId is a valid ULID (26 chars, Crockford Base32)
       if (!ULID_RE.test(data.saveId)) {
@@ -55,16 +67,13 @@ export const savesCrudScenarios: ScenarioDefinition[] = [
 
       createdSaveId = data.saveId;
       createdSaveUrl = uniqueUrl;
+      createdSaveVersion = data.version ?? 1;
 
       // Register cleanup: soft-delete the save after all scenarios.
-      // Use jwtAuth() and getClient() at execution time to avoid stale tokens.
       if (registerCleanupFn) {
         registerCleanupFn(async () => {
           try {
-            const freshAuth = jwtAuth();
-            await getClient().delete(`/saves/${createdSaveId}`, {
-              auth: freshAuth,
-            });
+            if (createdSaveId) await deleteSave(createdSaveId, jwtAuth());
           } catch {
             // Cleanup errors are non-fatal
           }
@@ -105,10 +114,10 @@ export const savesCrudScenarios: ScenarioDefinition[] = [
     },
   },
 
-  // SC3: List saves (verifies save appears in list)
+  // SC3: List saves (Story 3.2.11: cursor pagination shape)
   {
     id: "SC3",
-    name: "GET /saves — list contains created save + hasMore present",
+    name: "GET /saves — list contains created save + cursor pagination shape",
     async run() {
       if (!createdSaveId) throw new Error("SC3 requires SC1 (no saveId)");
       const client = getClient();
@@ -116,23 +125,14 @@ export const savesCrudScenarios: ScenarioDefinition[] = [
 
       const res = await client.get("/saves", { auth });
       assertStatus(res.status, 200, "SC3: GET /saves");
+      assertCursorPagination(res.body);
 
       const body = res.body as {
-        data: { items: Array<{ saveId: string }>; hasMore: boolean };
+        data: Array<{ saveId: string }>;
+        meta: { cursor: string | null };
+        links: { self: string };
       };
-      if (!Array.isArray(body.data?.items)) {
-        throw new Error(
-          `SC3: data.items is not an array: ${JSON.stringify(res.body)}`
-        );
-      }
-      if (body.data.hasMore === undefined) {
-        throw new Error(
-          `SC3: data.hasMore is missing: ${JSON.stringify(res.body)}`
-        );
-      }
-      const found = body.data.items.some(
-        (item) => item.saveId === createdSaveId
-      );
+      const found = body.data.some((item) => item.saveId === createdSaveId);
       if (!found) {
         throw new Error(`SC3: Created save ${createdSaveId} not found in list`);
       }
@@ -141,7 +141,7 @@ export const savesCrudScenarios: ScenarioDefinition[] = [
     },
   },
 
-  // SC4: Update save
+  // SC4: Update save (Story 3.2.11: + Idempotency-Key, If-Match, store new version)
   {
     id: "SC4",
     name: "PATCH /saves/:saveId — update title → 200 + title changed",
@@ -153,14 +153,25 @@ export const savesCrudScenarios: ScenarioDefinition[] = [
       const res = await client.patch(
         `/saves/${createdSaveId}`,
         { title: "Smoke Test Updated" },
-        { auth }
+        {
+          auth,
+          headers: {
+            ...idempotencyKey(),
+            "If-Match": String(createdSaveVersion),
+          },
+        }
       );
       assertStatus(res.status, 200, "SC4: PATCH /saves/:saveId");
       assertSaveShape(res.body);
 
       const data = (
         res.body as {
-          data: { title: string; createdAt: string; updatedAt: string };
+          data: {
+            title: string;
+            version: number;
+            createdAt: string;
+            updatedAt: string;
+          };
         }
       ).data;
       if (data.title !== "Smoke Test Updated") {
@@ -171,12 +182,13 @@ export const savesCrudScenarios: ScenarioDefinition[] = [
           `SC4: updatedAt (${data.updatedAt}) < createdAt (${data.createdAt})`
         );
       }
+      createdSaveVersion = data.version ?? createdSaveVersion + 1;
 
       return res.status;
     },
   },
 
-  // SC5: Delete save (soft-delete)
+  // SC5: Delete save (Story 3.2.11: + Idempotency-Key)
   {
     id: "SC5",
     name: "DELETE /saves/:saveId — soft-delete → 204",
@@ -185,7 +197,10 @@ export const savesCrudScenarios: ScenarioDefinition[] = [
       const client = getClient();
       const auth = jwtAuth();
 
-      const res = await client.delete(`/saves/${createdSaveId}`, { auth });
+      const res = await client.delete(`/saves/${createdSaveId}`, {
+        auth,
+        headers: idempotencyKey(),
+      });
       assertStatus(res.status, 204, "SC5: DELETE /saves/:saveId");
 
       return res.status;
@@ -209,7 +224,7 @@ export const savesCrudScenarios: ScenarioDefinition[] = [
     },
   },
 
-  // SC7: Restore deleted save
+  // SC7: Restore deleted save (Story 3.2.11: + Idempotency-Key)
   {
     id: "SC7",
     name: "POST /saves/:saveId/restore — restore → 200 + no deletedAt",
@@ -221,7 +236,7 @@ export const savesCrudScenarios: ScenarioDefinition[] = [
       const res = await client.post(
         `/saves/${createdSaveId}/restore`,
         undefined,
-        { auth }
+        { auth, headers: idempotencyKey() }
       );
       assertStatus(res.status, 200, "SC7: POST /saves/:saveId/restore");
       assertSaveShape(res.body);

--- a/scripts/smoke-test/scenarios/saves-validation.ts
+++ b/scripts/smoke-test/scenarios/saves-validation.ts
@@ -8,10 +8,17 @@
 
 import type { ScenarioDefinition } from "../types.js";
 import { getClient } from "../client.js";
-import { assertStatus, assertADR008, jwtAuth } from "../helpers.js";
+import {
+  assertStatus,
+  assertADR008,
+  jwtAuth,
+  idempotencyKey,
+  createSave,
+  deleteSave,
+} from "../helpers.js";
 
 export const savesValidationScenarios: ScenarioDefinition[] = [
-  // SV1: Invalid URL → 400 VALIDATION_ERROR
+  // SV1: Invalid URL → 400 VALIDATION_ERROR (Story 3.2.11: + Idempotency-Key)
   {
     id: "SV1",
     name: "POST /saves with invalid URL → 400 VALIDATION_ERROR",
@@ -19,7 +26,14 @@ export const savesValidationScenarios: ScenarioDefinition[] = [
       const client = getClient();
       const auth = jwtAuth();
 
-      const res = await client.post("/saves", { url: "not-a-url" }, { auth });
+      const res = await client.post(
+        "/saves",
+        { url: "not-a-url" },
+        {
+          auth,
+          headers: idempotencyKey(),
+        }
+      );
       assertStatus(res.status, 400, "SV1: POST /saves invalid URL");
       assertADR008(res.body, "VALIDATION_ERROR");
 
@@ -62,6 +76,7 @@ export const savesValidationScenarios: ScenarioDefinition[] = [
   },
 
   // SV4: Immutable field (url) in PATCH → 400 VALIDATION_ERROR
+  // Story 3.2.11: uses createSave/deleteSave helpers, sends If-Match + Idempotency-Key
   {
     id: "SV4",
     name: "PATCH /saves/:saveId with immutable url field → 400 VALIDATION_ERROR",
@@ -69,33 +84,28 @@ export const savesValidationScenarios: ScenarioDefinition[] = [
       const client = getClient();
       const auth = jwtAuth();
 
-      // Create a temporary save for this test
-      const uniqueUrl = `https://example.com/smoke-validation-${Date.now()}`;
-      const createRes = await client.post(
-        "/saves",
-        { url: uniqueUrl },
-        { auth }
-      );
-      assertStatus(createRes.status, 201, "SV4: setup POST /saves");
-
-      const saveId = (createRes.body as { data: { saveId: string } }).data
-        .saveId;
+      const save = await createSave(auth);
 
       try {
-        // Attempt to PATCH with immutable field
+        // Attempt to PATCH with immutable field — send required headers
         const res = await client.patch(
-          `/saves/${saveId}`,
+          `/saves/${save.saveId}`,
           { url: "https://changed.com" },
-          { auth }
+          {
+            auth,
+            headers: {
+              ...idempotencyKey(),
+              "If-Match": String(save.version),
+            },
+          }
         );
         assertStatus(res.status, 400, "SV4: PATCH immutable field");
         assertADR008(res.body, "VALIDATION_ERROR");
 
         return res.status;
       } finally {
-        // Cleanup: soft-delete the temporary save
         try {
-          await client.delete(`/saves/${saveId}`, { auth });
+          await deleteSave(save.saveId, auth);
         } catch {
           // Cleanup errors are non-fatal
         }

--- a/scripts/smoke-test/scenarios/user-profile.ts
+++ b/scripts/smoke-test/scenarios/user-profile.ts
@@ -4,37 +4,43 @@
  */
 
 import { getClient } from "../client.js";
-import { assertADR008, assertStatus } from "../helpers.js";
+import { assertADR008, assertStatus, idempotencyKey } from "../helpers.js";
 import type { ScenarioDefinition } from "../types.js";
 
 export const userProfileScenarios: ScenarioDefinition[] = [
+  // Story 3.2.11: + If-Match + Idempotency-Key on PATCH /users/me
   {
     id: "AC11",
     name: "Valid JWT → PATCH /users/me displayName → 200 + updated value",
     async run() {
       const jwt = process.env.SMOKE_TEST_CLERK_JWT;
       if (!jwt) throw new Error("SMOKE_TEST_CLERK_JWT is required for AC11");
+      const auth = { type: "jwt" as const, token: jwt };
 
-      // Fetch current profile to save original displayName for restore
-      const getRes = await getClient().get("/users/me", {
-        auth: { type: "jwt", token: jwt },
-      });
+      // Fetch current profile to get version + original displayName
+      const getRes = await getClient().get("/users/me", { auth });
       assertStatus(getRes.status, 200, "GET /users/me before PATCH");
-      const original = (
-        (getRes.body as Record<string, unknown>).data as
-          | Record<string, unknown>
-          | undefined
-      )?.displayName as string | undefined;
+      const profileData = (getRes.body as Record<string, unknown>).data as
+        | Record<string, unknown>
+        | undefined;
+      const original = profileData?.displayName as string | undefined;
+      const version = profileData?.version as number | undefined;
 
       let patched = false;
       try {
         const patchRes = await getClient().patch(
           "/users/me",
           { displayName: "Smoke Test User" },
-          { auth: { type: "jwt", token: jwt } }
+          {
+            auth,
+            headers: {
+              ...idempotencyKey(),
+              ...(version != null ? { "If-Match": String(version) } : {}),
+            },
+          }
         );
         assertStatus(patchRes.status, 200, "PATCH /users/me with displayName");
-        patched = true; // PATCH succeeded — must restore even if body check fails
+        patched = true;
 
         const data =
           ((patchRes.body as Record<string, unknown>).data as
@@ -47,14 +53,30 @@ export const userProfileScenarios: ScenarioDefinition[] = [
         }
         return patchRes.status;
       } finally {
-        // Restore original displayName only if the user had one before
         if (patched && original) {
+          // Re-fetch version before restoring
+          const refetch = await getClient()
+            .get("/users/me", { auth })
+            .catch(() => null);
+          const newVersion = refetch
+            ? ((
+                (refetch.body as Record<string, unknown>).data as
+                  | Record<string, unknown>
+                  | undefined
+              )?.version as number | undefined)
+            : undefined;
           await getClient()
             .patch(
               "/users/me",
               { displayName: original },
               {
-                auth: { type: "jwt", token: jwt },
+                auth,
+                headers: {
+                  ...idempotencyKey(),
+                  ...(newVersion != null
+                    ? { "If-Match": String(newVersion) }
+                    : {}),
+                },
               }
             )
             .catch(() => undefined);
@@ -63,18 +85,34 @@ export const userProfileScenarios: ScenarioDefinition[] = [
     },
   },
 
+  // Story 3.2.11: + If-Match + Idempotency-Key before testing validation
   {
     id: "AC12",
     name: "Invalid PATCH body → 400 VALIDATION_ERROR",
     async run() {
       const jwt = process.env.SMOKE_TEST_CLERK_JWT;
       if (!jwt) throw new Error("SMOKE_TEST_CLERK_JWT is required for AC12");
+      const auth = { type: "jwt" as const, token: jwt };
 
-      // Send a field that should fail validation (unknown field or wrong type)
+      // Fetch version so middleware doesn't reject with 428 before body validation
+      const getRes = await getClient().get("/users/me", { auth });
+      assertStatus(getRes.status, 200, "GET /users/me before invalid PATCH");
+      const version = (
+        (getRes.body as Record<string, unknown>).data as
+          | Record<string, unknown>
+          | undefined
+      )?.version as number | undefined;
+
       const res = await getClient().patch(
         "/users/me",
         { role: "superadmin" },
-        { auth: { type: "jwt", token: jwt } }
+        {
+          auth,
+          headers: {
+            ...idempotencyKey(),
+            ...(version != null ? { "If-Match": String(version) } : {}),
+          },
+        }
       );
       assertStatus(res.status, 400, "PATCH /users/me with invalid body");
       assertADR008(res.body, "VALIDATION_ERROR");


### PR DESCRIPTION
## Summary

Closes #254

Retrofits all existing smoke test scenarios with mandatory Epic 3.2 middleware headers and adds new scenario files covering 9 previously untested endpoints.

### Changes

**Retrofitted scenarios (Part A):**
- saves-crud (SC1–SC8): Idempotency-Key on all mutations, If-Match on PATCH, cursor pagination assertions on list, version tracking
- saves-validation (SV1–SV4): createSave/deleteSave helpers, If-Match + Idempotency-Key on bad PATCH
- api-key-auth (AC5–AC8, AC13): Idempotency-Key on create/delete, AC6 rewritten to assert 403 SCOPE_INSUFFICIENT
- user-profile (AC11–AC12): Fetch version → If-Match + Idempotency-Key on PATCH
- eventbridge-verify (EB1–EB3): Idempotency-Key on all mutations, If-Match on PATCH, deleteSave for cleanup

**New scenarios (Part B):**
- `ops-endpoints.ts` — OP1 (GET /health), OP2 (GET /ready) — unauthenticated
- `discovery-endpoints.ts` — DS1 (GET /actions + entity filter), DS2 (GET /states/saves) — JWT auth
- `command-endpoints.ts` — CM1 (update-metadata), CM2 (event history), CM3 (user update command), CM4 (API key revoke command)
- `batch-operations.ts` — BA1 (2 GETs), BA2 (partial failure), BA3 (unauthenticated rejection)
- `agent-native-behaviors.ts` — AN1 (response envelope), AN2 (idempotency replay), AN3 (409 conflict), AN4 (428 precondition), AN5 (scope enforcement), AN6 (rate limit headers), AN7 (cursor pagination), AN8 (X-Agent-ID)

**Infrastructure (Part C–D):**
- Shared helpers: `idempotencyKey()`, `createSave()`, `deleteSave()`, `assertResponseEnvelope()`, `assertCursorPagination()`
- Phase registry: Phase 1 +ops/discovery/AN1,AN5,AN6,AN8; Phase 2 +command/AN2,AN3,AN4,AN7; Phase 3 (batch)

### Coverage

- 39 acceptance criteria
- 2,100 unit tests passing (no regressions)
- Lint + type-check clean
- 5 new scenario files, 8 retrofitted files

## Test plan

- [ ] All 2,100 unit tests pass (`npm test`)
- [ ] Lint and type-check clean (`npm run lint && npm run type-check`)
- [ ] After deployment: `npm run smoke-test` passes all phases end-to-end
- [ ] `npm run smoke-test -- --phase=1` runs OP1, OP2, DS1, DS2, AN1, AN5, AN6, AN8 alongside existing
- [ ] `npm run smoke-test -- --phase=2` runs retrofitted SC1–SC8, CM1–CM4, AN2, AN3, AN4, AN7
- [ ] `npm run smoke-test -- --phase=3` runs BA1–BA3
- [ ] `npm run smoke-test -- --phase=4` runs retrofitted SV1–SV4

🤖 Generated with [Claude Code](https://claude.com/claude-code)