### PR TITLE
feat: Epic 1 Code Cleanup — type dedup, IAM narrowing, CDK tests (Story 3.5.1)

### DIFF
--- a/.claude/docs/README.md
+++ b/.claude/docs/README.md
@@ -26,6 +26,10 @@ For **Claude Code hooks** (PreToolUse, PostToolUse, Stop): see `.claude/hooks/RE
 
 Start with project-level only; add module/feature CLAUDE.md files as the codebase grows.
 
+## Ephemeral Files
+
+Files named `review-findings-*.md` and `dedup-findings-*.md` in `_bmad-output/implementation-artifacts/` are ephemeral session outputs from the epic auto-review loop. They may be archived or deleted — they are not canonical documentation.
+
 ## Full Sources
 
 **Canonical path for planning output:** `_bmad-output/planning-artifacts/` is BMAD planning output and may be regenerated; do not edit it directly for product docs. See this README for the canonical reference.

--- a/.claude/docs/api-patterns.md
+++ b/.claude/docs/api-patterns.md
@@ -66,6 +66,10 @@ Lambdas use `@ai-learning-hub/middleware`:
 
 All API handlers must use `wrapHandler`; do not return raw responses. Authorizers do not use the wrapper (they use `createLogger()` from `@ai-learning-hub/logging`).
 
+## Logging
+
+API handlers receive `ctx.logger` automatically via `wrapHandler` — no manual logger creation needed. Authorizer Lambdas (JWT, API Key) cannot use `wrapHandler` because they return API Gateway authorizer policy documents, not HTTP responses. Authorizers must call `createLogger()` from `@ai-learning-hub/logging` once per invocation and pass the resulting logger explicitly.
+
 ## Rules
 
 - **No Lambda-to-Lambda:** Call APIs via HTTP or emit events (EventBridge). Never `lambda.invoke()`.

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -216,6 +216,8 @@ paths = [
   '''infra/test/stacks/api/api-gateway.stack.test.ts''',
   '''infra/test/stacks/api/auth-routes.stack.test.ts''',
   '''infra/test/stacks/api/cross-stack-deps.test.ts''',
+  '''infra/test/stacks/api/saves-routes.stack.test.ts''',
+  '''infra/test/stacks/api/ops-routes.stack.test.ts''',
   '''docs/progress/aws-setup-complete.md''',
   # Docs that mention connection-string patterns as examples (mongodb://, postgres://, redis://)
   '''docs/writing-pipeline/projects/''',

--- a/_bmad-output/implementation-artifacts/3-5-1-epic-1-code-cleanup.md
+++ b/_bmad-output/implementation-artifacts/3-5-1-epic-1-code-cleanup.md
@@ -1,0 +1,249 @@
+---
+id: "3.5.1"
+title: "Epic 1 Code Cleanup"
+status: ready-for-dev
+depends_on: []
+touches:
+  - backend/functions/invite-codes/handler.ts
+  - backend/functions/jwt-authorizer/handler.ts
+  - backend/functions/api-key-authorizer/handler.ts
+  - backend/shared/types/src/api.ts
+  - backend/shared/middleware/src/authorizerConstants.ts
+  - backend/shared/middleware/src/index.ts
+  - infra/lib/stacks/api/api-gateway.stack.ts
+  - infra/lib/stacks/auth/auth.stack.ts
+  - infra/test/stacks/auth/auth.stack.test.ts
+  - infra/lib/stacks/api/saves-routes.stack.ts
+  - infra/test/stacks/api/saves-routes.stack.test.ts
+  - infra/test/stacks/api/ops-routes.stack.test.ts
+  - .claude/docs/api-patterns.md
+  - .claude/docs/README.md
+risk: medium
+---
+
+# Story 3.5.1: Epic 1 Code Cleanup
+
+## Story
+
+As a **developer maintaining the ai-learning-hub codebase**,
+I want **the Epic 1 code review findings resolved — type duplication eliminated, IAM permissions narrowed to least-privilege, missing CDK tests added, and stale TODOs/comments cleaned up**,
+so that **the foundation is consistent, secure by default, and fully tested before building on top of it**.
+
+## Acceptance Criteria
+
+1. **AC1: FieldValidationError de-duplicated** — `backend/shared/types/src/api.ts` no longer declares its own `FieldValidationError` interface; it re-exports the canonical `ValidationErrorDetail` from `@ai-learning-hub/validation` as `FieldValidationError`. The `validation` package remains the single source of truth; all consumers receive structurally identical types regardless of which package they import from.
+
+2. **AC2: AUTHORIZER_CACHE_TTL consolidated** — `AUTHORIZER_CACHE_TTL = 300` is defined exactly once, in `@ai-learning-hub/middleware`. Neither authorizer handler declares it locally. CDK's `api-gateway.stack.ts` uses `cdk.Duration.seconds(AUTHORIZER_CACHE_TTL)` for the JWT authorizer `resultsCacheTtl`, so the CDK-synthesized template reflects the value from the shared constant. The API Key authorizer CDK config continues to use `resultsCacheTtl: 0` — this is intentional and is not changed by this story.
+
+3. **AC3: Invite-codes handler imports from local schemas** — `backend/functions/invite-codes/handler.ts` imports `paginationQuerySchema` (and `validateQueryParams`) from `./schemas.js` instead of directly from `@ai-learning-hub/validation`, so the three-file pattern is consistently applied and `schemas.ts` is actually consumed.
+
+4. **AC4: Stale TODO comments removed from authorizers** — The "TODO: Wire into API Gateway TokenAuthorizer in the API story" comment is removed from `jwt-authorizer/handler.ts` and the equivalent "TODO: Wire into API Gateway RequestAuthorizer" from `api-key-authorizer/handler.ts`. Each is replaced with a one-line comment noting the constant is used by CDK for `resultsCacheTtl` (now referencing the shared import from AC2).
+
+5. **AC5: validateInviteFunction IAM narrowed** — `infra/lib/stacks/auth/auth.stack.ts` replaces `inviteCodesTable.grantReadWriteData(this.validateInviteFunction)` with an explicit `addToRolePolicy` granting only `dynamodb:GetItem` and `dynamodb:UpdateItem` on the invite codes table ARN (and its index ARN). `DeleteItem`, `PutItem`, `BatchWriteItem`, `BatchGetItem` are no longer granted to this function.
+
+6. **AC6: generateInviteFunction IAM narrowed** — `infra/lib/stacks/auth/auth.stack.ts` replaces `inviteCodesTable.grantReadWriteData(this.generateInviteFunction)` with an explicit `addToRolePolicy` granting only `dynamodb:PutItem` and `dynamodb:Query` on the invite codes table ARN (and its index ARN). `DeleteItem`, `GetItem` (single-item), `UpdateItem`, `BatchWriteItem` are no longer granted.
+
+7. **AC7: Saves mutation function IAM narrowed for usersTable and eventsTable** — In `saves-routes.stack.ts`, the four mutation functions (`savesCreate`, `savesUpdate`, `savesDelete`, `savesRestore`) replace `usersTable.grantReadWriteData()` with explicit `addToRolePolicy` for only `dynamodb:UpdateItem` + `dynamodb:Query` on usersTable. They replace `eventsTable.grantReadWriteData()` with explicit `addToRolePolicy` for only `dynamodb:PutItem` on eventsTable (append-only). `DeleteItem`, `PutItem` (users), `GetItem` (events), `BatchGetItem`/`BatchWriteItem` on both tables are no longer granted to mutation functions.
+
+8. **AC8: savesGetFunction IAM narrowed** — In `saves-routes.stack.ts`, `savesTable.grantReadWriteData(savesGetFunction)` is replaced with an explicit `addToRolePolicy` granting only `dynamodb:GetItem` and `dynamodb:UpdateItem` on savesTable ARN (and index ARN). `PutItem`, `DeleteItem`, `BatchGetItem`, `BatchWriteItem` on the saves table are no longer granted to the GET handler.
+
+9. **AC9: NAG suppressions tightened after IAM narrowing** — After fixing AC5–AC8, the blanket `AwsSolutions-IAM5` suppressions in `saves-routes.stack.ts` and `auth.stack.ts` are updated: the `reason` text accurately reflects that wildcards are scoped to `index/*` only (not broad table-level wildcards), and `appliesTo` arrays limit each suppression to `Resource::<table-arn>/index/*` patterns where applicable.
+
+10. **AC10: CDK test for SavesRoutesStack added** — `infra/test/stacks/api/saves-routes.stack.test.ts` is created following the `auth.stack.test.ts` pattern. It asserts: (a) Lambda function count and runtime for the seven saves functions, (b) IAM grants per function reflecting the narrowed permissions from AC7–AC8, (c) required environment variables on each function, (d) route resource and method presence matching the route registry.
+
+11. **AC11: CDK test for OpsRoutesStack added** — `infra/test/stacks/api/ops-routes.stack.test.ts` is created. It asserts: Lambda function count and runtime for health, readiness, and batch functions; environment variables; route resource and method presence.
+
+12. **AC12: Auth stack IAM tests made function-specific** — The generic "grants the Lambda read/write access to users table" test in `auth.stack.test.ts` is replaced with function-specific assertions. Each Lambda in `AuthStack` that has an explicit policy gets its own assertion verifying the actions and table ARN bound to that function's role (using CDK logical ID matching, as done in the existing API Key authorizer tests). A test that accidentally grants `DeleteItem` to `usersMeFunction` would now fail.
+
+13. **AC13: Logger usage documented in api-patterns.md** — `.claude/docs/api-patterns.md` gains a "Logging" subsection explaining: API handlers receive `ctx.logger` via `wrapHandler`; authorizers (JWT, API Key) cannot use `wrapHandler` and must call `createLogger()` from `@ai-learning-hub/logging` once per invocation. No code changes.
+
+14. **AC14: CORS intent documented in route stacks** — A short inline comment is added to the `allowOrigins: apigateway.Cors.ALL_ORIGINS` lines in `saves-routes.stack.ts` and `ops-routes.stack.ts` explaining the intent (agent callers may originate from arbitrary origins; frontend origin enforcement is at the CloudFront level). No functional change.
+
+15. **AC15: All tests pass and lints clean** — `npm test` passes with no regressions. `npm run lint` passes. `npm run type-check` passes (type alias re-export is valid TypeScript). `cdk synth` succeeds with no new CDK Nag errors.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Fix FieldValidationError duplication — types package (AC: #1)
+  - [ ] 1.0 **Circular dependency check (pre-mortem guard):** Before writing any code, check `backend/shared/validation/package.json` — does it already import from `@ai-learning-hub/types`? If yes, adding a re-export from `types` back to `validation` creates a circular dependency. In that case, the direction must flip: define the canonical shape only in `@ai-learning-hub/types`, and have `validation` import from `types`. Document which direction was chosen (and why) in a comment in `api.ts`.
+  - [ ] 1.1 Open `backend/shared/types/src/api.ts`; find the `FieldValidationError` interface (line ~61) and the comment "Mirrors ValidationErrorDetail"
+  - [ ] 1.2 Delete the standalone `FieldValidationError` interface declaration
+  - [ ] 1.3 Add `export type { ValidationErrorDetail as FieldValidationError } from '@ai-learning-hub/validation'` (or import + re-export pattern) at the appropriate location in the file
+  - [ ] 1.4 Run `npm run type-check` in `backend/shared/types` to confirm no type errors; run in root to confirm all consumers still compile
+
+- [ ] Task 2: Consolidate AUTHORIZER_CACHE_TTL (AC: #2)
+  - [ ] 2.1 Create `backend/shared/middleware/src/authorizerConstants.ts` exporting `export const AUTHORIZER_CACHE_TTL = 300;` with a brief JSDoc comment
+  - [ ] 2.2 Add export of `AUTHORIZER_CACHE_TTL` to `backend/shared/middleware/src/index.ts`
+  - [ ] 2.3 In `jwt-authorizer/handler.ts`, remove the local `export const AUTHORIZER_CACHE_TTL = 300` declaration; add import from `@ai-learning-hub/middleware`
+  - [ ] 2.4 In `api-key-authorizer/handler.ts`, remove the local `export const AUTHORIZER_CACHE_TTL = 300` declaration; add import from `@ai-learning-hub/middleware`
+  - [ ] 2.5 In `infra/lib/stacks/api/api-gateway.stack.ts`, import `AUTHORIZER_CACHE_TTL` from `@ai-learning-hub/middleware`; replace the hardcoded `300` in `resultsCacheTtl` with `cdk.Duration.seconds(AUTHORIZER_CACHE_TTL)`
+  - [ ] 2.6 **Build before CDK (pre-mortem guard):** Run `npm run build` in `backend/shared/middleware/` (or at the monorepo root) before running `cdk synth`. CDK resolves `@ai-learning-hub/middleware` from built output — if the package hasn't been rebuilt after adding `authorizerConstants.ts`, CDK will fail with "Cannot find module" even though TypeScript looks fine locally.
+
+- [ ] Task 3: Fix invite-codes import and remove stale TODOs (AC: #3, #4)
+  - [ ] 3.1 In `backend/functions/invite-codes/handler.ts`, change the import of `paginationQuerySchema` (and `validateQueryParams` if present) from `@ai-learning-hub/validation` to `./schemas.js`
+  - [ ] 3.2 Confirm `backend/functions/invite-codes/schemas.ts` already re-exports these from validation (it should per finding 1.1 — no change needed to schemas.ts)
+  - [ ] 3.3 In `jwt-authorizer/handler.ts`, remove the "TODO: Wire into API Gateway TokenAuthorizer in the API story" comment; replace with a one-line note like `// Imported by CDK api-gateway.stack.ts as resultsCacheTtl via @ai-learning-hub/middleware`
+  - [ ] 3.4 In `api-key-authorizer/handler.ts`, remove the equivalent TODO comment with the same type of replacement note
+
+- [ ] Task 4: Narrow IAM — auth.stack.ts (AC: #5, #6)
+  - [ ] 4.1 In `infra/lib/stacks/auth/auth.stack.ts`, locate `inviteCodesTable.grantReadWriteData(this.validateInviteFunction)` (~line 384) and the follow-on `addToRolePolicy` calls
+  - [ ] 4.2 Replace `grantReadWriteData` with an explicit `addToRolePolicy` for `dynamodb:GetItem` + `dynamodb:UpdateItem` on `inviteCodesTable.tableArn` and `${inviteCodesTable.tableArn}/index/*`; remove the existing narrow-scope TODO comment once done
+  - [ ] 4.3 Locate `inviteCodesTable.grantReadWriteData(this.generateInviteFunction)` (~line 574) and replace with explicit `addToRolePolicy` for `dynamodb:PutItem` + `dynamodb:Query` on the same table/index ARNs; remove the existing narrow-scope TODO comment once done
+
+- [ ] Task 5: Narrow IAM — saves-routes.stack.ts (AC: #7, #8, #9)
+  - [ ] 5.0 **Audit actual DynamoDB calls (pre-mortem guard):** Before replacing any `grantReadWriteData`, grep each handler source for all DynamoDB SDK calls (`getItem`, `updateItem`, `query`, `putItem`, `deleteItem`, `batchWriteItem`, etc.). Produce a verified action list per function. Do not rely solely on the code review findings — verify directly in source. Any action found in code but not in the replacement policy is a latent runtime 403.
+  - [ ] 5.1 For each of `savesCreateFunction`, `savesUpdateFunction`, `savesDeleteFunction`, `savesRestoreFunction`: replace `usersTable.grantReadWriteData(fn)` with explicit `addToRolePolicy` for `dynamodb:UpdateItem` + `dynamodb:Query` on usersTable ARN and index ARN
+  - [ ] 5.2 For the same four functions: replace `eventsTable.grantReadWriteData(fn)` with explicit `addToRolePolicy` for `dynamodb:PutItem` only on eventsTable ARN (no index needed for append-only writes)
+  - [ ] 5.3 Replace `savesTable.grantReadWriteData(savesGetFunction)` with explicit `addToRolePolicy` for `dynamodb:GetItem` + `dynamodb:UpdateItem` on savesTable ARN and index ARN
+  - [ ] 5.4 Update CDK Nag suppressions in `saves-routes.stack.ts`: add `appliesTo: ["Resource::<saves-table-arn>/index/*", ...]` to each suppression so they only suppress the expected `index/*` wildcard, not any table-level wildcards introduced accidentally. Update `reason` to "Index ARN wildcards are standard CDK behavior for GSI access"
+
+- [ ] Task 6: Add CDK tests for SavesRoutesStack (AC: #10)
+  - [ ] 6.0 **Read constructor signature first (pre-mortem guard):** Before writing any test code, read `infra/lib/stacks/api/saves-routes.stack.ts` in full to identify the props interface and every required constructor argument (tables, API Gateway RestApi reference, authorizer constructs, etc.). `SavesRoutesStack` likely requires more than just tables — check `infra/test/stacks/api/auth-routes.stack.test.ts` and `api-gateway.stack.test.ts` for how route-level stacks are instantiated in tests. List all required props and plan stubs before writing any test code.
+  - [ ] 6.1 Create `infra/test/stacks/api/saves-routes.stack.test.ts`
+  - [ ] 6.2 Follow the `auth.stack.test.ts` setup pattern: create a test app and mock stacks for all dependent tables; instantiate `SavesRoutesStack`; call `Template.fromStack()`
+  - [ ] 6.3 Assert Lambda function count (7 functions: create, list, get, update, delete, restore, events)
+  - [ ] 6.4 Assert runtime is `NODEJS_22_X` for each function (or whatever the current project runtime is)
+  - [ ] 6.5 Assert required environment variables on each function (e.g. `TABLE_NAME`, `USERS_TABLE_NAME`, `EVENTS_TABLE_NAME`, `POWERTOOLS_SERVICE_NAME`)
+  - [ ] 6.6 Assert IAM policy actions per function — the narrowed permissions from Task 5, not broad `grantReadWriteData`
+  - [ ] 6.7 Assert route resources and methods are present (e.g. `/saves` with GET and POST, `/saves/{saveId}` with GET/PUT/DELETE)
+
+- [ ] Task 7: Add CDK tests for OpsRoutesStack (AC: #11)
+  - [ ] 7.1 Create `infra/test/stacks/api/ops-routes.stack.test.ts`
+  - [ ] 7.2 Set up test app, instantiate `OpsRoutesStack`, call `Template.fromStack()`
+  - [ ] 7.3 Assert Lambda function count and runtime for health, readiness, and batch functions
+  - [ ] 7.4 Assert environment variables on each function
+  - [ ] 7.5 Assert route resources and methods (`/health`, `/readiness`, `/batch/*`)
+
+- [ ] Task 8: Fix auth stack IAM tests to be function-specific (AC: #12)
+  - [ ] 8.0 **Coverage map audit (pre-mortem guard):** Before removing any existing assertion, list ALL Lambda functions in `AuthStack` that have `addToRolePolicy` or `grantReadWriteData` calls. Create a coverage map: `function → expected actions → table`. Confirm a function-specific assertion exists (or will be added) for every single one. The old generic test may have implicitly covered functions not called out in finding 6.2 (e.g. `usersMeFunction`) — those cannot be left without an assertion.
+  - [ ] 8.1 Open `infra/test/stacks/auth/auth.stack.test.ts`; find the "IAM Permissions" describe block (lines ~104–131)
+  - [ ] 8.2 Replace the generic "grants the Lambda read/write access to users table" assertion with per-function assertions for each Lambda that has an explicit IAM policy — using CDK logical ID matching (the same pattern as the existing API Key authorizer tests at lines ~155–219)
+  - [ ] 8.3 Specifically: `jwtAuthorizerFunction` → assert `GetItem`, `PutItem`, `UpdateItem`, `Query` on users table; `validateInviteFunction` → assert `GetItem`, `UpdateItem` on invite-codes table (post AC5 narrowing); `generateInviteFunction` → assert `PutItem`, `Query` on invite-codes table (post AC6 narrowing); `apiKeysFunction` → verify existing assertions still pass
+
+- [ ] Task 9: Documentation updates (AC: #13, #14)
+  - [ ] 9.1 Open `.claude/docs/api-patterns.md`; add a "## Logging" (or "### Logging") subsection documenting the authorizer vs handler logger split
+  - [ ] 9.2 In `saves-routes.stack.ts`, add an inline comment on the `allowOrigins: apigateway.Cors.ALL_ORIGINS` line explaining agent-caller intent and CloudFront frontend enforcement
+  - [ ] 9.3 In `ops-routes.stack.ts`, add the same CORS intent comment
+  - [ ] 9.4 In `.claude/docs/README.md` (or whichever file describes the `.claude/` directory structure), add a one-line note that `review-findings-*.md` and `dedup-findings-*.md` files are ephemeral session outputs and may be archived or deleted — they are not canonical documentation (finding 1.2). No files need to be moved; the note is sufficient.
+
+- [ ] Task 10: Verify (AC: #15)
+  - [ ] 10.1 Run `npm run type-check` — no TypeScript errors
+  - [ ] 10.2 Run `npm test` — all tests pass, no regressions
+  - [ ] 10.3 Run `npm run lint` — no lint errors
+  - [ ] 10.4 Run `cdk synth` — succeeds, no new CDK Nag errors
+  - [ ] 10.5 (Recommended, post-deploy) Run the existing smoke test against the dev environment to confirm no IAM regressions — the IAM narrowing is verified statically by tests but real DynamoDB call paths are only exercised under live traffic
+
+## Dev Notes
+
+- **Scope:** Code cleanup only — no behavior changes, no new features, no API contract changes. Every change should be provably equivalent or strictly tighter (IAM narrowing). If a change is non-trivial to verify as equivalent, add a comment explaining why.
+- **Greenfield rule:** Delete old patterns entirely. No `@deprecated` wrappers, no compatibility re-exports. The duplicate `FieldValidationError` interface in `types` should be removed, not deprecated.
+- **Execution order matters:** Complete Tasks 4–5 (IAM narrowing) before Tasks 6–8 (CDK tests), so the new tests assert the correct narrowed permissions from the start. If you write tests first against current broad permissions, you'll have to rewrite them immediately after.
+- **PR review guidance:** This PR touches two independent risk areas. Review IAM narrowing (Tasks 4–5, ACs 5–9) as a separate pass from the rest — type system, constant consolidation, and tests. Mixing them in one review pass increases the chance of approving an incorrect IAM grant alongside an unrelated doc change.
+- **API Key authorizer TTL must stay at 0:** When consolidating `AUTHORIZER_CACHE_TTL` into `@ai-learning-hub/middleware`, both handlers import the constant — but CDK's `api-gateway.stack.ts` continues to set `resultsCacheTtl: cdk.Duration.seconds(0)` for the API Key authorizer. This is intentional (caching is disabled for API key auth). Do NOT replace the `0` with `AUTHORIZER_CACHE_TTL` for the API Key authorizer in CDK — that would silently enable caching and is a behavioral change.
+- **Finding 6.3 deferred:** Code review finding 6.3 (CI does not run coverage with `--coverage` flag, only validates threshold config exists) is not addressed in this story. It requires a CI YAML change and a root `test:coverage` script, which is a CI infrastructure concern better handled in a dedicated CI hygiene story. Do not attempt to fix it here.
+- **FieldValidationError re-export approach:** The cleanest pattern is a named re-export in `backend/shared/types/src/api.ts`:
+  ```typescript
+  export type { ValidationErrorDetail as FieldValidationError } from '@ai-learning-hub/validation';
+  ```
+  Confirm the `@ai-learning-hub/validation` package is already listed in `backend/shared/types/package.json` dependencies (it likely is via workspace). If not, add it. After this change, any consumer that `import { FieldValidationError } from '@ai-learning-hub/types'` will get the exact same type as `import { ValidationErrorDetail } from '@ai-learning-hub/validation'`.
+- **authorizerConstants.ts location:** Place in `backend/shared/middleware/src/authorizerConstants.ts`. This is the right home because the constant governs the authorizer cache behavior configured in CDK — it's closer to "how the middleware layer (authorizers) is configured" than to types or validation. Export from the middleware `index.ts`.
+- **IAM addToRolePolicy pattern (established in codebase):** Follow the existing pattern from `auth.stack.ts` lines 82–95:
+  ```typescript
+  fn.addToRolePolicy(
+    new iam.PolicyStatement({
+      actions: ["dynamodb:GetItem", "dynamodb:UpdateItem"],
+      resources: [table.tableArn, `${table.tableArn}/index/*`],
+    })
+  );
+  ```
+  Import `* as iam from 'aws-cdk-lib/aws-iam'` (already imported in both stacks). Remove the `grantReadWriteData` call entirely — do not leave both.
+- **⚠️ index/* ARN is not automatic with addToRolePolicy (pre-mortem guard):** `grantReadWriteData` silently adds `${table.tableArn}/index/*` to the resource list so GSI `Query` works. `addToRolePolicy` does NOT — you must add the index ARN explicitly. **Rule: every replacement policy that includes `dynamodb:Query` MUST have `resources: [table.tableArn, \`${table.tableArn}/index/*\`]`.** Omitting the index ARN compiles and synths cleanly but produces a runtime 403 on any GSI query. The only exception is `dynamodb:PutItem` on `eventsTable` (append-only, no GSI needed) which correctly uses only `eventsTable.tableArn`.
+- **eventsTable for saves mutations:** Only `dynamodb:PutItem` is needed — events are append-only from the mutation path. No index ARN needed (PutItem always targets the base table). Use `resources: [eventsTable.tableArn]` only.
+- **usersTable for saves mutations:** Mutations need `UpdateItem` (rate-limit counter increment) and `Query` (profile GSI lookup). Use `resources: [usersTable.tableArn, \`${usersTable.tableArn}/index/*\`]`.
+- **SavesRoutesStack test setup:** The stack requires several DynamoDB table dependencies. Follow the exact same pattern as `auth.stack.test.ts` — create a `TestTablesStack`, create `Table` constructs for each required table, pass them to `SavesRoutesStack` constructor. Check `infra/lib/stacks/api/saves-routes.stack.ts` constructor props type to see exactly which tables are required.
+- **OpsRoutesStack test setup:** Similar approach. Check `infra/lib/stacks/api/ops-routes.stack.ts` constructor signature.
+- **CDK logical ID matching for IAM tests:** The pattern used in `auth.stack.test.ts` lines ~155–219 uses `Match.arrayWith([Match.objectLike({ Ref: Match.stringLikeRegexp("ApiKeyAuthorizer") })])` to scope assertions to a specific function's role. Use the same approach in the new SavesRoutesStack tests.
+- **NAG suppressions `appliesTo`:** The CDK Nag `AwsSolutions-IAM5` suppression with `appliesTo` looks like:
+  ```typescript
+  NagSuppressions.addResourceSuppressions(fn, [{
+    id: "AwsSolutions-IAM5",
+    reason: "Index ARN wildcards are standard CDK behavior for GSI access",
+    appliesTo: ["Resource::<SavesTableArn>/index/*"],
+  }], true);
+  ```
+  Where `<SavesTableArn>` is the CDK token for the table ARN. After the IAM narrowing in Task 5, only the `index/*` wildcard should remain — the broad table-level wildcard from `grantReadWriteData` is eliminated.
+- **invite-codes schemas.ts:** The file already exists with the re-exports (per the review — "the file exists intentionally"). Only the handler import path changes; `schemas.ts` itself is not modified.
+- **api-patterns.md logger section:** Keep it concise — 3–5 lines. The key points: `ctx.logger` from `wrapHandler` for all API handlers; `createLogger()` from `@ai-learning-hub/logging` directly in authorizers (which cannot use `wrapHandler`). Add under a "## Logging" heading or as a subsection of the existing middleware/patterns section.
+
+### Project Structure Notes
+
+- **Backend shared packages** live in `backend/shared/`. The middleware package is at `backend/shared/middleware/src/`. Its barrel export is `backend/shared/middleware/src/index.ts`. The authorizerConstants file should follow the existing single-export-per-file pattern seen in the package.
+- **CDK stacks path:** `infra/lib/stacks/`. Auth stack is `infra/lib/stacks/auth/auth.stack.ts`. Route stacks: `infra/lib/stacks/api/saves-routes.stack.ts` and `infra/lib/stacks/api/ops-routes.stack.ts`.
+- **CDK tests path:** `infra/test/stacks/`. Existing examples: `infra/test/stacks/auth/auth.stack.test.ts`, `infra/test/stacks/api/api-gateway.stack.test.ts`.
+- **File guard:** `infra/` is ESCALATE per workspace rules — the story explicitly scopes changes to the files listed in `touches`, all of which are within this cleanup scope. No new stacks or top-level CDK constructs are created.
+
+### References
+
+- [Source: _bmad-output/implementation-artifacts/epic-1-code-review-output.md] — All findings: 1.1, 2.1, 2.2, 3.1, 4.2, 5.1, 6.1, 6.2, 7.1, 7.2, 7.3, 7.4, 7.5 — canonical source for each task
+- [Source: infra/lib/stacks/auth/auth.stack.ts#lines 82-95] — Established `addToRolePolicy` pattern (jwt-authorizer)
+- [Source: infra/test/stacks/auth/auth.stack.test.ts#lines 104-219] — IAM test patterns including logical ID matching
+- [Source: backend/shared/validation/src/index.ts#lines 55-56] — Current `ValidationErrorDetail` / `FieldValidationError` re-export in validation package
+- [Source: backend/shared/types/src/api.ts#lines 59-67] — Duplicate `FieldValidationError` interface to be removed
+- [Source: infra/lib/stacks/api/saves-routes.stack.ts#lines 145-340] — Current broad `grantReadWriteData` calls to be replaced
+- [Source: infra/lib/stacks/api/saves-routes.stack.ts#lines 436-453] — Current blanket NAG suppressions to be tightened
+
+## Developer Context & Guardrails
+
+### Technical Requirements
+
+- **TypeScript:** All backend and CDK code is TypeScript. `npm run type-check` must pass after every change. The `FieldValidationError` re-export change is a type-only change — no runtime impact, but verify structural compatibility.
+- **CDK:** `aws-cdk-lib` TypeScript. Use `iam.PolicyStatement` for all new explicit grants. IAM `addToRolePolicy` is the established project pattern for least-privilege access (see `auth.stack.ts`).
+- **Shared packages workspace:** `@ai-learning-hub/middleware` is a pnpm workspace package. After adding `authorizerConstants.ts` and its export, run `npm install` at the root (or let the workspace resolve it) to ensure the new export is picked up by consumers (authorizers and CDK).
+- **Test framework:** Vitest for all tests (backend + infra). CDK tests use `@aws-cdk/assertions` (via `aws-cdk-lib/assertions`). Pattern: `Template.fromStack(stack)` + `template.hasResourceProperties()` + `Match.*` helpers.
+
+### Architecture Compliance
+
+- **ADR-008 (Standardized error responses):** The `FieldValidationError` type is part of the standardized error contract. Keeping it as a re-export from `@ai-learning-hub/validation` (single source of truth) is the correct ADR-008-compliant approach.
+- **ADR-006 (CDK multi-stack):** All IAM narrowing changes stay within the existing stacks — no new stacks created.
+- **CLAUDE.md NEVER rules:** No utility functions created without checking `/shared` first; the `authorizerConstants.ts` file is specifically needed in `middleware` as that's where authorizer behavior is configured. No Lambda-to-Lambda calls involved.
+
+### Library / Framework Requirements
+
+- **`@ai-learning-hub/middleware`:** Add `authorizerConstants.ts` here. No new npm packages needed.
+- **`aws-cdk-lib/aws-iam`:** Already imported in both stacks (`* as iam`). Use `iam.PolicyStatement`.
+- **CDK Nag:** `cdk-nag` is already a dev dependency. `NagSuppressions.addResourceSuppressions()` already used in both stacks.
+
+### File Structure Requirements
+
+**New files:**
+- `backend/shared/middleware/src/authorizerConstants.ts` — exports `AUTHORIZER_CACHE_TTL`
+- `infra/test/stacks/api/saves-routes.stack.test.ts` — CDK tests for SavesRoutesStack
+- `infra/test/stacks/api/ops-routes.stack.test.ts` — CDK tests for OpsRoutesStack
+
+**Modified files:**
+- `backend/functions/invite-codes/handler.ts` — update import path
+- `backend/functions/jwt-authorizer/handler.ts` — remove local constant, add import, remove stale TODO
+- `backend/functions/api-key-authorizer/handler.ts` — remove local constant, add import, remove stale TODO
+- `backend/shared/types/src/api.ts` — remove duplicate interface, add re-export
+- `backend/shared/middleware/src/index.ts` — add `authorizerConstants` export
+- `infra/lib/stacks/api/api-gateway.stack.ts` — use imported `AUTHORIZER_CACHE_TTL`
+- `infra/lib/stacks/auth/auth.stack.ts` — narrow inviteFunction IAM, remove TODO comments
+- `infra/test/stacks/auth/auth.stack.test.ts` — make IAM tests function-specific
+- `infra/lib/stacks/api/saves-routes.stack.ts` — narrow IAM, tighten NAG, add CORS comment
+- `.claude/docs/api-patterns.md` — add Logging subsection
+
+### Testing Requirements
+
+- **CDK assertion tests (required):** `saves-routes.stack.test.ts` and `ops-routes.stack.test.ts` must be created with meaningful assertions covering Lambda config, environment variables, IAM, and routes. Follow `auth.stack.test.ts` as the model.
+- **Regression:** All existing tests must still pass — no behavior changes means no test changes except: (a) fixing the generic IAM test in `auth.stack.test.ts` to be function-specific (AC12), and (b) any tests that directly import `FieldValidationError` from `@ai-learning-hub/types` should continue to work since it's still exported (as a re-export).
+- **Type-check:** Run `npm run type-check` after Task 1 (type de-duplication) and again after Task 2 (authorizerConstants) to catch any import issues early.
+- **Coverage:** `npm test` runs with coverage thresholds. The new test files should bring CDK infra test coverage up (SavesRoutesStack and OpsRoutesStack were previously untested stacks).
+
+## Dev Agent Record
+
+### Agent Model Used
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -125,6 +125,11 @@ development_status:
   3-2-9-health-readiness-batch: ready-for-dev
   epic-3-2-retrospective: optional
 
+  # Epic 3.5: Code Cleanup & Technical Integrity (stories generated from code review)
+  epic-3-5-cleanup: in-progress
+  3-5-1-epic-1-code-cleanup: in-progress
+  epic-3-5-retrospective: optional
+
   # Epic 4: Project Management (stories TBD)
   epic-4: backlog
   epic-4-retrospective: optional

--- a/backend/functions/api-key-authorizer/handler.test.ts
+++ b/backend/functions/api-key-authorizer/handler.test.ts
@@ -68,6 +68,7 @@ vi.mock("@ai-learning-hub/middleware", () => ({
     context: { errorCode },
   }),
   getClerkSecretKey: vi.fn().mockResolvedValue("test-clerk-secret-key"),
+  AUTHORIZER_CACHE_TTL: 300,
 }));
 
 import { handler } from "./handler.js";
@@ -588,8 +589,9 @@ describe("API Key Authorizer Handler", () => {
   });
 
   describe("Authorizer cache TTL", () => {
-    it("exports AUTHORIZER_CACHE_TTL = 300", async () => {
-      const { AUTHORIZER_CACHE_TTL } = await import("./handler.js");
+    it("AUTHORIZER_CACHE_TTL = 300 is exported from @ai-learning-hub/middleware", async () => {
+      const { AUTHORIZER_CACHE_TTL } =
+        await import("@ai-learning-hub/middleware");
       expect(AUTHORIZER_CACHE_TTL).toBe(300);
     });
   });

--- a/backend/functions/api-key-authorizer/handler.ts
+++ b/backend/functions/api-key-authorizer/handler.ts
@@ -29,14 +29,6 @@ import {
   getClerkSecretKey,
 } from "@ai-learning-hub/middleware";
 
-/**
- * Authorizer cache TTL in seconds.
- * This value will be consumed by the CDK ApiStack when configuring the
- * API Gateway RequestAuthorizer's resultsCacheTtl.
- * TODO: Wire into API Gateway RequestAuthorizer in the API story.
- */
-export const AUTHORIZER_CACHE_TTL = 300;
-
 function hashApiKey(apiKey: string): string {
   return createHash("sha256").update(apiKey).digest("hex");
 }

--- a/backend/functions/invite-codes/handler.ts
+++ b/backend/functions/invite-codes/handler.ts
@@ -21,10 +21,7 @@ import {
   type HandlerContext,
 } from "@ai-learning-hub/middleware";
 import { AppError, ErrorCode } from "@ai-learning-hub/types";
-import {
-  validateQueryParams,
-  paginationQuerySchema,
-} from "@ai-learning-hub/validation";
+import { validateQueryParams, paginationQuerySchema } from "./schemas.js";
 
 /**
  * POST /users/invite-codes — Generate a new invite code (AC10).

--- a/backend/functions/invite-codes/schemas.ts
+++ b/backend/functions/invite-codes/schemas.ts
@@ -6,4 +6,7 @@
  *
  * Per Story 2.9, Task 3: maintains the three-file pattern (handler, test, schemas).
  */
-export { paginationQuerySchema } from "@ai-learning-hub/validation";
+export {
+  paginationQuerySchema,
+  validateQueryParams,
+} from "@ai-learning-hub/validation";

--- a/backend/functions/jwt-authorizer/handler.test.ts
+++ b/backend/functions/jwt-authorizer/handler.test.ts
@@ -85,6 +85,7 @@ vi.mock("@ai-learning-hub/middleware", () => ({
   }),
   getClerkSecretKey: vi.fn().mockResolvedValue("sk_test_fake_key"),
   resetClerkSecretKeyCache: vi.fn(),
+  AUTHORIZER_CACHE_TTL: 300,
 }));
 
 import { handler } from "./handler.js";
@@ -330,8 +331,9 @@ describe("JWT Authorizer Handler", () => {
   });
 
   describe("AC8: Authorizer cache TTL", () => {
-    it("is exported as AUTHORIZER_CACHE_TTL = 300", async () => {
-      const { AUTHORIZER_CACHE_TTL } = await import("./handler.js");
+    it("AUTHORIZER_CACHE_TTL = 300 is exported from @ai-learning-hub/middleware", async () => {
+      const { AUTHORIZER_CACHE_TTL } =
+        await import("@ai-learning-hub/middleware");
       expect(AUTHORIZER_CACHE_TTL).toBe(300);
     });
   });

--- a/backend/functions/jwt-authorizer/handler.ts
+++ b/backend/functions/jwt-authorizer/handler.ts
@@ -25,14 +25,6 @@ import {
   getClerkSecretKey,
 } from "@ai-learning-hub/middleware";
 
-/**
- * Authorizer cache TTL in seconds (AC8).
- * This value is consumed by the CDK ApiStack when configuring the
- * API Gateway TokenAuthorizer's resultsCacheTtl.
- * TODO: Wire into API Gateway TokenAuthorizer in the API story.
- */
-export const AUTHORIZER_CACHE_TTL = 300;
-
 export async function handler(
   event: APIGatewayTokenAuthorizerEvent,
   _context: Context

--- a/backend/shared/middleware/src/authorizerConstants.ts
+++ b/backend/shared/middleware/src/authorizerConstants.ts
@@ -1,0 +1,6 @@
+/**
+ * Authorizer cache TTL in seconds.
+ * Used by CDK api-gateway.stack.ts for the JWT authorizer's resultsCacheTtl.
+ * The API Key authorizer intentionally uses TTL=0 (caching disabled).
+ */
+export const AUTHORIZER_CACHE_TTL = 300;

--- a/backend/shared/middleware/src/index.ts
+++ b/backend/shared/middleware/src/index.ts
@@ -111,5 +111,8 @@ export type {
   HttpMethod,
 } from "@ai-learning-hub/types";
 
+// Authorizer constants (shared between handlers and CDK)
+export { AUTHORIZER_CACHE_TTL } from "./authorizerConstants.js";
+
 // SSM utilities
 export { getClerkSecretKey, resetClerkSecretKeyCache } from "./ssm.js";

--- a/backend/shared/types/src/api.ts
+++ b/backend/shared/types/src/api.ts
@@ -55,8 +55,9 @@ export interface ApiSuccessResponse<T> {
 
 /**
  * Field-level validation error detail (AC14)
- * Canonical type for individual field validation errors in API responses.
- * Mirrors ValidationErrorDetail from @ai-learning-hub/validation.
+ * Canonical source of truth for field validation error shape.
+ * @ai-learning-hub/validation imports this type (as ValidationErrorDetail)
+ * to avoid circular dependency (validation depends on types, not vice versa).
  */
 export interface FieldValidationError {
   field: string;

--- a/backend/shared/validation/src/validator.ts
+++ b/backend/shared/validation/src/validator.ts
@@ -2,18 +2,18 @@
  * Validation utilities and error formatting
  */
 import { z, ZodError, ZodSchema } from "zod";
-import { AppError, ErrorCode } from "@ai-learning-hub/types";
+import {
+  AppError,
+  ErrorCode,
+  type FieldValidationError,
+} from "@ai-learning-hub/types";
 
 /**
- * Validation error details (AC6: enhanced with constraint and allowed_values)
+ * Validation error details — re-exported from @ai-learning-hub/types
+ * where the canonical FieldValidationError interface lives.
+ * Direction: types owns the shape; validation aliases it to avoid circular deps.
  */
-export interface ValidationErrorDetail {
-  field: string;
-  message: string;
-  code: string;
-  constraint?: string;
-  allowed_values?: string[];
-}
+export type ValidationErrorDetail = FieldValidationError;
 
 /**
  * Format Zod errors into a structured array (AC7: constraint extraction)

--- a/docs/progress/epic-3.5-auto-run.md
+++ b/docs/progress/epic-3.5-auto-run.md
@@ -1,0 +1,36 @@
+---
+epic_id: "3.5"
+epic_title: "Code Cleanup & Technical Integrity"
+status: in-progress
+started: "2026-03-03T16:24:50Z"
+runner: github-cli
+stories:
+  "3.5.1":
+    title: "Epic 1 Code Cleanup"
+    status: pending
+    file: "_bmad-output/implementation-artifacts/3-5-1-epic-1-code-cleanup.md"
+    depends_on: []
+    touches:
+      - backend/functions/invite-codes/handler.ts
+      - backend/functions/jwt-authorizer/handler.ts
+      - backend/functions/api-key-authorizer/handler.ts
+      - backend/shared/types/src/api.ts
+      - backend/shared/middleware/src/authorizerConstants.ts
+      - backend/shared/middleware/src/index.ts
+      - infra/lib/stacks/api/api-gateway.stack.ts
+      - infra/lib/stacks/auth/auth.stack.ts
+      - infra/test/stacks/auth/auth.stack.test.ts
+      - infra/lib/stacks/api/saves-routes.stack.ts
+      - infra/test/stacks/api/saves-routes.stack.test.ts
+      - infra/test/stacks/api/ops-routes.stack.test.ts
+      - .claude/docs/api-patterns.md
+      - .claude/docs/README.md
+---
+
+# Epic 3.5 Auto-Run — Code Cleanup & Technical Integrity
+
+## Activity Log
+
+### Story 3.5.1: Epic 1 Code Cleanup
+
+- [16:24] Story loaded. Status: pending → in-progress

--- a/infra/lib/stacks/api/api-gateway.stack.ts
+++ b/infra/lib/stacks/api/api-gateway.stack.ts
@@ -21,6 +21,10 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 // wafv2 import removed — WAF association moved to ApiDeploymentStack
 import { NagSuppressions } from "cdk-nag";
 import { Construct } from "constructs";
+// Canonical value lives in @ai-learning-hub/middleware (AUTHORIZER_CACHE_TTL).
+// CDK runs as CJS and cannot require() the ESM middleware package at synth time,
+// so we duplicate the constant here. Keep in sync with middleware/authorizerConstants.ts.
+const AUTHORIZER_CACHE_TTL = 300;
 
 export interface ApiGatewayStackProps extends cdk.StackProps {
   /** JWT authorizer Lambda ARN (from AuthStack.jwtAuthorizerFunction.functionArn).
@@ -157,7 +161,7 @@ export class ApiGatewayStack extends cdk.Stack {
     this.jwtAuthorizer = new apigateway.TokenAuthorizer(this, "JwtAuthorizer", {
       handler: jwtAuthorizerFunction,
       identitySource: apigateway.IdentitySource.header("Authorization"),
-      resultsCacheTtl: cdk.Duration.seconds(300),
+      resultsCacheTtl: cdk.Duration.seconds(AUTHORIZER_CACHE_TTL),
       authorizerName: "jwt-authorizer",
     });
 

--- a/infra/lib/stacks/api/ops-routes.stack.ts
+++ b/infra/lib/stacks/api/ops-routes.stack.ts
@@ -66,6 +66,8 @@ export class OpsRoutesStack extends cdk.Stack {
     // CORS preflight config — must match api-gateway.stack.ts since imported
     // APIs do NOT inherit defaultCorsPreflightOptions
     const corsOptions: apigateway.CorsOptions = {
+      // ALL_ORIGINS: agent callers may originate from arbitrary origins;
+      // frontend origin enforcement is at the CloudFront level.
       allowOrigins: apigateway.Cors.ALL_ORIGINS,
       allowMethods: apigateway.Cors.ALL_METHODS,
       allowHeaders: [

--- a/infra/lib/stacks/api/saves-routes.stack.ts
+++ b/infra/lib/stacks/api/saves-routes.stack.ts
@@ -72,6 +72,8 @@ export class SavesRoutesStack extends cdk.Stack {
     // CORS preflight config — must match api-gateway.stack.ts since imported
     // APIs do NOT inherit defaultCorsPreflightOptions
     const corsOptions: apigateway.CorsOptions = {
+      // ALL_ORIGINS: agent callers may originate from arbitrary origins;
+      // frontend origin enforcement is at the CloudFront level.
       allowOrigins: apigateway.Cors.ALL_ORIGINS,
       allowMethods: apigateway.Cors.ALL_METHODS,
       allowHeaders: [
@@ -141,11 +143,23 @@ export class SavesRoutesStack extends cdk.Stack {
       }
     );
 
-    // IAM permissions
+    // IAM permissions — savesTable + idempotency retain broad grants; usersTable + eventsTable narrowed
     savesTable.grantReadWriteData(this.savesCreateFunction);
-    usersTable.grantReadWriteData(this.savesCreateFunction);
     idempotencyTable.grantReadWriteData(this.savesCreateFunction);
-    eventsTable.grantReadWriteData(this.savesCreateFunction);
+    // usersTable: UpdateItem only (rate-limit counter increment)
+    this.savesCreateFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["dynamodb:UpdateItem"],
+        resources: [usersTable.tableArn],
+      })
+    );
+    // eventsTable: PutItem only (append-only event recording)
+    this.savesCreateFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["dynamodb:PutItem"],
+        resources: [eventsTable.tableArn],
+      })
+    );
 
     // EventBridge PutEvents permission
     this.savesCreateFunction.addToRolePolicy(
@@ -215,8 +229,13 @@ export class SavesRoutesStack extends cdk.Stack {
         bundling: readOnlyBundling,
       }
     );
-    // grantReadWriteData for updateItem (lastAccessedAt)
-    savesTable.grantReadWriteData(savesGetFunction);
+    // Least-privilege: GetItem (read save), UpdateItem (lastAccessedAt)
+    savesGetFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["dynamodb:GetItem", "dynamodb:UpdateItem"],
+        resources: [savesTable.tableArn],
+      })
+    );
     this.savesGetFunction = savesGetFunction;
 
     // saves-update — PATCH + POST update-metadata /saves/:saveId (Story 3.3, 3.2.7)
@@ -240,9 +259,21 @@ export class SavesRoutesStack extends cdk.Stack {
       }
     );
     savesTable.grantReadWriteData(savesUpdateFunction);
-    usersTable.grantReadWriteData(savesUpdateFunction);
     idempotencyTable.grantReadWriteData(savesUpdateFunction);
-    eventsTable.grantReadWriteData(savesUpdateFunction);
+    // usersTable: UpdateItem only (rate-limit counter increment)
+    savesUpdateFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["dynamodb:UpdateItem"],
+        resources: [usersTable.tableArn],
+      })
+    );
+    // eventsTable: PutItem only (append-only event recording)
+    savesUpdateFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["dynamodb:PutItem"],
+        resources: [eventsTable.tableArn],
+      })
+    );
     savesUpdateFunction.addToRolePolicy(
       new iam.PolicyStatement({
         actions: ["events:PutEvents"],
@@ -272,9 +303,21 @@ export class SavesRoutesStack extends cdk.Stack {
       }
     );
     savesTable.grantReadWriteData(savesDeleteFunction);
-    usersTable.grantReadWriteData(savesDeleteFunction);
     idempotencyTable.grantReadWriteData(savesDeleteFunction);
-    eventsTable.grantReadWriteData(savesDeleteFunction);
+    // usersTable: UpdateItem only (rate-limit counter increment)
+    savesDeleteFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["dynamodb:UpdateItem"],
+        resources: [usersTable.tableArn],
+      })
+    );
+    // eventsTable: PutItem only (append-only event recording)
+    savesDeleteFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["dynamodb:PutItem"],
+        resources: [eventsTable.tableArn],
+      })
+    );
     savesDeleteFunction.addToRolePolicy(
       new iam.PolicyStatement({
         actions: ["events:PutEvents"],
@@ -304,9 +347,21 @@ export class SavesRoutesStack extends cdk.Stack {
       }
     );
     savesTable.grantReadWriteData(savesRestoreFunction);
-    usersTable.grantReadWriteData(savesRestoreFunction);
     idempotencyTable.grantReadWriteData(savesRestoreFunction);
-    eventsTable.grantReadWriteData(savesRestoreFunction);
+    // usersTable: UpdateItem only (rate-limit counter increment)
+    savesRestoreFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["dynamodb:UpdateItem"],
+        resources: [usersTable.tableArn],
+      })
+    );
+    // eventsTable: PutItem only (append-only event recording)
+    savesRestoreFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["dynamodb:PutItem"],
+        resources: [eventsTable.tableArn],
+      })
+    );
     savesRestoreFunction.addToRolePolicy(
       new iam.PolicyStatement({
         actions: ["events:PutEvents"],
@@ -442,7 +497,7 @@ export class SavesRoutesStack extends cdk.Stack {
       {
         id: "AwsSolutions-IAM5",
         reason:
-          "DynamoDB table grants include index ARNs with wildcards, which is standard CDK behavior",
+          "Index ARN wildcards are standard CDK behavior for GSI access; remaining broad grants are on savesTable and idempotencyTable only",
       },
       {
         id: "AwsSolutions-L1",

--- a/infra/lib/stacks/auth/auth.stack.ts
+++ b/infra/lib/stacks/auth/auth.stack.ts
@@ -378,10 +378,16 @@ export class AuthStack extends cdk.Stack {
       }
     );
 
-    // Grant read/write to invite-codes table (GetItem for lookup, UpdateItem for redemption)
-    // TODO: Narrow to explicit actions (dynamodb:GetItem + dynamodb:UpdateItem) in a future story.
-    // AC16 only covers authorizer Lambdas; this function is out of scope for D7.
-    inviteCodesTable.grantReadWriteData(this.validateInviteFunction);
+    // Least-privilege: GetItem for invite lookup, UpdateItem for redemption
+    this.validateInviteFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["dynamodb:GetItem", "dynamodb:UpdateItem"],
+        resources: [
+          inviteCodesTable.tableArn,
+          `${inviteCodesTable.tableArn}/index/*`,
+        ],
+      })
+    );
 
     // Grant least-privilege: only UpdateItem needed for rate limit counter increments (Story 2.7)
     this.validateInviteFunction.addToRolePolicy(
@@ -432,7 +438,7 @@ export class AuthStack extends cdk.Stack {
         {
           id: "AwsSolutions-IAM5",
           reason:
-            "Wildcard permissions for DynamoDB table read/write and X-Ray are scoped to specific table ARN by CDK grantReadWriteData",
+            "Index ARN wildcards are standard CDK behavior for GSI access; X-Ray tracing is managed by CDK Lambda construct",
         },
       ],
       true
@@ -568,10 +574,16 @@ export class AuthStack extends cdk.Stack {
       }
     );
 
-    // Grant read/write to invite-codes table (PutItem for create, Query for list via GSI)
-    // TODO: Narrow to explicit actions (dynamodb:PutItem + dynamodb:Query) in a future story.
-    // AC16 only covers authorizer Lambdas; this function is out of scope for D7.
-    inviteCodesTable.grantReadWriteData(this.generateInviteFunction);
+    // Least-privilege: PutItem for create, Query for list via GSI
+    this.generateInviteFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["dynamodb:PutItem", "dynamodb:Query"],
+        resources: [
+          inviteCodesTable.tableArn,
+          `${inviteCodesTable.tableArn}/index/*`,
+        ],
+      })
+    );
 
     // Grant least-privilege: only UpdateItem needed for rate limit counter increments
     this.generateInviteFunction.addToRolePolicy(
@@ -605,7 +617,7 @@ export class AuthStack extends cdk.Stack {
         {
           id: "AwsSolutions-IAM5",
           reason:
-            "Wildcard permissions for DynamoDB table read/write and X-Ray are scoped to specific table ARN by CDK grantReadWriteData",
+            "Index ARN wildcards are standard CDK behavior for GSI access; X-Ray tracing is managed by CDK Lambda construct",
         },
       ],
       true

--- a/infra/test/stacks/api/ops-routes.stack.test.ts
+++ b/infra/test/stacks/api/ops-routes.stack.test.ts
@@ -1,0 +1,238 @@
+/**
+ * OpsRoutesStack Tests (AC11)
+ *
+ * Validates health, readiness, and batch operations routes:
+ * Lambda count, runtime, environment variables, and API Gateway route wiring.
+ */
+import * as cdk from "aws-cdk-lib";
+import { App, Stack } from "aws-cdk-lib";
+import * as apigateway from "aws-cdk-lib/aws-apigateway";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { Template, Match } from "aws-cdk-lib/assertions";
+import { describe, it, expect, beforeAll } from "vitest";
+import { OpsRoutesStack } from "../../../lib/stacks/api/ops-routes.stack";
+import { getAwsEnv } from "../../../config/aws-env";
+
+describe("OpsRoutesStack", () => {
+  let template: Template;
+
+  beforeAll(() => {
+    const app = new App();
+    const awsEnv = getAwsEnv();
+
+    // Create a standalone RestApi (no ApiGatewayStack needed — avoids
+    // cross-stack resolution issues with the unused JWT authorizer)
+    const apiStack = new Stack(app, "TestApiStack", { env: awsEnv });
+    const restApi = new apigateway.RestApi(apiStack, "TestRestApi", {
+      deploy: false,
+    });
+    // Dummy method to satisfy CDK validation (routes are added cross-stack)
+    restApi.root.addMethod("GET");
+
+    // Create a mock RequestAuthorizer attached to this RestApi
+    const authorizerFn = lambda.Function.fromFunctionArn(
+      apiStack,
+      "MockAuthFn",
+      `arn:aws:lambda:${awsEnv.region ?? "us-east-2"}:${awsEnv.account ?? "123456789012"}:function:MockAuthFn`
+    );
+    const apiKeyAuthorizer = new apigateway.RequestAuthorizer(
+      apiStack,
+      "MockAuthorizer",
+      {
+        handler: authorizerFn,
+        identitySources: [],
+        resultsCacheTtl: cdk.Duration.seconds(0),
+      }
+    );
+
+    // Create mock tables
+    const tablesStack = new Stack(app, "TestTablesStack", { env: awsEnv });
+    const usersTable = new dynamodb.Table(tablesStack, "UsersTable", {
+      tableName: "ai-learning-hub-users",
+      partitionKey: { name: "PK", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "SK", type: dynamodb.AttributeType.STRING },
+    });
+    const inviteCodesTable = new dynamodb.Table(
+      tablesStack,
+      "InviteCodesTable",
+      {
+        tableName: "ai-learning-hub-invite-codes",
+        partitionKey: { name: "PK", type: dynamodb.AttributeType.STRING },
+        sortKey: { name: "SK", type: dynamodb.AttributeType.STRING },
+      }
+    );
+    const savesTable = new dynamodb.Table(tablesStack, "SavesTable", {
+      tableName: "ai-learning-hub-saves",
+      partitionKey: { name: "PK", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "SK", type: dynamodb.AttributeType.STRING },
+    });
+    const idempotencyTable = new dynamodb.Table(
+      tablesStack,
+      "IdempotencyTable",
+      {
+        tableName: "ai-learning-hub-idempotency",
+        partitionKey: { name: "PK", type: dynamodb.AttributeType.STRING },
+      }
+    );
+    const eventsTable = new dynamodb.Table(tablesStack, "EventsTable", {
+      tableName: "ai-learning-hub-events",
+      partitionKey: { name: "PK", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "SK", type: dynamodb.AttributeType.STRING },
+    });
+
+    const stack = new OpsRoutesStack(app, "TestOpsRoutesStack", {
+      env: awsEnv,
+      restApiId: restApi.restApiId,
+      rootResourceId: restApi.restApiRootResourceId,
+      apiKeyAuthorizer,
+      usersTable,
+      inviteCodesTable,
+      savesTable,
+      idempotencyTable,
+      eventsTable,
+      stageName: "dev",
+    });
+
+    template = Template.fromStack(stack);
+  });
+
+  describe("Lambda Functions", () => {
+    it("creates 3 Lambda functions (health, readiness, batch)", () => {
+      template.resourceCountIs("AWS::Lambda::Function", 3);
+    });
+
+    it("all functions use the latest Node.js runtime", () => {
+      const functions = template.findResources("AWS::Lambda::Function");
+      for (const [, fn] of Object.entries(functions)) {
+        const props = (fn as { Properties: Record<string, unknown> })
+          .Properties;
+        expect(props.Runtime).toBe(lambda.Runtime.NODEJS_LATEST.name);
+      }
+    });
+
+    it("all functions have X-Ray tracing enabled", () => {
+      const functions = template.findResources("AWS::Lambda::Function");
+      for (const [, fn] of Object.entries(functions)) {
+        const props = (fn as { Properties: Record<string, unknown> })
+          .Properties;
+        expect(props.TracingConfig).toEqual({ Mode: "Active" });
+      }
+    });
+  });
+
+  describe("Environment Variables", () => {
+    it("all functions have USERS_TABLE_NAME", () => {
+      const functions = template.findResources("AWS::Lambda::Function");
+      for (const [logicalId, fn] of Object.entries(functions)) {
+        const envVars = (
+          fn as {
+            Properties: { Environment: { Variables: Record<string, unknown> } };
+          }
+        ).Properties?.Environment?.Variables;
+        expect(
+          envVars?.USERS_TABLE_NAME,
+          `${logicalId} missing USERS_TABLE_NAME`
+        ).toBeDefined();
+      }
+    });
+
+    it("batch function has API_BASE_URL", () => {
+      template.hasResourceProperties("AWS::Lambda::Function", {
+        FunctionName: "ai-learning-hub-batch",
+        Environment: {
+          Variables: Match.objectLike({
+            API_BASE_URL: Match.anyValue(),
+          }),
+        },
+      });
+    });
+
+    it("batch function has higher memory (512 MB) and timeout (30s)", () => {
+      template.hasResourceProperties("AWS::Lambda::Function", {
+        FunctionName: "ai-learning-hub-batch",
+        MemorySize: 512,
+        Timeout: 30,
+      });
+    });
+  });
+
+  describe("Route Resources", () => {
+    it("creates /health resource", () => {
+      template.hasResourceProperties("AWS::ApiGateway::Resource", {
+        PathPart: "health",
+      });
+    });
+
+    it("creates /ready resource", () => {
+      template.hasResourceProperties("AWS::ApiGateway::Resource", {
+        PathPart: "ready",
+      });
+    });
+
+    it("creates /batch resource", () => {
+      template.hasResourceProperties("AWS::ApiGateway::Resource", {
+        PathPart: "batch",
+      });
+    });
+  });
+
+  describe("Route Methods", () => {
+    it("health and readiness routes use AuthorizationType.NONE", () => {
+      const allMethods = template.findResources("AWS::ApiGateway::Method");
+      const noneMethods = Object.entries(allMethods).filter(([, method]) => {
+        const props = (method as { Properties: Record<string, unknown> })
+          .Properties;
+        return props.HttpMethod === "GET" && props.AuthorizationType === "NONE";
+      });
+      // /health GET and /ready GET
+      expect(noneMethods).toHaveLength(2);
+    });
+
+    it("batch route uses CUSTOM auth type", () => {
+      template.hasResourceProperties("AWS::ApiGateway::Method", {
+        HttpMethod: "POST",
+        AuthorizationType: "CUSTOM",
+      });
+    });
+
+    it("creates OPTIONS preflight methods on route resources", () => {
+      const allMethods = template.findResources("AWS::ApiGateway::Method");
+      const optionsMethods = Object.entries(allMethods).filter(([, method]) => {
+        const props = (method as { Properties: Record<string, unknown> })
+          .Properties;
+        return props.HttpMethod === "OPTIONS";
+      });
+      // /health, /ready, /batch = 3
+      expect(optionsMethods.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe("IAM Permissions", () => {
+    it("readiness function has read access to users table", () => {
+      template.hasResourceProperties("AWS::IAM::Policy", {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: Match.arrayWith(["dynamodb:GetItem"]),
+              Effect: "Allow",
+            }),
+          ]),
+        },
+      });
+    });
+
+    it("batch function has read/write access to idempotency table", () => {
+      template.hasResourceProperties("AWS::IAM::Policy", {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: Match.arrayWith(["dynamodb:PutItem"]),
+              Effect: "Allow",
+            }),
+          ]),
+        },
+      });
+    });
+  });
+});

--- a/infra/test/stacks/api/saves-routes.stack.test.ts
+++ b/infra/test/stacks/api/saves-routes.stack.test.ts
@@ -1,0 +1,402 @@
+/**
+ * SavesRoutesStack Tests (AC10)
+ *
+ * Validates saves CRUD routes: Lambda count, runtime, environment variables,
+ * IAM permissions (narrowed per AC7-AC8), and API Gateway route wiring.
+ */
+import * as cdk from "aws-cdk-lib";
+import { App, Stack } from "aws-cdk-lib";
+import * as apigateway from "aws-cdk-lib/aws-apigateway";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as events from "aws-cdk-lib/aws-events";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { Template, Match } from "aws-cdk-lib/assertions";
+import { describe, it, expect, beforeAll } from "vitest";
+import { SavesRoutesStack } from "../../../lib/stacks/api/saves-routes.stack";
+import { getAwsEnv } from "../../../config/aws-env";
+
+describe("SavesRoutesStack", () => {
+  let template: Template;
+
+  beforeAll(() => {
+    const app = new App();
+    const awsEnv = getAwsEnv();
+
+    // Create a standalone RestApi (no ApiGatewayStack needed — avoids
+    // cross-stack resolution issues with the unused JWT authorizer)
+    const apiStack = new Stack(app, "TestApiStack", { env: awsEnv });
+    const restApi = new apigateway.RestApi(apiStack, "TestRestApi", {
+      deploy: false,
+    });
+    // Dummy method to satisfy CDK validation (routes are added cross-stack)
+    restApi.root.addMethod("GET");
+
+    // Create a mock RequestAuthorizer attached to this RestApi
+    const authorizerFn = lambda.Function.fromFunctionArn(
+      apiStack,
+      "MockAuthFn",
+      `arn:aws:lambda:${awsEnv.region ?? "us-east-2"}:${awsEnv.account ?? "123456789012"}:function:MockAuthFn`
+    );
+    const apiKeyAuthorizer = new apigateway.RequestAuthorizer(
+      apiStack,
+      "MockAuthorizer",
+      {
+        handler: authorizerFn,
+        identitySources: [],
+        resultsCacheTtl: cdk.Duration.seconds(0),
+      }
+    );
+
+    // Create mock tables
+    const tablesStack = new Stack(app, "TestTablesStack", { env: awsEnv });
+    const savesTable = new dynamodb.Table(tablesStack, "SavesTable", {
+      tableName: "ai-learning-hub-saves",
+      partitionKey: { name: "PK", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "SK", type: dynamodb.AttributeType.STRING },
+    });
+    const usersTable = new dynamodb.Table(tablesStack, "UsersTable", {
+      tableName: "ai-learning-hub-users",
+      partitionKey: { name: "PK", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "SK", type: dynamodb.AttributeType.STRING },
+    });
+    const inviteCodesTable = new dynamodb.Table(
+      tablesStack,
+      "InviteCodesTable",
+      {
+        tableName: "ai-learning-hub-invite-codes",
+        partitionKey: { name: "PK", type: dynamodb.AttributeType.STRING },
+        sortKey: { name: "SK", type: dynamodb.AttributeType.STRING },
+      }
+    );
+    const idempotencyTable = new dynamodb.Table(
+      tablesStack,
+      "IdempotencyTable",
+      {
+        tableName: "ai-learning-hub-idempotency",
+        partitionKey: { name: "PK", type: dynamodb.AttributeType.STRING },
+      }
+    );
+    const eventsTable = new dynamodb.Table(tablesStack, "EventsTable", {
+      tableName: "ai-learning-hub-events",
+      partitionKey: { name: "PK", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "SK", type: dynamodb.AttributeType.STRING },
+    });
+    const eventBus = new events.EventBus(tablesStack, "EventBus", {
+      eventBusName: "ai-learning-hub-events",
+    });
+
+    const stack = new SavesRoutesStack(app, "TestSavesRoutesStack", {
+      env: awsEnv,
+      restApiId: restApi.restApiId,
+      rootResourceId: restApi.restApiRootResourceId,
+      apiKeyAuthorizer,
+      savesTable,
+      usersTable,
+      inviteCodesTable,
+      idempotencyTable,
+      eventsTable,
+      eventBus,
+    });
+
+    template = Template.fromStack(stack);
+  });
+
+  describe("Lambda Functions", () => {
+    it("creates 7 Lambda functions (create, list, get, update, delete, restore, events)", () => {
+      template.resourceCountIs("AWS::Lambda::Function", 7);
+    });
+
+    it("all functions use the latest Node.js runtime", () => {
+      const functions = template.findResources("AWS::Lambda::Function");
+      for (const [, fn] of Object.entries(functions)) {
+        const props = (fn as { Properties: Record<string, unknown> })
+          .Properties;
+        expect(props.Runtime).toBe(lambda.Runtime.NODEJS_LATEST.name);
+      }
+    });
+
+    it("all functions have X-Ray tracing enabled", () => {
+      const functions = template.findResources("AWS::Lambda::Function");
+      for (const [, fn] of Object.entries(functions)) {
+        const props = (fn as { Properties: Record<string, unknown> })
+          .Properties;
+        expect(props.TracingConfig).toEqual({ Mode: "Active" });
+      }
+    });
+  });
+
+  describe("Environment Variables", () => {
+    it("all functions have SAVES_TABLE_NAME", () => {
+      const functions = template.findResources("AWS::Lambda::Function");
+      for (const [logicalId, fn] of Object.entries(functions)) {
+        const envVars = (
+          fn as {
+            Properties: { Environment: { Variables: Record<string, unknown> } };
+          }
+        ).Properties?.Environment?.Variables;
+        expect(
+          envVars?.SAVES_TABLE_NAME,
+          `${logicalId} missing SAVES_TABLE_NAME`
+        ).toBeDefined();
+      }
+    });
+
+    it("mutation functions have EVENT_BUS_NAME", () => {
+      const functions = template.findResources("AWS::Lambda::Function");
+      const mutationFns = Object.entries(functions).filter(([, fn]) => {
+        const envVars = (
+          fn as {
+            Properties: { Environment: { Variables: Record<string, unknown> } };
+          }
+        ).Properties?.Environment?.Variables;
+        return envVars?.EVENT_BUS_NAME;
+      });
+      // create, update, delete, restore = 4 mutation functions
+      expect(mutationFns).toHaveLength(4);
+    });
+
+    it("all functions have USERS_TABLE_NAME and INVITE_CODES_TABLE_NAME", () => {
+      const functions = template.findResources("AWS::Lambda::Function");
+      for (const [logicalId, fn] of Object.entries(functions)) {
+        const envVars = (
+          fn as {
+            Properties: { Environment: { Variables: Record<string, unknown> } };
+          }
+        ).Properties?.Environment?.Variables;
+        expect(
+          envVars?.USERS_TABLE_NAME,
+          `${logicalId} missing USERS_TABLE_NAME`
+        ).toBeDefined();
+        expect(
+          envVars?.INVITE_CODES_TABLE_NAME,
+          `${logicalId} missing INVITE_CODES_TABLE_NAME`
+        ).toBeDefined();
+      }
+    });
+  });
+
+  describe("IAM Permissions — Narrowed (AC7, AC8)", () => {
+    it("mutation functions have explicit usersTable policy with UpdateItem only", () => {
+      const policies = template.findResources("AWS::IAM::Policy");
+      const mutationNames = [
+        "SavesCreate",
+        "SavesUpdate",
+        "SavesDelete",
+        "SavesRestore",
+      ];
+      for (const fnName of mutationNames) {
+        const found = Object.values(policies).some((resource) => {
+          const statements =
+            (
+              resource as {
+                Properties: {
+                  PolicyDocument: { Statement: Array<Record<string, unknown>> };
+                  Roles: Array<Record<string, unknown>>;
+                };
+              }
+            ).Properties?.PolicyDocument?.Statement ?? [];
+          const hasUpdateOnly = statements.some((s) => {
+            const actions = s.Action;
+            return (
+              typeof actions === "string" && actions === "dynamodb:UpdateItem"
+            );
+          });
+          const roles =
+            (
+              resource as {
+                Properties: { Roles: Array<Record<string, unknown>> };
+              }
+            ).Properties?.Roles ?? [];
+          const attachedToFn = roles.some((r) => {
+            const ref = (r as Record<string, unknown>).Ref ?? "";
+            return typeof ref === "string" && ref.includes(fnName);
+          });
+          return hasUpdateOnly && attachedToFn;
+        });
+        expect(
+          found,
+          `${fnName} missing UpdateItem-only usersTable policy`
+        ).toBe(true);
+      }
+    });
+
+    it("mutation functions have explicit eventsTable policy with PutItem only", () => {
+      const policies = template.findResources("AWS::IAM::Policy");
+      const mutationNames = [
+        "SavesCreate",
+        "SavesUpdate",
+        "SavesDelete",
+        "SavesRestore",
+      ];
+      for (const fnName of mutationNames) {
+        const found = Object.values(policies).some((resource) => {
+          const statements =
+            (
+              resource as {
+                Properties: {
+                  PolicyDocument: { Statement: Array<Record<string, unknown>> };
+                  Roles: Array<Record<string, unknown>>;
+                };
+              }
+            ).Properties?.PolicyDocument?.Statement ?? [];
+          const hasPutOnly = statements.some((s) => {
+            const actions = s.Action;
+            if (typeof actions === "string")
+              return actions === "dynamodb:PutItem";
+            if (Array.isArray(actions))
+              return actions.length === 1 && actions[0] === "dynamodb:PutItem";
+            return false;
+          });
+          const roles =
+            (
+              resource as {
+                Properties: { Roles: Array<Record<string, unknown>> };
+              }
+            ).Properties?.Roles ?? [];
+          const attachedToFn = roles.some((r) => {
+            const ref = (r as Record<string, unknown>).Ref ?? "";
+            return typeof ref === "string" && ref.includes(fnName);
+          });
+          return hasPutOnly && attachedToFn;
+        });
+        expect(found, `${fnName} missing PutItem-only eventsTable policy`).toBe(
+          true
+        );
+      }
+    });
+
+    it("savesGetFunction has explicit GetItem + UpdateItem policy (not broad grantReadWriteData)", () => {
+      const policies = template.findResources("AWS::IAM::Policy");
+      const found = Object.values(policies).some((resource) => {
+        const statements =
+          (
+            resource as {
+              Properties: {
+                PolicyDocument: { Statement: Array<Record<string, unknown>> };
+                Roles: Array<Record<string, unknown>>;
+              };
+            }
+          ).Properties?.PolicyDocument?.Statement ?? [];
+        const hasGetUpdate = statements.some((s) => {
+          const actions = s.Action;
+          if (!Array.isArray(actions)) return false;
+          return (
+            actions.includes("dynamodb:GetItem") &&
+            actions.includes("dynamodb:UpdateItem") &&
+            !actions.includes("dynamodb:PutItem") &&
+            actions.length === 2
+          );
+        });
+        const roles =
+          (
+            resource as {
+              Properties: { Roles: Array<Record<string, unknown>> };
+            }
+          ).Properties?.Roles ?? [];
+        const attachedToGet = roles.some((r) => {
+          const ref = (r as Record<string, unknown>).Ref ?? "";
+          return typeof ref === "string" && ref.includes("SavesGet");
+        });
+        return hasGetUpdate && attachedToGet;
+      });
+      expect(found, "SavesGet missing GetItem+UpdateItem policy").toBe(true);
+    });
+
+    it("mutation functions have EventBridge PutEvents permission", () => {
+      template.hasResourceProperties("AWS::IAM::Policy", {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: "events:PutEvents",
+              Effect: "Allow",
+            }),
+          ]),
+        },
+      });
+    });
+  });
+
+  describe("Route Resources", () => {
+    it("creates /saves resource", () => {
+      template.hasResourceProperties("AWS::ApiGateway::Resource", {
+        PathPart: "saves",
+      });
+    });
+
+    it("creates /saves/{saveId} resource", () => {
+      template.hasResourceProperties("AWS::ApiGateway::Resource", {
+        PathPart: "{saveId}",
+      });
+    });
+
+    it("creates /saves/{saveId}/restore resource", () => {
+      template.hasResourceProperties("AWS::ApiGateway::Resource", {
+        PathPart: "restore",
+      });
+    });
+
+    it("creates /saves/{saveId}/update-metadata resource", () => {
+      template.hasResourceProperties("AWS::ApiGateway::Resource", {
+        PathPart: "update-metadata",
+      });
+    });
+
+    it("creates /saves/{saveId}/events resource", () => {
+      template.hasResourceProperties("AWS::ApiGateway::Resource", {
+        PathPart: "events",
+      });
+    });
+  });
+
+  describe("Route Methods", () => {
+    it("creates POST method on /saves", () => {
+      template.hasResourceProperties("AWS::ApiGateway::Method", {
+        HttpMethod: "POST",
+        AuthorizationType: "CUSTOM",
+      });
+    });
+
+    it("creates GET method on /saves", () => {
+      template.hasResourceProperties("AWS::ApiGateway::Method", {
+        HttpMethod: "GET",
+        AuthorizationType: "CUSTOM",
+      });
+    });
+
+    it("creates PATCH method on /saves/{saveId}", () => {
+      template.hasResourceProperties("AWS::ApiGateway::Method", {
+        HttpMethod: "PATCH",
+        AuthorizationType: "CUSTOM",
+      });
+    });
+
+    it("creates DELETE method on /saves/{saveId}", () => {
+      template.hasResourceProperties("AWS::ApiGateway::Method", {
+        HttpMethod: "DELETE",
+        AuthorizationType: "CUSTOM",
+      });
+    });
+
+    it("all non-OPTIONS methods use CUSTOM auth type", () => {
+      const allMethods = template.findResources("AWS::ApiGateway::Method");
+      for (const [, method] of Object.entries(allMethods)) {
+        const props = (method as { Properties: Record<string, unknown> })
+          .Properties;
+        if (props.HttpMethod !== "OPTIONS") {
+          expect(props.AuthorizationType).toBe("CUSTOM");
+        }
+      }
+    });
+
+    it("creates OPTIONS preflight methods on route resources", () => {
+      const allMethods = template.findResources("AWS::ApiGateway::Method");
+      const optionsMethods = Object.entries(allMethods).filter(([, method]) => {
+        const props = (method as { Properties: Record<string, unknown> })
+          .Properties;
+        return props.HttpMethod === "OPTIONS";
+      });
+      // /saves, /saves/{saveId}, /restore, /update-metadata, /events = 5
+      expect(optionsMethods.length).toBeGreaterThanOrEqual(5);
+    });
+  });
+});

--- a/infra/test/stacks/auth/auth.stack.test.ts
+++ b/infra/test/stacks/auth/auth.stack.test.ts
@@ -102,22 +102,7 @@ describe("AuthStack", () => {
   });
 
   describe("IAM Permissions", () => {
-    it("grants the Lambda read/write access to users table", () => {
-      // CDK grantReadWriteData creates a policy with DynamoDB actions
-      // The actions may be in one or multiple statements depending on CDK version
-      template.hasResourceProperties("AWS::IAM::Policy", {
-        PolicyDocument: {
-          Statement: Match.arrayWith([
-            Match.objectLike({
-              Action: Match.arrayWith(["dynamodb:PutItem"]),
-              Effect: "Allow",
-            }),
-          ]),
-        },
-      });
-    });
-
-    it("grants the Lambda ssm:GetParameter for the Clerk secret key", () => {
+    it("grants ssm:GetParameter for the Clerk secret key", () => {
       template.hasResourceProperties("AWS::IAM::Policy", {
         PolicyDocument: {
           Statement: Match.arrayWith([
@@ -128,6 +113,118 @@ describe("AuthStack", () => {
           ]),
         },
       });
+    });
+
+    it("validateInviteFunction gets GetItem + UpdateItem on inviteCodesTable (AC12)", () => {
+      const policies = template.findResources("AWS::IAM::Policy");
+      const validateInvitePolicies = Object.values(policies).filter(
+        (resource) => {
+          const statements =
+            resource.Properties?.PolicyDocument?.Statement ?? [];
+          const hasGetUpdateOnly = statements.some(
+            (s: Record<string, unknown>) => {
+              const actions = s.Action;
+              if (!Array.isArray(actions)) return false;
+              return (
+                actions.includes("dynamodb:GetItem") &&
+                actions.includes("dynamodb:UpdateItem") &&
+                !actions.includes("dynamodb:PutItem") &&
+                !actions.includes("dynamodb:Query") &&
+                actions.length === 2
+              );
+            }
+          );
+          const roles = resource.Properties?.Roles ?? [];
+          const attachedToValidateInvite = roles.some(
+            (r: Record<string, unknown>) => {
+              const ref = r.Ref ?? "";
+              return typeof ref === "string" && ref.includes("ValidateInvite");
+            }
+          );
+          return hasGetUpdateOnly && attachedToValidateInvite;
+        }
+      );
+      expect(validateInvitePolicies.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("generateInviteFunction gets PutItem + Query on inviteCodesTable (AC12)", () => {
+      const policies = template.findResources("AWS::IAM::Policy");
+      const generateInvitePolicies = Object.values(policies).filter(
+        (resource) => {
+          const statements =
+            resource.Properties?.PolicyDocument?.Statement ?? [];
+          const hasPutQuery = statements.some((s: Record<string, unknown>) => {
+            const actions = s.Action;
+            if (!Array.isArray(actions)) return false;
+            return (
+              actions.includes("dynamodb:PutItem") &&
+              actions.includes("dynamodb:Query") &&
+              !actions.includes("dynamodb:GetItem") &&
+              !actions.includes("dynamodb:DeleteItem") &&
+              actions.length === 2
+            );
+          });
+          const roles = resource.Properties?.Roles ?? [];
+          const attachedToGenerateInvite = roles.some(
+            (r: Record<string, unknown>) => {
+              const ref = r.Ref ?? "";
+              return typeof ref === "string" && ref.includes("GenerateInvite");
+            }
+          );
+          return hasPutQuery && attachedToGenerateInvite;
+        }
+      );
+      expect(generateInvitePolicies.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("jwtAuthorizerFunction gets GetItem + PutItem + UpdateItem + Query on usersTable (AC12)", () => {
+      const policies = template.findResources("AWS::IAM::Policy");
+      const jwtPolicies = Object.values(policies).filter((resource) => {
+        const statements = resource.Properties?.PolicyDocument?.Statement ?? [];
+        const hasFourActions = statements.some((s: Record<string, unknown>) => {
+          const actions = s.Action;
+          if (!Array.isArray(actions)) return false;
+          return (
+            actions.includes("dynamodb:GetItem") &&
+            actions.includes("dynamodb:PutItem") &&
+            actions.includes("dynamodb:UpdateItem") &&
+            actions.includes("dynamodb:Query") &&
+            actions.length === 4
+          );
+        });
+        const roles = resource.Properties?.Roles ?? [];
+        const attachedToJwt = roles.some((r: Record<string, unknown>) => {
+          const ref = r.Ref ?? "";
+          return typeof ref === "string" && ref.includes("JwtAuthorizer");
+        });
+        return hasFourActions && attachedToJwt;
+      });
+      expect(jwtPolicies.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("usersMeFunction gets GetItem + UpdateItem on usersTable (AC12)", () => {
+      const policies = template.findResources("AWS::IAM::Policy");
+      const usersMePolicies = Object.values(policies).filter((resource) => {
+        const statements = resource.Properties?.PolicyDocument?.Statement ?? [];
+        const hasGetUpdate = statements.some((s: Record<string, unknown>) => {
+          const actions = s.Action;
+          if (!Array.isArray(actions)) return false;
+          return (
+            actions.includes("dynamodb:GetItem") &&
+            actions.includes("dynamodb:UpdateItem") &&
+            !actions.includes("dynamodb:PutItem") &&
+            !actions.includes("dynamodb:Query") &&
+            actions.length === 2
+          );
+        });
+        const roles = resource.Properties?.Roles ?? [];
+        const attachedToUsersMe = roles.some((r: Record<string, unknown>) => {
+          const ref = r.Ref ?? "";
+          return typeof ref === "string" && ref.includes("UsersMe");
+        });
+        return hasGetUpdate && attachedToUsersMe;
+      });
+      expect(usersMePolicies.length).toBeGreaterThanOrEqual(1);
     });
   });
 


### PR DESCRIPTION
## Summary

- **Type deduplication:** `FieldValidationError` canonical in `@ai-learning-hub/types`; `validation` imports as type alias (avoids circular dependency)
- **Constant consolidation:** `AUTHORIZER_CACHE_TTL` extracted to `@ai-learning-hub/middleware`; both authorizer handlers import from single source. CDK duplicates locally due to CJS/ESM boundary.
- **Import fix:** `invite-codes/handler.ts` imports from local `./schemas.ts` (three-file pattern compliance)
- **IAM least-privilege narrowing:**
  - Auth stack: `validateInviteFunction` gets `GetItem+UpdateItem`, `generateInviteFunction` gets `PutItem+Query` on inviteCodesTable
  - Saves stack: mutation functions get `UpdateItem` only on usersTable, `PutItem` only on eventsTable
  - `savesGetFunction` gets `GetItem+UpdateItem` on savesTable (no index wildcard)
- **New CDK tests:** SavesRoutesStack (21 tests), OpsRoutesStack (14 tests) — Lambda count, runtime, env vars, narrowed IAM with role-specific assertions, route resources and methods
- **Auth test hardening:** Function-specific IAM assertions for all 4 Lambda functions with `addToRolePolicy` calls
- **Documentation:** Logging subsection in api-patterns.md, CORS intent comments in route stacks, ephemeral file note in README.md

Closes #258

## Test plan

- [x] `npm run type-check` — clean (0 errors)
- [x] `npm test` — 2,138 tests pass across 109 test files, 0 failures
- [x] `npm run lint` — clean
- [x] `cdk synth` — successfully synthesized 12 stacks, no CDK Nag errors
- [ ] Post-deploy: run smoke tests to confirm no IAM regressions on live DynamoDB calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)