### PR TITLE
docs: add story definitions for 3.5, 3.6, and 3.6a

### DIFF
--- a/_bmad-output/implementation-artifacts/3-5-ios-shortcut-capture.md
+++ b/_bmad-output/implementation-artifacts/3-5-ios-shortcut-capture.md
@@ -1,0 +1,257 @@
+---
+id: "3.5"
+title: "iOS Shortcut Capture"
+status: ready-for-dev
+depends_on:
+  - "3.1b"
+  - "2.2"
+touches:
+  - frontend/public/shortcuts/ai-learning-hub.shortcut
+  - frontend/src/pages/guides/IosShortcutSetup.tsx
+  - frontend/src/App.tsx
+risk: medium
+---
+
+# Story 3.5: iOS Shortcut Capture
+
+## Story
+
+As a mobile user on iPhone or iPad,
+I want to tap "Save to AI Learning Hub" in my share sheet,
+so that I can capture any URL in under 3 seconds without opening the app.
+
+## Acceptance Criteria
+
+1. **AC1: Share sheet integration** — An iOS Shortcut named "Save to AI Learning Hub" appears in the iPhone/iPad share sheet after the user installs it. The shortcut can be triggered from any app that surfaces the share sheet (Safari, podcasts, LinkedIn, YouTube, etc.). Requires iOS 16 or later; the shortcut binary sets minimum client version to iOS 16.
+
+2. **AC2: URL capture and save** — When triggered, the shortcut extracts the shared URL and calls `POST /saves` with `x-api-key` header (capture-scoped) and body `{ "url": "<shared_url>" }`. The save is created within 3 seconds (FR46).
+
+3. **AC3: Success confirmation** — On a successful save (HTTP 201) the shortcut displays an iOS native notification: "✓ Saved". Short and instant — no need to read it, just glance and continue.
+
+4. **AC4: Duplicate handling** — On a duplicate URL (HTTP 409), the shortcut treats it as success and shows "✓ Saved to AI Learning Hub" — identical to a new save. No distinct duplicate message; the URL is in the library either way.
+
+5. **AC5: Non-URL input guard** — If the shared content contains no extractable URL (e.g. plain text, image, file), the shortcut stops immediately and shows: "Nothing to save — share a link, not text or an image." No API call is made.
+
+6. **AC6: Error notification** — On network failure or non-2xx/non-DUPLICATE_SAVE response, the shortcut shows an iOS native notification: "Couldn't save. Check your API key or connection."
+
+7. **AC7: API key import question** — When the user first installs the shortcut, they are prompted (via one iOS Shortcuts Import Question) to enter their API key. The key is stored as a shortcut variable and used on every capture. The API base URL (`https://api.build.cirrusly-clever.com`) is hardcoded in the shortcut binary — no second Import Question.
+
+8. **AC8: Downloadable shortcut file** — The `.shortcut` binary file is served from the frontend public path (`/shortcuts/ai-learning-hub.shortcut`) with `Content-Type: application/octet-stream`. A direct link opens the Shortcuts app installation flow on iOS.
+
+9. **AC9: Setup guide page** — A page exists at `/guides/ios-shortcut-setup` that is publicly accessible (no auth required). The guide covers: generate a capture-scoped API key → install the shortcut → run it once to paste the key → test from the share sheet. The API key generation step includes an inline sign-in prompt for users who are not yet authenticated. The guide states the iOS 16+ requirement.
+
+10. **AC10: Capture-scoped API key** — The guide directs users to generate an API key with the `capture` scope. The `capture` scope grants only `saves:create` and nothing else — verified in middleware's scope-resolver.
+
+11. **AC11: Integration test** — A test exercises `POST /saves` with a `capture`-scoped mock API key and verifies a 201 response, confirming the entire auth+save pipeline works for the shortcut's request format.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Create the iOS Shortcut binary file (AC: #1, #2, #3, #4, #5, #6, #7)
+  - [ ] 1.1 On an iPhone/iPad running iOS 16+, open the Shortcuts app and create a new shortcut following the exact action sequence in Dev Notes (includes the non-URL guard at Action 2b). Set the shortcut name to "Save to AI Learning Hub". Add **one** Import Question for the API key only — the API URL `https://api.build.cirrusly-clever.com` is hardcoded in Action 4.
+  - [ ] 1.2 In the shortcut settings: enable "Show in Share Sheet", set accepted input types to "URLs" and "Safari web pages", and set minimum iOS version to 16 (Shortcut Details → iOS 16).
+  - [ ] 1.3 Test the shortcut from Safari and one non-Safari app (e.g. YouTube). Verify success notification and that the save appears in `GET /saves`.
+  - [ ] 1.4 Export the shortcut: long-press → Share → Save to Files → commit the binary at `frontend/public/shortcuts/ai-learning-hub.shortcut`.
+  - [ ] 1.5 Verify the file is served correctly by Vite dev server at `http://localhost:5173/shortcuts/ai-learning-hub.shortcut` with a 200 response.
+
+- [ ] Task 2: Add setup guide frontend page (AC: #8, #9)
+  - [ ] 2.1 Create `frontend/src/pages/guides/IosShortcutSetup.tsx` following the Quetzal design system (see Dev Notes for design requirements). The page must render without auth.
+  - [ ] 2.2 Guide content (5 steps): (1) Generate a capture-scoped API key — include an inline sign-in prompt for unauthenticated users ("Sign in first to generate your key →"); (2) Copy the key; (3) Tap "Install Shortcut" (link to `/shortcuts/ai-learning-hub.shortcut`); (4) Paste your API key when the Shortcuts app prompts; (5) Test — open any app, tap Share → "Save to AI Learning Hub". Include a requirements note near the top: "Requires iPhone or iPad running iOS 16 or later."
+  - [ ] 2.3 Include a prominent "Install Shortcut" `<a>` element pointing to `/shortcuts/ai-learning-hub.shortcut`. On iOS this opens the Shortcuts install sheet; on desktop it downloads the file. Use the primary Button style (indigo fill).
+  - [ ] 2.4 Add a public route in `frontend/src/App.tsx`: `<Route path="/guides/ios-shortcut-setup" element={<IosShortcutSetup />} />` — outside the `<ProtectedRoute>` wrapper. The step-1 API key link should point to `/settings/api-keys`; if the user is unauthenticated show a `<SignInButton>` / redirect prompt inline rather than a broken link.
+
+- [ ] Task 3: Verify capture scope correctness (AC: #9, #10)
+  - [ ] 3.1 Confirm `capture` scope resolves to `saves:create` in `backend/shared/middleware/src/scope-resolver.ts` (already implemented — read and verify only, no code change needed).
+  - [ ] 3.2 Add an integration test in `backend/functions/saves/handler.test.ts` that covers: `POST /saves` with a mocked `capture`-scoped API key auth context (`isApiKey: true, scopes: ['capture']`) produces a 201 with a valid save body. Add a second case: same request with scope `read` produces a 403.
+  - [ ] 3.3 Run `npm test`, `npm run lint`, `npm run build`, `npm run type-check`, `npm run format`. All must pass.
+
+## Dev Notes
+
+### iOS Shortcut Action Sequence (Exact Spec for Task 1.1)
+
+**API base URL (hardcoded):** `https://api.build.cirrusly-clever.com`
+**Import Questions:** one only — API key.
+
+```
+Action 1: Receive [URL, Safari web page] as input from Share Sheet
+  - "If there's no input" → Stop and Respond
+  - Accept: Share Sheet, Action Menus
+
+Action 2: Get URLs from [Shortcut Input]
+  - Store result as Magic Variable: InputURL
+
+Action 2b: If [InputURL] has no items  ← NON-URL GUARD
+  - Show Notification:
+      Title: "Nothing to save"
+      Body: "Share a link, not text or an image."
+  - Stop Shortcut
+  (End If)
+
+Action 3: URL → Text (convert URL type to string)
+  - Input: InputURL
+  - Store result as variable: URLString
+
+  [URL normalization: iOS share sheet may include trailing slashes or
+  tracking parameters. No normalisation needed in the shortcut —
+  the backend normalizeUrl() handles this before dedup checks.
+  App deep links (spotify://, youtube://) pass through and are rejected
+  by the backend's URL validation with a 400 — accepted edge case for V1.]
+
+Action 4: Get Contents of URL
+  - URL: https://api.build.cirrusly-clever.com/saves
+  - Method: POST
+  - Headers:
+      Content-Type: application/json
+      x-api-key: [API Key] (Import Question variable — see below)
+  - Request Body: JSON
+      { "url": [URLString] }
+  - Store result as variable: Response
+
+Action 5: Get Dictionary Value "error" from [Response]
+  - Store result as variable: ErrorValue
+
+Action 6: If [ErrorValue] has any value
+  - (error branch — includes DUPLICATE_SAVE which also has an "error" key in the 409 body)
+  - Get Dictionary Value "code" from [ErrorValue]
+  - If [code] equals "DUPLICATE_SAVE"
+      → Go to success notification (Action 8)
+    Otherwise
+      → Show Notification: Title "Couldn't Save", Body "Check your API key or connection."
+      → Stop Shortcut
+
+Action 7 (no error key — HTTP 201): (fall-through)
+
+Action 8: Show Notification
+  - Title: "✓ Saved"
+  - Body: "" (empty — fast, no extra reading)
+```
+
+**Import Question configuration (one only):**
+- Name: `API Key`
+- Question: "Enter your AI Learning Hub API key (Settings → API Keys → Generate with Capture scope)"
+- Default value: (leave empty)
+
+**Why one Import Question:** The API URL `https://api.build.cirrusly-clever.com` is the production domain and is hardcoded in the binary. If the domain ever changes, re-export the shortcut with the updated URL. No need to burden users with entering a URL.
+
+**Why 409 → "✓ Saved":** The URL is already in the user's library — the save succeeded from their perspective. Showing a different message adds cognitive load for zero benefit. The `error.code === "DUPLICATE_SAVE"` branch explicitly routes to the success notification.
+
+### iOS Shortcut Error Handling
+
+| Scenario | API Response | Detection | Shortcut shows |
+|----------|-------------|-----------|----------------|
+| New save | 201 `{ data: { saveId, ... } }` | No `error` key | "✓ Saved" |
+| Duplicate | 409 `{ error: { code: "DUPLICATE_SAVE" }, existingSave: {...} }` | `error.code === "DUPLICATE_SAVE"` | "✓ Saved" |
+| Bad API key | 401/403 `{ error: { code: "..." } }` | `error` present, code ≠ DUPLICATE_SAVE | "Couldn't Save" |
+| Invalid URL | 400 `{ error: { code: "VALIDATION_ERROR" } }` | `error` present, code ≠ DUPLICATE_SAVE | "Couldn't Save" |
+| Network timeout | No response / timeout | Response is empty / null | "Couldn't Save" |
+| Server error | 5xx | `error` present or empty response | "Couldn't Save" |
+
+**iOS Shortcuts timeout:** The "Get Contents of URL" action has a ~60-second system timeout. On a failed network request the shortcut will wait up to 60s before surfacing the "Couldn't Save" notification. This is acceptable for V1; users on poor connections can dismiss and retry.
+
+**Multiple installs:** Each import of the shortcut creates an independent copy with its own stored API key variable. Users can install twice with different keys (e.g. personal vs work). Each copy is independent — no conflicts.
+
+### Frontend Guide Page Design Requirements
+
+The guide page at `/guides/ios-shortcut-setup` must follow Quetzal design system:
+- **Font**: Inter (ui-sans-serif fallback)
+- **Colors**: Use CSS variables (`--background`, `--foreground`, `--brand` for success accents, `--accent` for interactive elements)
+- **Icons**: Lucide React
+- **Components**: Use existing shadcn components (Button, Badge, Separator)
+- **Public access**: Route must be outside `<ProtectedRoute>` in App.tsx
+
+Guide must include:
+1. A "persona-driven" header — use Maya persona language ("Save anything in 5 seconds")
+2. Step-by-step numbered list with clear step titles
+3. An "Install Shortcut" button (`<a href="/shortcuts/ai-learning-hub.shortcut">`) — primary button style
+4. Link to Settings → API Keys (`/settings/api-keys`) for key generation step
+5. A "What it looks like" mockup or description of the share sheet flow
+
+### Project Structure Notes
+
+- Shortcut binary: `frontend/public/shortcuts/ai-learning-hub.shortcut` — Vite copies `public/` contents as-is to `dist/`; no import needed
+- Guide page: `frontend/src/pages/guides/IosShortcutSetup.tsx`
+- Route in App.tsx: add before the `<ProtectedRoute>` block, alongside `/` and `*` routes
+- No new API endpoints or Lambda functions — `POST /saves` already handles capture
+- No new CDK changes — shortcut file is static content bundled with the frontend
+
+### API Contract Reference
+
+The shortcut calls this existing endpoint:
+
+```
+POST https://api.build.cirrusly-clever.com/saves
+Headers:
+  Content-Type: application/json
+  x-api-key: <capture-scoped-key>
+
+Body: { "url": "https://example.com" }
+
+Responses:
+  201: { data: { saveId, url, contentType, ... } }          → "✓ Saved" (no "error" key)
+  409: { error: { code: "DUPLICATE_SAVE", ... }, existingSave: {...} } → "✓ Saved" (error.code check)
+  401: { message: "Unauthorized" }                           → "Couldn't Save"
+  403: { error: { code: "INSUFFICIENT_SCOPE", ... } }       → "Couldn't Save"
+  400: { error: { code: "VALIDATION_ERROR", ... } }         → "Couldn't Save"
+```
+
+The `capture` scope key already grants `saves:create` via `scope-resolver.ts`:
+```typescript
+// backend/shared/middleware/src/scope-resolver.ts
+capture: ["saves:create"],  // maps capture tier → saves:create operation
+```
+
+The saves-create handler requires `requiredScope: "saves:create"`:
+```typescript
+// backend/functions/saves/handler.ts
+export const handler = wrapHandler(savesCreateHandler, {
+  requireAuth: true,
+  requiredScope: "saves:create",
+  ...
+});
+```
+
+### Capture Flow Performance (FR46: < 3 seconds)
+
+The entire Shortcuts flow (share sheet tap → API call → notification) must complete in < 3 seconds. Current API hot path:
+- Lambda cold start adds 1–3s (documented, accepted per NFR-P1 note)
+- Warm invocation: < 1s (API Gateway + Lambda + DynamoDB PutItem)
+- For capture path: enable Lambda Provisioned Concurrency for the saves-create function if cold start latency becomes an issue post-deployment (post-deploy optimization, not blocking this story)
+
+### Domain Change Procedure
+
+The API URL `https://api.build.cirrusly-clever.com` is hardcoded in Action 4 of the shortcut binary. If the domain changes:
+
+1. Open the `.shortcut` file on an iPhone (tap the file → opens Shortcuts app for editing)
+2. Update the URL in Action 4 to the new domain
+3. Re-export: long-press → Share → Save to Files
+4. Overwrite `frontend/public/shortcuts/ai-learning-hub.shortcut` in the repo
+5. Deploy. The new file is served immediately to any user who re-downloads and reinstalls
+
+**Existing users** must manually reinstall the shortcut — there is no auto-update mechanism. This is why domain stability matters; treat `api.build.cirrusly-clever.com` as permanent for V1.
+
+The domain is managed in the secondary AWS account (us-east-1), separate from the CDK deployment account.
+
+### Offline Behaviour
+
+No offline queue in V1. On poor or no connectivity the shortcut waits up to ~60 seconds (iOS system timeout) then shows "Couldn't Save". The user must retry manually. The PWA (Story 3.6) will implement an offline save queue via service worker + IndexedDB for in-app captures — the iOS Shortcut has no equivalent and this gap is accepted for V1.
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/prd.md#Mobile-Capture] — FR44, FR45, FR46, FR47
+- [Source: _bmad-output/planning-artifacts/ux-design-specification.md#9-Mobile-Capture-System] — iOS Shortcut flow, setup guide spec, error handling
+- [Source: _bmad-output/planning-artifacts/ux-design-specification.md#6-Information-Architecture] — `/guides/ios-shortcut-setup` route is P0
+- [Source: _bmad-output/planning-artifacts/architecture.md#ADR-011] — iOS Shortcut + PWA approach decision
+- [Source: backend/shared/middleware/src/scope-resolver.ts] — `capture` scope grants `saves:create`
+- [Source: backend/functions/saves/handler.ts] — `requiredScope: "saves:create"`, request/response shape
+- [Source: _bmad-output/planning-artifacts/prd.md#API-Key-Scopes] — `capture` scope: `POST /saves` only, 100/min rate limit
+
+## Dev Agent Record
+
+### Agent Model Used
+
+{{agent_model_name_version}}
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/3-6-pwa-share-target.md
+++ b/_bmad-output/implementation-artifacts/3-6-pwa-share-target.md
@@ -1,0 +1,478 @@
+---
+id: "3.6"
+title: "PWA Share Target"
+status: ready-for-dev
+depends_on: []
+touches:
+  - frontend/vite.config.ts
+  - frontend/src/sw.ts
+  - frontend/src/pages/ShareTargetPage.tsx
+  - frontend/src/pages/guides/AndroidPwaSetup.tsx
+  - frontend/src/App.tsx
+  - frontend/public/icons/pwa-192x192.png
+  - frontend/public/icons/pwa-512x512.png
+risk: medium
+---
+
+# Story 3.6: PWA Share Target
+
+## Story
+
+As an Android user with AI Learning Hub installed as a PWA,
+I want to tap "AI Learning Hub" in my Android share sheet from any app,
+so that I can save any URL in under 3 seconds without navigating to the app.
+
+## Acceptance Criteria
+
+1. **AC1: Manifest share_target registered** — The web app manifest includes a valid `share_target` object with `action: "/save"`, `method: "POST"`, `enctype: "application/x-www-form-urlencoded"`, and params mapping `url`, `title`, and `text`. Android Chrome registers the PWA as a share target when the app is installed ("Add to Home Screen").
+
+2. **AC2: Share target appears in Android share sheet** — After the user installs the PWA ("Add to Home Screen"), "AI Learning Hub" appears as an option in the Android share sheet. Tapping it opens the `/save` page.
+
+3. **AC3: URL extracted and saved** — The share target page extracts the shared URL from the service worker cache, calls `POST /saves` authenticated via Clerk JWT session, and the save is created within 3 seconds on a warm Lambda invocation (FR46).
+
+4. **AC4: Success confirmation screen** — On successful save (201), the `/save` page shows a full-screen confirmation: "✓ Saved" with the saved URL displayed. An optional "+ Add a note" prompt appears for 3–4 seconds. A "← Back" button returns the user to the originating Android app: it calls `window.history.back()` if `window.history.length > 1`, otherwise falls back to `window.close()` (handles the case where the share target opened a fresh standalone PWA window with no prior history).
+
+5. **AC5: Duplicate URL handling** — If the API returns 409 with `error.code === "DUPLICATE_SAVE"`, the page treats it as success and shows the same "✓ Saved" confirmation. No distinct duplicate message.
+
+6. **AC6: Error state** — On network failure or non-2xx (excluding DUPLICATE_SAVE), the page shows: "Couldn't save — try again." with a retry button that re-attempts the save without user needing to re-share.
+
+7. **AC7: Unauthenticated state** — If the user is not signed into the PWA, the `/save` page shows: "Sign in to AI Learning Hub to save this link" with a Sign In button (Clerk modal, not redirect). The shared URL is preserved: the cache entry in `share-target-data` is **not consumed** until the save is attempted. After the Clerk sign-in modal closes and `isSignedIn` becomes `true`, the page re-reads the cached URL and proceeds with the save automatically — the user does not need to re-share.
+
+8. **AC8: Offline queue** — When the device is offline and a share is attempted, the save request is queued in IndexedDB via Workbox BackgroundSync. The page shows: "Saved offline — will sync when you reconnect." When connectivity returns, the queued save is automatically submitted. Queue retries for up to 24 hours.
+
+9. **AC9: PWA manifest complete** — The manifest includes `name`, `short_name`, `description`, `theme_color` (#4f46e5 — Quetzal brand indigo), `background_color`, `display: standalone`, `start_url: /`, `scope: /`, and two icon sizes (192×192 and 512×512 PNG). The manifest passes Chrome's PWA installability criteria.
+
+10. **AC10: Service worker uses injectManifest strategy** — `vite.config.ts` is updated to use `strategies: 'injectManifest'` with `srcDir: 'src'` and `filename: 'sw.ts'`. The custom service worker at `frontend/src/sw.ts` includes precaching via `precacheAndRoute(self.__WB_MANIFEST)`, the share target fetch handler, and BackgroundSync plugin registration.
+
+11. **AC11: Unit tests** — `ShareTargetPage` has unit tests covering: (a) authenticated + URL available → shows success UI after mock API call; (b) unauthenticated → shows sign-in prompt; (c) API error → shows retry UI; (d) DUPLICATE_SAVE → treated as success; (e) non-URL text content → shows "Nothing to save" message; (f) Cancel during loading → mutation is reset and back navigation fires. Tests use `vi.mock` for `useAuth` and `useCreateSave`.
+
+12. **AC12: Cancel during in-flight save** — While the save is in-flight (loading state), a "Cancel" button is visible alongside the loading spinner. Tapping Cancel calls `mutation.reset()` and navigates back via the same `window.close()` / `history.back()` logic as the success Back button. This prevents accidental saves when the user taps the wrong app in the share sheet.
+
+13. **AC13: Non-URL content guard** — Before calling `POST /saves`, the page validates that the resolved shared content is a parseable URL (passes `new URL(value)` without throwing). If the `url` param is absent and the `text` param contains non-URL prose (e.g. a tweet body), the page shows: "Nothing to save — share a link, not text or an image." No API call is made. This mirrors the iOS Shortcut guard in Story 3.5 (AC5).
+
+14. **AC14: Android PWA install guide** — A publicly accessible page exists at `/guides/android-pwa-setup` explaining how to install the PWA on Android and enable the share target. The guide covers: open AI Learning Hub in Chrome → tap the three-dot menu → "Add to Home Screen" → confirm → locate the app on your home screen → test from any app's share sheet. The page is outside `<ProtectedRoute>`. It is linked from the iOS guide page footer ("On Android? See the Android setup guide →") and reachable directly.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Add workbox dev dependencies and update vite.config.ts (AC: #9, #10)
+  - [ ] 1.1 Install devDependencies: `workbox-precaching workbox-routing workbox-strategies workbox-background-sync workbox-core` — run `npm install -D workbox-precaching workbox-routing workbox-strategies workbox-background-sync workbox-core` from `frontend/` directory.
+  - [ ] 1.2 Update `frontend/vite.config.ts`: change VitePWA plugin to use `strategies: 'injectManifest'`, `srcDir: 'src'`, `filename: 'sw.ts'`. Add complete `manifest` object (name, short_name, description, theme_color `#4f46e5`, background_color `#ffffff`, display `standalone`, start_url `/`, scope `/`, icons array with 192x192 and 512x512). Add `share_target` object per ADR-012 spec (see Dev Notes).
+  - [ ] 1.3 Run `npm run build` from `frontend/` to confirm the build succeeds with the new vite.config. The SW file will fail to compile until Task 2 is complete — that is expected.
+
+- [ ] Task 2: Create custom service worker `frontend/src/sw.ts` (AC: #1, #8, #10)
+  - [ ] 2.1 Create `frontend/src/sw.ts` with: `declare let self: ServiceWorkerGlobalScope` type declaration, import `precacheAndRoute` from `workbox-precaching` and call `precacheAndRoute(self.__WB_MANIFEST)`.
+  - [ ] 2.2 Add the Web Share Target fetch handler: intercept `fetch` events where `url.pathname === '/save'` and `method === 'POST'`. Extract `url`, `text`, `title` from `event.request.formData()`. Resolve the shared content: prefer `url` param, fall back to `text` param. Store the raw value (validated or not) as a JSON response in `caches.open('share-target-data')` at key `/share-target-pending` — include both `url` (the raw value) and `title` fields. Respond with `Response.redirect('/save?shared=1', 302)`. **Note:** URL validity is validated in the React page (Task 4.3), not in the SW — the SW stores whatever was shared and lets the UI decide.
+  - [ ] 2.3 Register a BackgroundSync queue named `'saves-queue'` using `workbox-background-sync` `BackgroundSyncPlugin` with `maxRetentionTime: 24 * 60` (24 hours in minutes). Register a POST route for `(url) => url.pathname === '/saves'` using `NetworkOnly` strategy with the plugin attached — so POST /saves calls that fail offline are queued and replayed automatically.
+  - [ ] 2.4 Add a `message` event listener on `self` for `{ type: 'SKIP_WAITING' }` to call `self.skipWaiting()` — enables the `autoUpdate` registration type to work correctly.
+  - [ ] 2.5 Run `npm run build` again to confirm no TypeScript errors in the SW file.
+
+- [ ] Task 3: Create PWA icons (AC: #9)
+  - [ ] 3.1 Create directory `frontend/public/icons/`.
+  - [ ] 3.2 Generate two PNG icons: `pwa-192x192.png` (192×192) and `pwa-512x512.png` (512×512). Design: indigo (#4f46e5) square background with a white bookmark icon (Lucide `BookmarkCheck` shape). These can be created using any image tool, Canvas API script, or an online PWA icon generator (e.g. maskable.app). The 512×512 icon should also serve as the maskable icon.
+  - [ ] 3.3 Place both files under `frontend/public/icons/` so Vite copies them to the build output root. Verify paths match the manifest `icons` array entries: `/icons/pwa-192x192.png` and `/icons/pwa-512x512.png`.
+
+- [ ] Task 4: Create `ShareTargetPage.tsx` (AC: #3, #4, #5, #6, #7, #8, #12, #13)
+  - [ ] 4.1 Create `frontend/src/pages/ShareTargetPage.tsx`. The page reads the pending share URL on mount: open `caches.open('share-target-data')`, `match('/share-target-pending')`, parse JSON to extract `{ url, title }`. **Do not delete the cache entry here** — only consume it (call `cache.delete`) after a successful save or explicit user cancel (finding #3: preserves URL through sign-in flow). If `?shared=1` query param is absent or no cached URL found, display a fallback "Nothing to save — try sharing again from the app you were in" message.
+  - [ ] 4.2 Implement auth gate: use Clerk's `useAuth()` hook. If `!isLoaded` show a centered loading spinner (Clerk initialising). If `!isSignedIn` show the unauthenticated UI — "Sign in to AI Learning Hub to save this link" with the pending URL displayed and a `<SignInButton mode="modal">`. **After sign-in**, Clerk fires an `isSignedIn` state change — use a `useEffect` that watches `isSignedIn` to trigger the save automatically once authenticated. Do not delete the cache entry until the save attempt.
+  - [ ] 4.3 Before calling `POST /saves`, validate the resolved URL: attempt `new URL(sharedUrl)`. If it throws, show: "Nothing to save — share a link, not text or an image." and do not call the API (AC13). If valid, call `useCreateSave()`. Show a loading spinner **and a "Cancel" button** while in-flight (AC12). On success (or DUPLICATE_SAVE error code), delete the cache entry and transition to the success state. On other errors, show the retry UI.
+  - [ ] 4.4 Implement the Cancel button (AC12): visible during loading state only. On click: call `mutation.reset()`, delete the cache entry (`caches.open('share-target-data').then(c => c.delete('/share-target-pending'))`), then navigate back using: `window.history.length > 1 ? window.history.back() : window.close()`.
+  - [ ] 4.5 Implement the success state UI (see Dev Notes for exact design): "✓ Saved" headline, the URL in a muted pill, optional "+ Add a note" CTA (input + "Save note" button), and a "← Back" button. Back button logic: `window.history.length > 1 ? window.history.back() : window.close()` (AC4 — handles standalone PWA window with no prior history).
+  - [ ] 4.6 Implement the error state UI: "Couldn't save — try again." message, a Retry button that re-fires the `createSave` mutation, and a "Go to app" fallback link to `/app`. Do not delete the cache entry on error — so Retry can re-attempt.
+  - [ ] 4.7 Implement offline detection: if `navigator.onLine === false` before the save attempt, show "Saved offline — will sync when you reconnect." and delete the cache entry (the BackgroundSync plugin has already queued the request via the SW). No manual IDB write needed in the React layer per V1 decision.
+  - [ ] 4.8 Implement the note prompt: after successful save, show a text input "Add a note (optional)" that auto-focuses. If the user types and submits within 10 seconds, call `useUpdateSave()` with the note. If they ignore it or tap elsewhere, it disappears after 4 seconds (use a countdown state). This is optional context capture per the UX spec.
+
+- [ ] Task 5: Add routes in App.tsx (AC: #2, #14)
+  - [ ] 5.1 Import `ShareTargetPage` and `AndroidPwaSetup` in `frontend/src/App.tsx`.
+  - [ ] 5.2 Add `<Route path="/save" element={<ShareTargetPage />} />` as a top-level route **outside** the `<ProtectedRoute>` wrapper, before the `<Route path="*">` catch-all. The page handles its own auth state internally.
+  - [ ] 5.3 Add `<Route path="/guides/android-pwa-setup" element={<AndroidPwaSetup />} />` as a top-level public route alongside the iOS guide route.
+
+- [ ] Task 6: Write tests (AC: #11, #12, #13)
+  - [ ] 6.1 Create `frontend/src/pages/ShareTargetPage.test.tsx`. Mock `caches` globally using `vi.stubGlobal('caches', ...)` with a fake Cache that returns configurable test data. Mock `useAuth` from `@clerk/clerk-react` to control signed-in/out state. Mock `useCreateSave` from `@/api/saves`. Mock `window.history` and `window.close` for navigation assertions.
+  - [ ] 6.2 Test: `authenticated + valid URL → shows success UI`. Mock cache returns `{ url: 'https://example.com' }`, `isSignedIn: true`, mutation resolves — assert "✓ Saved" visible and cache was deleted.
+  - [ ] 6.3 Test: `unauthenticated → shows sign-in prompt, cache not deleted`. Mock `{ isSignedIn: false, isLoaded: true }`. Assert "Sign in to AI Learning Hub" visible; assert `cache.delete` not called; assert no API call made.
+  - [ ] 6.4 Test: `sign-in triggers auto-save`. Start with `isSignedIn: false`, then re-render with `isSignedIn: true` (simulating Clerk modal close) — assert `createSave` is called with the cached URL.
+  - [ ] 6.5 Test: `API error → shows retry UI, cache not deleted`. Mock mutation rejects with a non-DUPLICATE_SAVE error. Assert "Couldn't save — try again." visible; assert `cache.delete` not called (so Retry can re-attempt).
+  - [ ] 6.6 Test: `DUPLICATE_SAVE → treated as success`. Mock mutation rejects with `ApiError` where `code === 'DUPLICATE_SAVE'`. Assert "✓ Saved" visible.
+  - [ ] 6.7 Test: `non-URL text → shows nothing-to-save guard` (AC13). Mock cache returns `{ url: 'just some tweet text without a URL' }`. Assert "Nothing to save — share a link" visible; assert no API call made.
+  - [ ] 6.8 Test: `Cancel during loading → reset mutation and close/back` (AC12). Mock mutation in pending state. Assert Cancel button visible. Fire click — assert `mutation.reset` called and `window.close` or `history.back` fired.
+  - [ ] 6.9 Test: `Back button uses window.close when history.length === 1`. Mock `window.history.length = 1`. In success state, click "← Back" — assert `window.close()` called, not `history.back()`.
+  - [ ] 6.10 Run `npm test`, `npm run lint`, `npm run build`, `npm run type-check`, `npm run format`. All must pass.
+
+- [ ] Task 7: Create Android PWA setup guide page (AC: #14)
+  - [ ] 7.1 Create `frontend/src/pages/guides/AndroidPwaSetup.tsx`. Follow the same Quetzal design conventions as `IosShortcutSetup.tsx` (Inter font, CSS variables, shadcn Button/Badge/Separator components, Lucide icons). Persona-driven header: "Save anything in 3 taps — no app needed."
+  - [ ] 7.2 Guide content (4 steps): (1) Open AI Learning Hub in Chrome on Android; (2) Tap the three-dot menu (⋮) → "Add to Home Screen" → "Add" — the app icon appears on your home screen; (3) Open any app (YouTube, Chrome, LinkedIn, Reddit…) → tap Share → "AI Learning Hub" appears in the sheet; (4) Tap it — your link is saved instantly. Include a requirements note: "Requires Android with Chrome (or Firefox). The app must be installed to your home screen first."
+  - [ ] 7.3 Add an "Open AI Learning Hub" CTA button linking to `/` (prompts Chrome to show the install banner if not already installed).
+  - [ ] 7.4 In the footer of `IosShortcutSetup.tsx`, add a discreet link: "On Android? [See the Android setup guide →](/guides/android-pwa-setup)".
+  - [ ] 7.5 Route already added in Task 5.3.
+
+## Dev Notes
+
+### Web Share Target API — Architecture Spec (ADR-012)
+
+The `share_target` entry in the manifest (per ADR-012):
+
+```json
+{
+  "share_target": {
+    "action": "/save",
+    "method": "POST",
+    "enctype": "application/x-www-form-urlencoded",
+    "params": {
+      "url": "url",
+      "title": "title",
+      "text": "text"
+    }
+  }
+}
+```
+
+- **method: POST** is required because `application/x-www-form-urlencoded` shares include a request body
+- The service worker **must** intercept the POST to `/save` — React Router never sees a POST request; the SW handles it first
+- Android Chrome requires the PWA to be installed ("Add to Home Screen") before the share target is registered in the OS share sheet
+- iOS Safari does **not** support Web Share Target — iOS users use the Shortcut (Story 3.5)
+
+[Source: _bmad-output/planning-artifacts/architecture.md#ADR-012]
+
+### Service Worker: Share Data Handoff Pattern
+
+The SW intercepts the POST, stores the URL, then redirects. This avoids the complexity of `BroadcastChannel` or `postMessage` to an as-yet-unopened client:
+
+```typescript
+// frontend/src/sw.ts — share target handler
+
+self.addEventListener('fetch', (event: FetchEvent) => {
+  const url = new URL(event.request.url);
+
+  if (url.pathname === '/save' && event.request.method === 'POST') {
+    event.respondWith(
+      (async (): Promise<Response> => {
+        const formData = await event.request.formData();
+        const sharedUrl =
+          (formData.get('url') as string) ||
+          (formData.get('text') as string) ||
+          '';
+
+        // Persist URL so the React page can read it after redirect
+        const cache = await caches.open('share-target-data');
+        await cache.put(
+          '/share-target-pending',
+          new Response(JSON.stringify({ url: sharedUrl }), {
+            headers: { 'Content-Type': 'application/json' },
+          })
+        );
+
+        return Response.redirect('/save?shared=1', 302);
+      })()
+    );
+  }
+});
+```
+
+The React page reads the cache on mount — but does **not** delete the entry until the save is confirmed. This preserves the URL through the sign-in flow (finding #3):
+
+```typescript
+// In ShareTargetPage.tsx — effect to read shared URL
+
+useEffect(() => {
+  const readSharedUrl = async () => {
+    if (!searchParams.get('shared')) return;
+    const cache = await caches.open('share-target-data');
+    const response = await cache.match('/share-target-pending');
+    if (response) {
+      const data = await response.json() as { url: string; title?: string };
+      // ⚠️  Do NOT delete here — preserve until save succeeds, errors, or user cancels
+      setSharedUrl(data.url);
+      setSharedTitle(data.title ?? '');
+    }
+  };
+  readSharedUrl().catch(() => {/* handle gracefully */});
+}, [searchParams]);
+
+// Separate helper — call this after successful save or explicit cancel:
+const consumeCache = async () => {
+  const cache = await caches.open('share-target-data');
+  await cache.delete('/share-target-pending');
+};
+```
+
+**Sign-in flow:** When the user signs in via Clerk modal, `isSignedIn` transitions from `false` → `true`. A `useEffect` watching `isSignedIn` triggers `consumeCache` + `createSave` automatically:
+
+```typescript
+useEffect(() => {
+  if (isSignedIn && sharedUrl && mutation.isIdle) {
+    triggerSave(sharedUrl);
+  }
+}, [isSignedIn, sharedUrl]);
+```
+
+### Non-URL Content Guard (AC13)
+
+Some Android apps populate the `text` share param with prose (e.g. a tweet body) rather than a URL. Validate before calling the API:
+
+```typescript
+function isValidUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// In save trigger:
+if (!isValidUrl(sharedUrl)) {
+  setPhase('invalid');  // shows "Nothing to save — share a link, not text or an image."
+  await consumeCache();
+  return;
+}
+```
+
+This mirrors the iOS Shortcut guard at Action 2b (Story 3.5, AC5).
+
+### Back Button: `window.close()` Fallback (AC4, AC12)
+
+When the share target opens a **new** standalone PWA window (common on Android), `window.history.length` is `1` — there is no prior page to go back to. `window.history.back()` would silently do nothing, stranding the user on the confirmation screen.
+
+```typescript
+function navigateBack(): void {
+  if (window.history.length > 1) {
+    window.history.back();
+  } else {
+    window.close();
+  }
+}
+```
+
+Use `navigateBack()` for all three exit points: Cancel, Back (success), and error state "Go to app" button.
+
+### Service Worker: BackgroundSync for Offline Queue
+
+```typescript
+// frontend/src/sw.ts — BackgroundSync registration
+
+import { BackgroundSyncPlugin } from 'workbox-background-sync';
+import { registerRoute } from 'workbox-routing';
+import { NetworkOnly } from 'workbox-strategies';
+
+const savesQueue = new BackgroundSyncPlugin('saves-queue', {
+  maxRetentionTime: 24 * 60,  // 24 hours in minutes
+});
+
+// Queue POST /saves calls that fail due to network error
+registerRoute(
+  ({ url, request }) =>
+    url.pathname === '/saves' && request.method === 'POST',
+  new NetworkOnly({ plugins: [savesQueue] }),
+  'POST'
+);
+```
+
+Note: `registerRoute` for POST methods requires the `method` argument as the third parameter (Workbox 7+).
+
+### Updated vite.config.ts Structure
+
+```typescript
+VitePWA({
+  registerType: 'autoUpdate',
+  strategies: 'injectManifest',
+  srcDir: 'src',
+  filename: 'sw.ts',
+  devOptions: {
+    enabled: true,         // Enable SW in dev mode for testing
+    type: 'module',
+  },
+  manifest: {
+    name: 'AI Learning Hub',
+    short_name: 'ALH',
+    description: 'Save and organise your learning resources',
+    theme_color: '#4f46e5',
+    background_color: '#ffffff',
+    display: 'standalone',
+    orientation: 'any',
+    scope: '/',
+    start_url: '/',
+    icons: [
+      {
+        src: '/icons/pwa-192x192.png',
+        sizes: '192x192',
+        type: 'image/png',
+      },
+      {
+        src: '/icons/pwa-512x512.png',
+        sizes: '512x512',
+        type: 'image/png',
+      },
+      {
+        src: '/icons/pwa-512x512.png',
+        sizes: '512x512',
+        type: 'image/png',
+        purpose: 'maskable',
+      },
+    ],
+    share_target: {
+      action: '/save',
+      method: 'POST',
+      enctype: 'application/x-www-form-urlencoded',
+      params: {
+        url: 'url',
+        title: 'title',
+        text: 'text',
+      },
+    },
+  },
+}),
+```
+
+### ShareTargetPage: Confirmed Design (from UX Spec)
+
+```
+┌──────────────────────────────────────────────────────┐
+│                                                      │
+│              ✓ Saved                                 │
+│    example.com · via share                           │
+│                                                      │
+│   ┌─────────────────────────────────────────────┐   │
+│   │  + Add a note...              [Save note]   │   │
+│   └─────────────────────────────────────────────┘   │
+│         (disappears after 4 seconds if ignored)      │
+│                                                      │
+│              ← Back                                  │
+│                                                      │
+└──────────────────────────────────────────────────────┘
+```
+
+[Source: _bmad-output/planning-artifacts/ux-design-specification.md#9-Mobile-Capture-System]
+
+- Full screen, centred layout (no NavRail, no AppLayout)
+- Quetzal design: `--brand` color for the ✓ checkmark, `--foreground` for text
+- `--background` for the page — matches system light/dark
+- Font: Inter via Tailwind `font-sans`
+- The note input should use the `Input` shadcn component; the Save note button uses the `Button` component (secondary variant)
+
+### API Client in Service Worker Context
+
+The service worker BackgroundSync plugin replays the raw `fetch` call — it does **not** go through the `ApiClient` class. The Clerk JWT token embedded in the original request headers is replayed as-is. This works correctly as long as the JWT hasn't expired (Clerk JWTs expire in ~60s by default for short-lived tokens, or up to 1 hour depending on config). If the token is expired when the SW retries, the API returns 401 — the save fails silently in the queue and will be retried until `maxRetentionTime` expires.
+
+**V1 accepted limitation — silent JWT expiry:** If a JWT expires before the offline queue drains (queue TTL is 24 hours; Clerk JWT TTL is ~1 hour by default), the BackgroundSync retry will receive a 401 from the API. Workbox treats this as a network success (non-network-error) and **removes** the request from the queue without retrying further. The save is silently lost from the user's perspective — they were shown "Saved offline" but the save never appears in their library.
+
+Mitigations considered for V1:
+- The 24-hour queue window is generous; most offline scenarios resolve within minutes
+- Users actively using the PWA will re-authenticate before the JWT expires
+- No user-visible notification of queue failure exists in V1
+
+**Future story recommendation:** Add a `sync` event listener in the service worker that re-validates the JWT before replaying queued saves, or use Workbox's `fetchDidFail` plugin callback to log failures to an app-visible store (IDB) so the library page can surface a "some saves may not have synced" banner. Track as a follow-up in Epic 3 or Epic 9.
+
+### Authentication Flow for Share Target
+
+The share target opens a new PWA window at `/save?shared=1`. Clerk restores the session from `localStorage` on the client side:
+
+1. PWA window opens → React loads → Clerk initialises from localStorage
+2. If session is valid: `isSignedIn = true` → proceed with save
+3. If session expired or absent: `isSignedIn = false` → show sign-in UI
+
+```typescript
+// In ShareTargetPage.tsx
+import { useAuth, SignInButton } from '@clerk/clerk-react';
+
+const { isSignedIn, isLoaded } = useAuth();
+
+if (!isLoaded) return <LoadingSpinner />;
+if (!isSignedIn) {
+  return <UnauthenticatedView pendingUrl={sharedUrl} />;
+}
+// proceed to save...
+```
+
+### Offline IDB Direct Queue (Fallback for Share Target)
+
+When `navigator.onLine === false` at the time of share:
+- The service worker's BackgroundSync will handle the retry automatically
+- BUT the React page should also show the right UI state (not a spinner)
+- Detection: `navigator.onLine` check before calling `createSave`
+
+For direct IDB queuing (supplementary to BackgroundSync):
+```typescript
+import { openDB } from 'idb'; // add idb as dependency if needed
+
+const db = await openDB('alh-offline-queue', 1, {
+  upgrade(db) {
+    db.createObjectStore('pending-saves', { keyPath: 'id', autoIncrement: true });
+  },
+});
+await db.add('pending-saves', { url: sharedUrl, queuedAt: Date.now() });
+```
+
+**Decision for V1:** Rely on Workbox BackgroundSync for offline retry (no manual IDB queue needed). The ShareTargetPage only needs to detect `navigator.onLine` to show appropriate UI — the actual retry is handled by the SW.
+
+### PWA Icon Generation
+
+Options for creating the icons:
+1. **Maskable.app** (online tool): paste the Quetzal brand mark, export 192/512 variants with safe zone
+2. **Canvas script**: see `scripts/generate-icons.ts` if one exists, or create a one-off Node script
+3. **Figma / Photoshop**: design a bookmark icon on `#4f46e5` background
+
+Icon requirements:
+- Both icons must be valid PNGs
+- 512×512 icon doubles as maskable (safe zone = inner 80%)
+- Icons referenced in manifest must exist at build time (Vite copies `public/` as-is)
+
+### Platform Support Matrix
+
+| Platform | Share Target Works | Requirement |
+|----------|-------------------|-------------|
+| Android Chrome | ✓ Full support | PWA installed |
+| Android Firefox | ✓ Supported | PWA installed |
+| iOS Safari | ✗ Not supported | Use iOS Shortcut (Story 3.5) |
+| Desktop Chrome | Limited | PWA installed on desktop |
+| Desktop Firefox | ✗ Not supported | N/A |
+
+[Source: _bmad-output/planning-artifacts/architecture.md#ADR-011, ADR-012]
+
+### Project Structure Notes
+
+- `frontend/src/sw.ts` — Custom service worker. Compiled by Vite to `dist/sw.js`. **Must** import `self.__WB_MANIFEST` via `precacheAndRoute` for vite-plugin-pwa injection to work.
+- `frontend/src/pages/ShareTargetPage.tsx` — New page. No `AppLayout` wrapper (full-screen capture UI). No NavRail. Must render standalone.
+- `frontend/src/pages/guides/AndroidPwaSetup.tsx` — New public guide page. Mirrors the pattern of `IosShortcutSetup.tsx`. Outside `<ProtectedRoute>`.
+- `frontend/src/App.tsx` — Add `/save` and `/guides/android-pwa-setup` routes before the `*` catch-all, **outside** `<ProtectedRoute>`.
+- `frontend/public/icons/` — Static icons. Vite copies `public/` verbatim into build output. No import needed.
+- No new Lambda functions, DynamoDB tables, or CDK changes — `POST /saves` already exists and handles capture.
+- No changes to shared backend packages — this is a pure frontend story.
+
+### iOS Shortcut vs PWA Share Target — Key Differences
+
+| Aspect | iOS Shortcut (3.5) | PWA Share Target (3.6) |
+|--------|-------------------|----------------------|
+| Auth | Capture-scoped API key | Clerk JWT session |
+| Setup | Manual install + API key entry | "Add to Home Screen" (Android Chrome) |
+| Platform | iOS/iPadOS | Android |
+| Offline | No queue (timeout → fail) | BackgroundSync queue (24h TTL) |
+| UX after save | iOS notification banner | Full-screen confirmation screen |
+| Notes capture | Not supported | Optional "+ Add a note" prompt (4s) |
+| Non-URL guard | AC5: shows "Nothing to save" | AC13: same guard, same wording |
+| Cancel mid-save | N/A (shortcut, no UI) | AC12: Cancel button during loading |
+| Back navigation | System handles (shortcut exits) | `history.back()` → `window.close()` fallback |
+| Setup guide | `/guides/ios-shortcut-setup` | `/guides/android-pwa-setup` (new) |
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/architecture.md#ADR-012] — Web Share Target API manifest spec
+- [Source: _bmad-output/planning-artifacts/architecture.md#ADR-011] — Platform strategy (PWA + Shortcut)
+- [Source: _bmad-output/planning-artifacts/ux-design-specification.md#9-Mobile-Capture-System] — PWA share target flow, confirmation screen design, offline save spec
+- [Source: _bmad-output/planning-artifacts/epics.md#Epic-3] — FR45 (PWA share target), FR46 (<3 second latency), FR47 (quick-save)
+- [Source: _bmad-output/implementation-artifacts/3-5-ios-shortcut-capture.md] — iOS Shortcut story; context on API endpoint, capture scope, and capture flow performance
+- [Source: frontend/vite.config.ts] — Existing VitePWA setup (`vite-plugin-pwa` v0.17.0 already installed)
+- [Source: frontend/src/api/client.ts] — ApiClient; JWT auth via Bearer token
+- [Source: frontend/src/App.tsx] — Routing structure; ProtectedRoute pattern
+- [Source: frontend/src/pages/guides/IosShortcutSetup.tsx] — Reference for public page pattern (no auth wrapper)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+{{agent_model_name_version}}
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/3-6a-ui-foundation-design-system.md
+++ b/_bmad-output/implementation-artifacts/3-6a-ui-foundation-design-system.md
@@ -1,0 +1,300 @@
+---
+id: "3.6a"
+title: "UI Foundation & Design System Setup"
+status: ready-for-dev
+depends_on: []
+touches:
+  - frontend/src/lib/content-type-icons.ts
+  - frontend/src/lib/toast.ts
+  - frontend/src/components/ui/card.tsx
+  - frontend/src/components/ui/error-boundary.tsx
+  - frontend/src/index.css
+  - frontend/src/components/SaveRow.tsx
+  - frontend/src/App.tsx
+  - frontend/test/components/ui/button.test.tsx
+  - frontend/test/components/ui/dialog.test.tsx
+  - frontend/test/components/ui/badge.test.tsx
+  - frontend/test/components/ui/skeleton.test.tsx
+  - frontend/test/components/ui/card.test.tsx
+  - frontend/test/components/ui/error-boundary.test.tsx
+  - frontend/test/components/ui/toast.test.tsx
+  - frontend/test/components/AppLayout.test.tsx
+  - frontend/test/components/NavRail.test.tsx
+  - frontend/test/components/EmptyState.test.tsx
+  - frontend/test/lib/content-type-icons.test.ts
+  - frontend/src/components/ThemeToggle.tsx
+  - frontend/test/components/ThemeToggle.test.tsx
+risk: low
+---
+
+# Story 3.6a: UI Foundation & Design System Setup
+
+## Story
+
+As a developer starting the frontend stories,
+I want design system decisions locked down and a reusable component foundation in place,
+so that Stories 3.7-3.9 can focus on feature logic rather than library choices and styling debates.
+
+## Status: Partially Complete
+
+The Quetzal frontend redesign (PR #273, merged to main) delivered the majority of this story's intent. This story formalizes what was built, closes remaining gaps, and adds the test coverage required by the project's 80% gate.
+
+### What Already Exists (DO NOT RECREATE)
+
+| Component / Feature | Location | Status |
+|---|---|---|
+| Tailwind CSS + design tokens | `frontend/src/index.css`, `tailwind.config.js` | Done |
+| Light + dark mode themes | `frontend/src/index.css` (CSS variables) | Done |
+| 13 shadcn/Radix UI primitives | `frontend/src/components/ui/` (button, badge, dialog, input, label, scroll-area, select, separator, sheet, skeleton, sonner, tabs, tooltip) | Done |
+| AppLayout (responsive wrapper) | `frontend/src/components/AppLayout.tsx` | Done |
+| NavRail (desktop rail + mobile bottom nav) | `frontend/src/components/NavRail.tsx` | Done |
+| SaveModal (paste-and-go URL capture) | `frontend/src/components/SaveModal.tsx` | Done |
+| DetailPanel (slide-in sheet) | `frontend/src/components/DetailPanel.tsx` | Done |
+| SaveRow (list item with type icon) | `frontend/src/components/SaveRow.tsx` | Done |
+| EmptyState (library/projects/search) | `frontend/src/components/EmptyState.tsx` | Done |
+| Sonner toast (mounted, styled) | `frontend/src/components/ui/sonner.tsx` | Done |
+| `cn()` utility | `frontend/src/lib/utils.ts` | Done |
+| `useIsMobile()` hook | `frontend/src/hooks/use-mobile.tsx` | Done |
+| Inter font + typography scale | `frontend/src/index.css` | Done |
+| Lucide icons (28+ used) | Various components | Done |
+| Clerk auth integration | `frontend/src/main.tsx`, `api/` | Done |
+| React Query setup | `frontend/src/App.tsx` | Done |
+| Routing (5 pages) | `frontend/src/App.tsx` | Done |
+
+### What Remains (THIS STORY'S SCOPE)
+
+1. **Extract content-type icon mapping** to shared module
+2. **Create Card component** (shadcn pattern)
+3. **Improve ErrorBoundary** with design-system styling and retry
+4. **Create toast helper** with typed variants (success/error/info/undo)
+5. **Align color tokens** with UX spec dual-accent palette (Indigo Ink + Quetzal Green)
+6. **Wire up dark mode toggle** (`next-themes` already installed, CSS variables already exist)
+7. **Add component tests** for all UI primitives and layout components
+
+## Acceptance Criteria
+
+1. **AC1: Dual-accent color palette** — CSS custom properties updated to implement the UX spec dual-accent system: Indigo Ink (`hsl(239, 84%, 57%)`) as UI accent for interactive elements, Quetzal Green (`hsl(162, 83%, 34%)`) reserved for brand moments (save confirmation, success states, logo). Both light and dark mode tokens defined. Existing `--accent` and `--brand` variables repurposed to match spec.
+
+2. **AC2: Toast helper with typed variants** — A `toast` helper module (`frontend/src/lib/toast.ts`) wrapping Sonner's `toast()` with typed functions: `showToast.success(message)`, `showToast.error(message)`, `showToast.info(message)`, `showToast.undo(message, onUndo)`. Success uses Quetzal Green glow. Errors persist until dismissed. Info auto-dismisses at 5s. Undo shows action button that calls the provided callback.
+
+3. **AC3: Content-type icon mapping extracted** — Content-type-to-icon mapping extracted from `SaveRow.tsx` into `frontend/src/lib/content-type-icons.ts` as an exported `CONTENT_TYPE_ICONS` constant. Mapping covers all types from UX spec: `video`, `podcast`, `article`, `github_repo`, `repository`, `newsletter`, `tool`, `reddit`, `linkedin`, `course`, `documentation`, `other`. Each maps to a Lucide icon component. Also exports `type ContentType = keyof typeof CONTENT_TYPE_ICONS` for type-safe usage in filters and components. `SaveRow.tsx` refactored to import from the shared module.
+
+4. **AC4: Card component created** — A `Card` component added at `frontend/src/components/ui/card.tsx` following shadcn conventions (Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter). General-purpose primitive for project cards, settings panels, and detail views in Stories 3.7-3.9. Note: saves list uses SaveRow (ultra-compact list per UX spec), not Card.
+
+5. **AC5: ErrorBoundary with design-system styling** — ErrorBoundary component extracted to `frontend/src/components/ui/error-boundary.tsx` as a reusable, styled component. Renders a centered error message with destructive color, a "Try again" button (calls `this.setState({ hasError: false })`), and an optional `onError` callback prop. Replaces the inline class component in `App.tsx`.
+
+6. **AC6: Dark mode toggle** — `next-themes` `ThemeProvider` wired into `App.tsx` with `attribute="class"` (matching existing Tailwind `darkMode: ["class"]` config), `defaultTheme="system"`, and `storageKey="alh-theme"`. A `ThemeToggle` button (Sun/Moon icon from Lucide) added to NavRail. Respects `prefers-color-scheme` by default with manual override persisted to localStorage.
+
+7. **AC7: Component test coverage** — Component tests written for existing primitives (Button, Dialog, Badge, Skeleton, AppLayout, NavRail, EmptyState) and new components created in this story (Card, ErrorBoundary, toast helper, content-type icons, ThemeToggle). Tests include keyboard navigation and ARIA assertions where applicable (Dialog focus trap, Button keyboard activation, ErrorBoundary retry via keyboard). Tests use Vitest + Testing Library. Coverage meets 80% threshold for touched files.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Align color tokens with UX spec dual-accent palette (AC: 1)
+  - [ ] 1.1 Update `--accent` in `index.css` to Indigo Ink hsl values for both light/dark
+  - [ ] 1.2 Ensure `--brand` maps to Quetzal Green (already close, verify exact values)
+  - [ ] 1.3 Add `--accent-soft` for indigo hover/selected states
+  - [ ] 1.4 Verify button variants use accent (indigo) not brand (quetzal) for primary
+  - [ ] 1.5 Verify destructive stays red, success uses brand/quetzal
+
+- [ ] Task 2: Extract content-type icon mapping (AC: 3)
+  - [ ] 2.1 Create `frontend/src/lib/content-type-icons.ts` with `CONTENT_TYPE_ICONS` map
+  - [ ] 2.2 Include all types: video, podcast, article, github_repo, repository, newsletter, tool, reddit, linkedin, course, documentation, other
+  - [ ] 2.3 Export `type ContentType = keyof typeof CONTENT_TYPE_ICONS` for type-safe usage
+  - [ ] 2.4 Add `getContentTypeIcon(type: string)` function returning icon component + fallback
+  - [ ] 2.5 Refactor `SaveRow.tsx` to import from shared module (delete inline `TYPE_ICONS`)
+  - [ ] 2.6 Write test: all known types resolve, unknown type returns fallback (Link2)
+
+- [ ] Task 3: Create Card component (AC: 4)
+  - [ ] 3.1 Add `frontend/src/components/ui/card.tsx` with shadcn Card pattern
+  - [ ] 3.2 Exports: Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter
+  - [ ] 3.3 Write test: renders with children, header/content/footer compose correctly
+
+- [ ] Task 4: Improve ErrorBoundary (AC: 5)
+  - [ ] 4.1 Create `frontend/src/components/ui/error-boundary.tsx` as styled reusable component
+  - [ ] 4.2 Style with design tokens: destructive color, centered layout, "Try again" button
+  - [ ] 4.3 Add `onError` callback prop for error reporting
+  - [ ] 4.4 Replace inline ErrorBoundary in `App.tsx` with new component
+  - [ ] 4.5 Write test: catches thrown error, shows message, retry resets state
+
+- [ ] Task 5: Create toast helper (AC: 2)
+  - [ ] 5.1 Create `frontend/src/lib/toast.ts` wrapping Sonner
+  - [ ] 5.2 Implement `showToast.success()` with Quetzal Green styling
+  - [ ] 5.3 Implement `showToast.error()` that persists until dismissed
+  - [ ] 5.4 Implement `showToast.info()` with 5s auto-dismiss
+  - [ ] 5.5 Implement `showToast.undo(message, onUndo)` with action button
+  - [ ] 5.6 Refactor `SaveModal.tsx` to use `showToast.success()` instead of raw `toast()`
+  - [ ] 5.7 Write test: each variant calls sonner with correct options
+
+- [ ] Task 6: Wire up dark mode toggle (AC: 6)
+  - [ ] 6.1 Add `<ThemeProvider attribute="class" defaultTheme="system" storageKey="alh-theme">` in `App.tsx`
+  - [ ] 6.2 Create `frontend/src/components/ThemeToggle.tsx` — Sun/Moon icon button using `useTheme()` from next-themes
+  - [ ] 6.3 Add ThemeToggle to NavRail (bottom of rail on desktop, end of bottom nav on mobile)
+  - [ ] 6.4 Write test: toggles between light/dark/system, icon changes accordingly
+
+- [ ] Task 7: Tests for existing components (AC: 7)
+  - [ ] 7.1 `frontend/test/components/ui/button.test.tsx` — renders all variants, click handler fires, disabled state, keyboard activation
+  - [ ] 7.2 `frontend/test/components/ui/dialog.test.tsx` — opens/closes, ESC dismisses, focus management
+  - [ ] 7.3 `frontend/test/components/ui/badge.test.tsx` — renders all variants including project status badges
+  - [ ] 7.4 `frontend/test/components/ui/skeleton.test.tsx` — renders with pulse animation class
+  - [ ] 7.5 `frontend/test/components/AppLayout.test.tsx` — renders NavRail + main content area
+  - [ ] 7.6 `frontend/test/components/NavRail.test.tsx` — renders nav items, active state, responsive behavior
+  - [ ] 7.7 `frontend/test/components/EmptyState.test.tsx` — renders each variant (library, projects, search)
+
+## Dev Notes
+
+### Architecture Compliance
+
+- **Component library:** shadcn/ui (copy-paste pattern) + Radix UI + Tailwind CSS. This is locked — do not introduce another component library.
+- **Icons:** Lucide React. Do not add a second icon library.
+- **Toast:** Sonner. The `showToast` helper wraps it; do not replace Sonner.
+- **State:** React Query for server state, React Context for app state (via `useApp()`). No Redux, Zustand, or Jotai.
+- **Styling:** Tailwind utility classes + CSS custom properties in `index.css`. No CSS modules, styled-components, or emotion.
+
+### UX Spec Alignment — Dual-Accent Color System
+
+The UX spec (`_bmad-output/planning-artifacts/ux-design-specification.md` Section 8) defines a dual-accent system:
+- **Indigo Ink** (`hsl(239, 84%, 57%)`) — UI accent for buttons, links, selected states, interactive elements
+- **Quetzal Green** (`hsl(162, 83%, 34%)`) — Brand accent used surgically: save confirmation toast, success states, logo mark only
+
+Current implementation uses Quetzal Green as the primary/accent color for everything (buttons, nav active states). Task 1 corrects this to match the spec: interactive elements use Indigo, brand moments use Quetzal Green.
+
+**Important:** The `--accent` variable cascades through every component using `bg-accent`, `text-accent`, `ring-accent`, etc. After changing tokens, run the app and verify both light and dark mode visually — button colors, nav active states, focus rings, hover states all shift from green to indigo.
+
+**Quetzal Green usage rules (from UX spec):**
+- Save confirmation toast (primary brand moment)
+- Success states (project created, tutorial completed)
+- Logo mark
+- **Never** buttons, backgrounds, borders, hover states, navigation
+
+### Content-Type Icon Mapping (Full Spec)
+
+From epic plan + UX spec, the complete mapping:
+
+| Content Type | Lucide Icon | Notes |
+|---|---|---|
+| `video` | `Video` | YouTube, Vimeo, etc. |
+| `podcast` | `Podcast` | Audio content |
+| `article` | `FileText` | Blog posts, articles |
+| `github_repo` / `repository` | `Github` | GitHub repos |
+| `newsletter` | `Mail` | Email newsletters |
+| `tool` | `Wrench` | Developer tools |
+| `reddit` | `MessageSquare` | Reddit posts/threads |
+| `linkedin` | `Linkedin` | LinkedIn posts |
+| `course` | `GraduationCap` | Online courses |
+| `documentation` | `BookOpen` | API docs, guides |
+| `other` | `Link2` | Fallback for unknown types |
+
+### Testing Approach
+
+- **Framework:** Vitest + @testing-library/react + @testing-library/user-event (already installed)
+- **Test location:** `frontend/test/` (matches existing pattern from `App.test.tsx`, `api/client.test.ts`)
+- **Coverage:** 80% threshold enforced. Focus on behavior, not implementation details.
+- **Mocking:** For toast tests, mock `sonner` module. For ErrorBoundary, use a component that throws.
+- **Accessibility assertions:** Use `screen.getByRole()`, verify `aria-*` attributes, test keyboard interactions with `userEvent.keyboard()`.
+
+### File Structure (After Story Completion)
+
+```
+frontend/src/
+├── components/
+│   ├── ui/
+│   │   ├── badge.tsx          (existing)
+│   │   ├── button.tsx         (existing)
+│   │   ├── card.tsx           (NEW)
+│   │   ├── dialog.tsx         (existing)
+│   │   ├── error-boundary.tsx (NEW — replaces inline in App.tsx)
+│   │   ├── input.tsx          (existing)
+│   │   ├── label.tsx          (existing)
+│   │   ├── scroll-area.tsx    (existing)
+│   │   ├── select.tsx         (existing)
+│   │   ├── separator.tsx      (existing)
+│   │   ├── sheet.tsx          (existing)
+│   │   ├── skeleton.tsx       (existing)
+│   │   ├── sonner.tsx         (existing)
+│   │   ├── tabs.tsx           (existing)
+│   │   └── tooltip.tsx        (existing)
+│   ├── AppLayout.tsx          (existing)
+│   ├── DetailPanel.tsx        (existing)
+│   ├── EmptyState.tsx         (existing)
+│   ├── NavRail.tsx            (existing, MODIFIED — add ThemeToggle)
+│   ├── SaveModal.tsx          (existing, refactored to use showToast)
+│   ├── SaveRow.tsx            (existing, refactored to use CONTENT_TYPE_ICONS)
+│   └── ThemeToggle.tsx        (NEW)
+├── lib/
+│   ├── content-type-icons.ts  (NEW)
+│   ├── toast.ts               (NEW)
+│   ├── mock-data.ts           (existing)
+│   ├── store.tsx              (existing)
+│   ├── types.ts               (existing)
+│   └── utils.ts               (existing)
+├── index.css                  (MODIFIED — dual-accent tokens)
+└── App.tsx                    (MODIFIED — use new ErrorBoundary + ThemeProvider)
+
+frontend/test/
+├── components/
+│   ├── ui/
+│   │   ├── button.test.tsx    (NEW)
+│   │   ├── dialog.test.tsx    (NEW)
+│   │   ├── badge.test.tsx     (NEW)
+│   │   ├── skeleton.test.tsx  (NEW)
+│   │   ├── card.test.tsx      (NEW)
+│   │   ├── error-boundary.test.tsx (NEW)
+│   │   └── toast.test.tsx     (NEW)
+│   ├── AppLayout.test.tsx     (NEW)
+│   ├── NavRail.test.tsx       (NEW)
+│   ├── EmptyState.test.tsx    (NEW)
+│   └── ThemeToggle.test.tsx   (NEW)
+├── lib/
+│   └── content-type-icons.test.ts (NEW)
+├── api/
+│   ├── client.test.ts         (existing)
+│   └── hooks.test.ts          (existing)
+└── App.test.tsx               (existing)
+```
+
+### Project Structure Notes
+
+- All new components follow existing shadcn/Radix patterns (forwardRef, cn() for className merging, CVA for variants)
+- Test files mirror source tree under `frontend/test/` (established convention)
+- No new dependencies needed — all libraries already installed
+- Color token changes in `index.css` will cascade through all components using `--accent` / `--brand` variables
+- `next-themes` is already installed — Task 6 wires it up with `ThemeProvider` and a toggle button
+
+### Card vs SaveRow — UX Spec Tension
+
+The original epic plan (Story 3.7 AC6) calls for "card grid on desktop, single-column list on mobile." However, the UX spec (Section E) explicitly chose **Direction C (Ultra-Compact List)** and **dropped Direction A (card grid)** as "too generic." The SaveRow component already implements the chosen direction. The Card component is still included here as a general-purpose shadcn primitive (useful for project cards, settings panels, etc.) but **Story 3.7 should use SaveRow for the saves list, not Card**. The dev agent for 3.7 should reference the UX spec, not the older epic plan, for layout decisions.
+
+### Dark Mode — Implementation Notes
+
+UX spec (Section 8) specifies: "`prefers-color-scheme` default, manual toggle override, localStorage persistence." This is exactly what `next-themes` provides out of the box. The `attribute="class"` setting matches Tailwind's `darkMode: ["class"]` config. The toggle cycles: system → light → dark. No additional dark mode CSS work needed — all dark mode tokens already exist in `index.css`.
+
+### Out of Scope — Agent-Friendly Web Surface
+
+The UX spec (Section D) defines agent-friendly features: `llms.txt`, `llms-full.txt`, `?format=md` query param on guides, JSON-LD structured data, semantic HTML, and `GET /openapi.json`. These are backend/infra/content concerns, not UI foundation. They should be tracked as a separate future story (likely in a Guides/Documentation epic or as part of Epic 3.2 agent-native patterns).
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/ux-design-specification.md#8-Component-System] — Component tier list, shadcn inventory, custom component specs
+- [Source: _bmad-output/planning-artifacts/ux-design-specification.md#Visual-Design-Tokens] — Dual-accent palette, typography, spacing
+- [Source: _bmad-output/planning-artifacts/ux-design-specification.md#Quetzal-Green-Usage-Rules] — Brand color restrictions
+- [Source: _bmad-output/planning-artifacts/ux-design-specification.md#Button-Hierarchy] — Button variant → color mapping
+- [Source: _bmad-output/planning-artifacts/ux-design-specification.md#E-Design-Direction-Reference] — Direction C chosen (ultra-compact list), Direction A (card grid) dropped
+- [Source: _bmad-output/planning-artifacts/ux-design-specification.md#D-Agent-Friendly-Web-Surface] — llms.txt, JSON-LD, ?format=md (out of scope, noted for future)
+- [Source: docs/progress/epic-3-stories-and-plan.md#Story-3.6a] — Original AC definitions, file list, test requirements
+- [Source: frontend/src/components/SaveRow.tsx] — Inline TYPE_ICONS to extract
+- [Source: frontend/src/App.tsx] — Inline ErrorBoundary to extract
+- [Source: frontend/src/components/ui/sonner.tsx] — Current toast wrapper
+
+## Dev Agent Record
+
+### Agent Model Used
+
+### Debug Log References
+
+### Completion Notes List
+
+### Change Log
+- 2026-03-11: Story created. Recognized existing Quetzal redesign (PR #273) as partial completion. Scoped remaining work to gap closure: dual-accent palette alignment, content-type icon extraction, Card component, ErrorBoundary upgrade, toast helper, dark mode toggle, and comprehensive component test coverage.
+- 2026-03-11: Elicitation rounds — Persona focus group (practical toast/icon feedback), Critique & Refine (removed redundant AC1, merged AC8 into tests, restructured tasks). Added dark mode toggle (AC6/Task 6). Added Card vs SaveRow UX spec tension note. Noted agent-friendly web surface as out-of-scope future work.
+
+### File List

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -91,9 +91,9 @@ development_status:
   3-2-list-get-saves-api: done # PR #186 merged 2026-02-23
   3-3-update-delete-restore-api: done # PR #188 merged 2026-02-23
   3-4-save-filtering-sorting: done # PR #190 created 2026-02-23
-  3-5-ios-shortcut-capture: backlog
-  3-6-pwa-share-target: backlog
-  3-6a-ui-foundation-design-system: backlog
+  3-5-ios-shortcut-capture: ready-for-dev
+  3-6-pwa-share-target: ready-for-dev
+  3-6a-ui-foundation-design-system: ready-for-dev
   3-7-saves-list-page: backlog
   3-8-save-filtering-sorting-ui: backlog
   3-9-save-actions-feedback: backlog


### PR DESCRIPTION
## Summary

- Add implementation-ready story files for the three remaining Epic 3 frontend/mobile stories
- **Story 3.5** — iOS Shortcut Capture: API-key-authenticated URL save via iOS Shortcuts, <3s completion
- **Story 3.6** — PWA Share Target & Offline Queue: Android share sheet integration with service worker offline queue and Background Sync
- **Story 3.6a** — UI Foundation & Design System Setup: formalizes existing Quetzal redesign (PR #273) and closes gaps — dual-accent color palette (Indigo Ink + Quetzal Green), dark mode toggle, content-type icon extraction, Card component, ErrorBoundary upgrade, toast helper, and component test coverage
- Update sprint-status.yaml: all three stories moved from `backlog` → `ready-for-dev`

## Changes

- `_bmad-output/implementation-artifacts/3-5-ios-shortcut-capture.md` (new)
- `_bmad-output/implementation-artifacts/3-6-pwa-share-target.md` (new)
- `_bmad-output/implementation-artifacts/3-6a-ui-foundation-design-system.md` (new)
- `_bmad-output/implementation-artifacts/sprint-status.yaml` (modified)

## Test plan

- [ ] Story files have valid YAML frontmatter (id, title, status, depends_on, touches, risk)
- [ ] Acceptance criteria follow flat numbered list format (AC1, AC2, ...)
- [ ] Sprint status correctly reflects ready-for-dev for all three stories
- [ ] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)