### PR TITLE
feat: story 3.6a — UI foundation & design system setup

### DIFF
--- a/_bmad-output/implementation-artifacts/3-6a-ui-foundation-design-system.md
+++ b/_bmad-output/implementation-artifacts/3-6a-ui-foundation-design-system.md
@@ -1,7 +1,7 @@
 ---
 id: "3.6a"
 title: "UI Foundation & Design System Setup"
-status: review
+status: done
 depends_on: []
 touches:
   - frontend/src/lib/content-type-icons.ts

--- a/_bmad-output/implementation-artifacts/3-6a-ui-foundation-design-system.md
+++ b/_bmad-output/implementation-artifacts/3-6a-ui-foundation-design-system.md
@@ -1,7 +1,7 @@
 ---
 id: "3.6a"
 title: "UI Foundation & Design System Setup"
-status: ready-for-dev
+status: review
 depends_on: []
 touches:
   - frontend/src/lib/content-type-icons.ts
@@ -41,25 +41,25 @@ The Quetzal frontend redesign (PR #273, merged to main) delivered the majority o
 
 ### What Already Exists (DO NOT RECREATE)
 
-| Component / Feature | Location | Status |
-|---|---|---|
-| Tailwind CSS + design tokens | `frontend/src/index.css`, `tailwind.config.js` | Done |
-| Light + dark mode themes | `frontend/src/index.css` (CSS variables) | Done |
-| 13 shadcn/Radix UI primitives | `frontend/src/components/ui/` (button, badge, dialog, input, label, scroll-area, select, separator, sheet, skeleton, sonner, tabs, tooltip) | Done |
-| AppLayout (responsive wrapper) | `frontend/src/components/AppLayout.tsx` | Done |
-| NavRail (desktop rail + mobile bottom nav) | `frontend/src/components/NavRail.tsx` | Done |
-| SaveModal (paste-and-go URL capture) | `frontend/src/components/SaveModal.tsx` | Done |
-| DetailPanel (slide-in sheet) | `frontend/src/components/DetailPanel.tsx` | Done |
-| SaveRow (list item with type icon) | `frontend/src/components/SaveRow.tsx` | Done |
-| EmptyState (library/projects/search) | `frontend/src/components/EmptyState.tsx` | Done |
-| Sonner toast (mounted, styled) | `frontend/src/components/ui/sonner.tsx` | Done |
-| `cn()` utility | `frontend/src/lib/utils.ts` | Done |
-| `useIsMobile()` hook | `frontend/src/hooks/use-mobile.tsx` | Done |
-| Inter font + typography scale | `frontend/src/index.css` | Done |
-| Lucide icons (28+ used) | Various components | Done |
-| Clerk auth integration | `frontend/src/main.tsx`, `api/` | Done |
-| React Query setup | `frontend/src/App.tsx` | Done |
-| Routing (5 pages) | `frontend/src/App.tsx` | Done |
+| Component / Feature                        | Location                                                                                                                                    | Status |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| Tailwind CSS + design tokens               | `frontend/src/index.css`, `tailwind.config.js`                                                                                              | Done   |
+| Light + dark mode themes                   | `frontend/src/index.css` (CSS variables)                                                                                                    | Done   |
+| 13 shadcn/Radix UI primitives              | `frontend/src/components/ui/` (button, badge, dialog, input, label, scroll-area, select, separator, sheet, skeleton, sonner, tabs, tooltip) | Done   |
+| AppLayout (responsive wrapper)             | `frontend/src/components/AppLayout.tsx`                                                                                                     | Done   |
+| NavRail (desktop rail + mobile bottom nav) | `frontend/src/components/NavRail.tsx`                                                                                                       | Done   |
+| SaveModal (paste-and-go URL capture)       | `frontend/src/components/SaveModal.tsx`                                                                                                     | Done   |
+| DetailPanel (slide-in sheet)               | `frontend/src/components/DetailPanel.tsx`                                                                                                   | Done   |
+| SaveRow (list item with type icon)         | `frontend/src/components/SaveRow.tsx`                                                                                                       | Done   |
+| EmptyState (library/projects/search)       | `frontend/src/components/EmptyState.tsx`                                                                                                    | Done   |
+| Sonner toast (mounted, styled)             | `frontend/src/components/ui/sonner.tsx`                                                                                                     | Done   |
+| `cn()` utility                             | `frontend/src/lib/utils.ts`                                                                                                                 | Done   |
+| `useIsMobile()` hook                       | `frontend/src/hooks/use-mobile.tsx`                                                                                                         | Done   |
+| Inter font + typography scale              | `frontend/src/index.css`                                                                                                                    | Done   |
+| Lucide icons (28+ used)                    | Various components                                                                                                                          | Done   |
+| Clerk auth integration                     | `frontend/src/main.tsx`, `api/`                                                                                                             | Done   |
+| React Query setup                          | `frontend/src/App.tsx`                                                                                                                      | Done   |
+| Routing (5 pages)                          | `frontend/src/App.tsx`                                                                                                                      | Done   |
 
 ### What Remains (THIS STORY'S SCOPE)
 
@@ -89,56 +89,56 @@ The Quetzal frontend redesign (PR #273, merged to main) delivered the majority o
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Align color tokens with UX spec dual-accent palette (AC: 1)
-  - [ ] 1.1 Update `--accent` in `index.css` to Indigo Ink hsl values for both light/dark
-  - [ ] 1.2 Ensure `--brand` maps to Quetzal Green (already close, verify exact values)
-  - [ ] 1.3 Add `--accent-soft` for indigo hover/selected states
-  - [ ] 1.4 Verify button variants use accent (indigo) not brand (quetzal) for primary
-  - [ ] 1.5 Verify destructive stays red, success uses brand/quetzal
+- [x] Task 1: Align color tokens with UX spec dual-accent palette (AC: 1)
+  - [x] 1.1 Update `--accent` in `index.css` to Indigo Ink hsl values for both light/dark
+  - [x] 1.2 Ensure `--brand` maps to Quetzal Green (already close, verify exact values)
+  - [x] 1.3 Add `--accent-soft` for indigo hover/selected states
+  - [x] 1.4 Verify button variants use accent (indigo) not brand (quetzal) for primary
+  - [x] 1.5 Verify destructive stays red, success uses brand/quetzal
 
-- [ ] Task 2: Extract content-type icon mapping (AC: 3)
-  - [ ] 2.1 Create `frontend/src/lib/content-type-icons.ts` with `CONTENT_TYPE_ICONS` map
-  - [ ] 2.2 Include all types: video, podcast, article, github_repo, repository, newsletter, tool, reddit, linkedin, course, documentation, other
-  - [ ] 2.3 Export `type ContentType = keyof typeof CONTENT_TYPE_ICONS` for type-safe usage
-  - [ ] 2.4 Add `getContentTypeIcon(type: string)` function returning icon component + fallback
-  - [ ] 2.5 Refactor `SaveRow.tsx` to import from shared module (delete inline `TYPE_ICONS`)
-  - [ ] 2.6 Write test: all known types resolve, unknown type returns fallback (Link2)
+- [x] Task 2: Extract content-type icon mapping (AC: 3)
+  - [x] 2.1 Create `frontend/src/lib/content-type-icons.ts` with `CONTENT_TYPE_ICONS` map
+  - [x] 2.2 Include all types: video, podcast, article, github_repo, repository, newsletter, tool, reddit, linkedin, course, documentation, other
+  - [x] 2.3 Export `type ContentType = keyof typeof CONTENT_TYPE_ICONS` for type-safe usage
+  - [x] 2.4 Add `getContentTypeIcon(type: string)` function returning icon component + fallback
+  - [x] 2.5 Refactor `SaveRow.tsx` to import from shared module (delete inline `TYPE_ICONS`)
+  - [x] 2.6 Write test: all known types resolve, unknown type returns fallback (Link2)
 
-- [ ] Task 3: Create Card component (AC: 4)
-  - [ ] 3.1 Add `frontend/src/components/ui/card.tsx` with shadcn Card pattern
-  - [ ] 3.2 Exports: Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter
-  - [ ] 3.3 Write test: renders with children, header/content/footer compose correctly
+- [x] Task 3: Create Card component (AC: 4)
+  - [x] 3.1 Add `frontend/src/components/ui/card.tsx` with shadcn Card pattern
+  - [x] 3.2 Exports: Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter
+  - [x] 3.3 Write test: renders with children, header/content/footer compose correctly
 
-- [ ] Task 4: Improve ErrorBoundary (AC: 5)
-  - [ ] 4.1 Create `frontend/src/components/ui/error-boundary.tsx` as styled reusable component
-  - [ ] 4.2 Style with design tokens: destructive color, centered layout, "Try again" button
-  - [ ] 4.3 Add `onError` callback prop for error reporting
-  - [ ] 4.4 Replace inline ErrorBoundary in `App.tsx` with new component
-  - [ ] 4.5 Write test: catches thrown error, shows message, retry resets state
+- [x] Task 4: Improve ErrorBoundary (AC: 5)
+  - [x] 4.1 Create `frontend/src/components/ui/error-boundary.tsx` as styled reusable component
+  - [x] 4.2 Style with design tokens: destructive color, centered layout, "Try again" button
+  - [x] 4.3 Add `onError` callback prop for error reporting
+  - [x] 4.4 Replace inline ErrorBoundary in `App.tsx` with new component
+  - [x] 4.5 Write test: catches thrown error, shows message, retry resets state
 
-- [ ] Task 5: Create toast helper (AC: 2)
-  - [ ] 5.1 Create `frontend/src/lib/toast.ts` wrapping Sonner
-  - [ ] 5.2 Implement `showToast.success()` with Quetzal Green styling
-  - [ ] 5.3 Implement `showToast.error()` that persists until dismissed
-  - [ ] 5.4 Implement `showToast.info()` with 5s auto-dismiss
-  - [ ] 5.5 Implement `showToast.undo(message, onUndo)` with action button
-  - [ ] 5.6 Refactor `SaveModal.tsx` to use `showToast.success()` instead of raw `toast()`
-  - [ ] 5.7 Write test: each variant calls sonner with correct options
+- [x] Task 5: Create toast helper (AC: 2)
+  - [x] 5.1 Create `frontend/src/lib/toast.ts` wrapping Sonner
+  - [x] 5.2 Implement `showToast.success()` with Quetzal Green styling
+  - [x] 5.3 Implement `showToast.error()` that persists until dismissed
+  - [x] 5.4 Implement `showToast.info()` with 5s auto-dismiss
+  - [x] 5.5 Implement `showToast.undo(message, onUndo)` with action button
+  - [x] 5.6 Refactor `SaveModal.tsx` to use `showToast.success()` instead of raw `toast()`
+  - [x] 5.7 Write test: each variant calls sonner with correct options
 
-- [ ] Task 6: Wire up dark mode toggle (AC: 6)
-  - [ ] 6.1 Add `<ThemeProvider attribute="class" defaultTheme="system" storageKey="alh-theme">` in `App.tsx`
-  - [ ] 6.2 Create `frontend/src/components/ThemeToggle.tsx` — Sun/Moon icon button using `useTheme()` from next-themes
-  - [ ] 6.3 Add ThemeToggle to NavRail (bottom of rail on desktop, end of bottom nav on mobile)
-  - [ ] 6.4 Write test: toggles between light/dark/system, icon changes accordingly
+- [x] Task 6: Wire up dark mode toggle (AC: 6)
+  - [x] 6.1 Add `<ThemeProvider attribute="class" defaultTheme="system" storageKey="alh-theme">` in `App.tsx`
+  - [x] 6.2 Create `frontend/src/components/ThemeToggle.tsx` — Sun/Moon icon button using `useTheme()` from next-themes
+  - [x] 6.3 Add ThemeToggle to NavRail (bottom of rail on desktop, end of bottom nav on mobile)
+  - [x] 6.4 Write test: toggles between light/dark/system, icon changes accordingly
 
-- [ ] Task 7: Tests for existing components (AC: 7)
-  - [ ] 7.1 `frontend/test/components/ui/button.test.tsx` — renders all variants, click handler fires, disabled state, keyboard activation
-  - [ ] 7.2 `frontend/test/components/ui/dialog.test.tsx` — opens/closes, ESC dismisses, focus management
-  - [ ] 7.3 `frontend/test/components/ui/badge.test.tsx` — renders all variants including project status badges
-  - [ ] 7.4 `frontend/test/components/ui/skeleton.test.tsx` — renders with pulse animation class
-  - [ ] 7.5 `frontend/test/components/AppLayout.test.tsx` — renders NavRail + main content area
-  - [ ] 7.6 `frontend/test/components/NavRail.test.tsx` — renders nav items, active state, responsive behavior
-  - [ ] 7.7 `frontend/test/components/EmptyState.test.tsx` — renders each variant (library, projects, search)
+- [x] Task 7: Tests for existing components (AC: 7)
+  - [x] 7.1 `frontend/test/components/ui/button.test.tsx` — renders all variants, click handler fires, disabled state, keyboard activation
+  - [x] 7.2 `frontend/test/components/ui/dialog.test.tsx` — opens/closes, ESC dismisses, focus management
+  - [x] 7.3 `frontend/test/components/ui/badge.test.tsx` — renders all variants including project status badges
+  - [x] 7.4 `frontend/test/components/ui/skeleton.test.tsx` — renders with pulse animation class
+  - [x] 7.5 `frontend/test/components/AppLayout.test.tsx` — renders NavRail + main content area
+  - [x] 7.6 `frontend/test/components/NavRail.test.tsx` — renders nav items, active state, responsive behavior
+  - [x] 7.7 `frontend/test/components/EmptyState.test.tsx` — renders each variant (library, projects, search)
 
 ## Dev Notes
 
@@ -153,6 +153,7 @@ The Quetzal frontend redesign (PR #273, merged to main) delivered the majority o
 ### UX Spec Alignment — Dual-Accent Color System
 
 The UX spec (`_bmad-output/planning-artifacts/ux-design-specification.md` Section 8) defines a dual-accent system:
+
 - **Indigo Ink** (`hsl(239, 84%, 57%)`) — UI accent for buttons, links, selected states, interactive elements
 - **Quetzal Green** (`hsl(162, 83%, 34%)`) — Brand accent used surgically: save confirmation toast, success states, logo mark only
 
@@ -161,6 +162,7 @@ Current implementation uses Quetzal Green as the primary/accent color for everyt
 **Important:** The `--accent` variable cascades through every component using `bg-accent`, `text-accent`, `ring-accent`, etc. After changing tokens, run the app and verify both light and dark mode visually — button colors, nav active states, focus rings, hover states all shift from green to indigo.
 
 **Quetzal Green usage rules (from UX spec):**
+
 - Save confirmation toast (primary brand moment)
 - Success states (project created, tutorial completed)
 - Logo mark
@@ -170,19 +172,19 @@ Current implementation uses Quetzal Green as the primary/accent color for everyt
 
 From epic plan + UX spec, the complete mapping:
 
-| Content Type | Lucide Icon | Notes |
-|---|---|---|
-| `video` | `Video` | YouTube, Vimeo, etc. |
-| `podcast` | `Podcast` | Audio content |
-| `article` | `FileText` | Blog posts, articles |
-| `github_repo` / `repository` | `Github` | GitHub repos |
-| `newsletter` | `Mail` | Email newsletters |
-| `tool` | `Wrench` | Developer tools |
-| `reddit` | `MessageSquare` | Reddit posts/threads |
-| `linkedin` | `Linkedin` | LinkedIn posts |
-| `course` | `GraduationCap` | Online courses |
-| `documentation` | `BookOpen` | API docs, guides |
-| `other` | `Link2` | Fallback for unknown types |
+| Content Type                 | Lucide Icon     | Notes                      |
+| ---------------------------- | --------------- | -------------------------- |
+| `video`                      | `Video`         | YouTube, Vimeo, etc.       |
+| `podcast`                    | `Podcast`       | Audio content              |
+| `article`                    | `FileText`      | Blog posts, articles       |
+| `github_repo` / `repository` | `Github`        | GitHub repos               |
+| `newsletter`                 | `Mail`          | Email newsletters          |
+| `tool`                       | `Wrench`        | Developer tools            |
+| `reddit`                     | `MessageSquare` | Reddit posts/threads       |
+| `linkedin`                   | `Linkedin`      | LinkedIn posts             |
+| `course`                     | `GraduationCap` | Online courses             |
+| `documentation`              | `BookOpen`      | API docs, guides           |
+| `other`                      | `Link2`         | Fallback for unknown types |
 
 ### Testing Approach
 
@@ -289,12 +291,50 @@ The UX spec (Section D) defines agent-friendly features: `llms.txt`, `llms-full.
 
 ### Agent Model Used
 
+Claude Opus 4.6
+
 ### Debug Log References
+
+N/A
 
 ### Completion Notes List
 
+- All 7 tasks completed with TDD approach
+- Color tokens: --primary/--accent → Indigo Ink, --brand → Quetzal Green, light + dark modes
+- Content-type icons: shared module with 12 types, SaveRow refactored
+- Card component: 6 exports following shadcn conventions
+- ErrorBoundary: extracted from App.tsx, design tokens, retry, onError callback
+- Toast helper: success/error/info/undo variants, SaveModal refactored
+- Dark mode: ThemeProvider in App.tsx, ThemeToggle in NavRail
+- 79 tests across 15 files, all passing. Coverage: 99.51%. Lint + type-check clean.
+
 ### Change Log
+
 - 2026-03-11: Story created. Recognized existing Quetzal redesign (PR #273) as partial completion. Scoped remaining work to gap closure: dual-accent palette alignment, content-type icon extraction, Card component, ErrorBoundary upgrade, toast helper, dark mode toggle, and comprehensive component test coverage.
 - 2026-03-11: Elicitation rounds — Persona focus group (practical toast/icon feedback), Critique & Refine (removed redundant AC1, merged AC8 into tests, restructured tasks). Added dark mode toggle (AC6/Task 6). Added Card vs SaveRow UX spec tension note. Noted agent-friendly web surface as out-of-scope future work.
+- 2026-03-11: Implementation completed — all 7 tasks, all 7 ACs satisfied.
 
 ### File List
+
+- frontend/src/index.css (MODIFIED)
+- frontend/src/App.tsx (MODIFIED)
+- frontend/src/components/SaveRow.tsx (MODIFIED)
+- frontend/src/components/SaveModal.tsx (MODIFIED)
+- frontend/src/components/NavRail.tsx (MODIFIED)
+- frontend/src/lib/content-type-icons.ts (NEW)
+- frontend/src/lib/toast.ts (NEW)
+- frontend/src/components/ui/card.tsx (NEW)
+- frontend/src/components/ui/error-boundary.tsx (NEW)
+- frontend/src/components/ThemeToggle.tsx (NEW)
+- frontend/test/lib/content-type-icons.test.ts (NEW)
+- frontend/test/components/ui/card.test.tsx (NEW)
+- frontend/test/components/ui/error-boundary.test.tsx (NEW)
+- frontend/test/components/ui/toast.test.tsx (NEW)
+- frontend/test/components/ui/button.test.tsx (NEW)
+- frontend/test/components/ui/dialog.test.tsx (NEW)
+- frontend/test/components/ui/badge.test.tsx (NEW)
+- frontend/test/components/ui/skeleton.test.tsx (NEW)
+- frontend/test/components/AppLayout.test.tsx (NEW)
+- frontend/test/components/NavRail.test.tsx (NEW)
+- frontend/test/components/EmptyState.test.tsx (NEW)
+- frontend/test/components/ThemeToggle.test.tsx (NEW)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -93,7 +93,7 @@ development_status:
   3-4-save-filtering-sorting: done # PR #190 created 2026-02-23
   3-5-ios-shortcut-capture: ready-for-dev
   3-6-pwa-share-target: ready-for-dev
-  3-6a-ui-foundation-design-system: ready-for-dev
+  3-6a-ui-foundation-design-system: review
   3-7-saves-list-page: backlog
   3-8-save-filtering-sorting-ui: backlog
   3-9-save-actions-feedback: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -93,7 +93,7 @@ development_status:
   3-4-save-filtering-sorting: done # PR #190 created 2026-02-23
   3-5-ios-shortcut-capture: ready-for-dev
   3-6-pwa-share-target: ready-for-dev
-  3-6a-ui-foundation-design-system: review
+  3-6a-ui-foundation-design-system: done # PR #276 — dual-accent palette, toast/icon/card/error-boundary/theme-toggle, 79 tests
   3-7-saves-list-page: backlog
   3-8-save-filtering-sorting-ui: backlog
   3-9-save-actions-feedback: backlog

--- a/docs/progress/epic-3-auto-run.md
+++ b/docs/progress/epic-3-auto-run.md
@@ -3,21 +3,29 @@ epic_id: Epic-3
 status: in-progress
 scope: ["3.6a"]
 started: "2026-03-11T00:00:00Z"
-last_updated: "2026-03-11T00:01:00Z"
+last_updated: "2026-03-11T00:10:00Z"
 stories:
-  "3.6a": { status: in-progress, startedAt: "2026-03-11T00:01:00Z" }
+  "3.6a":
+    {
+      status: review,
+      startedAt: "2026-03-11T00:01:00Z",
+      commit: "e80257cc0053d0d7fc109d7592265bb8e3f31420",
+      coverage: 99,
+    }
 ---
 
 <!-- Human-readable display below (generated from frontmatter) -->
 
 # Epic 3 Auto-Run Progress
 
-| Story | Status         | PR  | Coverage | Review Rounds | Duration |
-| ----- | -------------- | --- | -------- | ------------- | -------- |
-| 3.6a  | 🔄 In Progress | -   | -        | -             | -        |
+| Story | Status       | PR  | Coverage | Review Rounds | Duration |
+| ----- | ------------ | --- | -------- | ------------- | -------- |
+| 3.6a  | 🔍 In Review | -   | 99%      | -             | -        |
 
 ## Activity Log
 
 - [00:00] Epic 3 auto-run started (scope: Story 3.6a only)
 - [00:01] Story 3.6a: Issue #275 created, branch story-3-6a-ui-foundation-design-system-setup created
 - [00:01] Story 3.6a: Implementation started
+- [00:10] Story 3.6a: Implementation complete, 79 tests passing, coverage 99.51%
+- [00:10] Story 3.6a: Committed (e80257c), entering review

--- a/docs/progress/epic-3-auto-run.md
+++ b/docs/progress/epic-3-auto-run.md
@@ -1,0 +1,23 @@
+---
+epic_id: Epic-3
+status: in-progress
+scope: ["3.6a"]
+started: "2026-03-11T00:00:00Z"
+last_updated: "2026-03-11T00:01:00Z"
+stories:
+  "3.6a": { status: in-progress, startedAt: "2026-03-11T00:01:00Z" }
+---
+
+<!-- Human-readable display below (generated from frontmatter) -->
+
+# Epic 3 Auto-Run Progress
+
+| Story | Status         | PR  | Coverage | Review Rounds | Duration |
+| ----- | -------------- | --- | -------- | ------------- | -------- |
+| 3.6a  | 🔄 In Progress | -   | -        | -             | -        |
+
+## Activity Log
+
+- [00:00] Epic 3 auto-run started (scope: Story 3.6a only)
+- [00:01] Story 3.6a: Issue #275 created, branch story-3-6a-ui-foundation-design-system-setup created
+- [00:01] Story 3.6a: Implementation started

--- a/docs/progress/epic-3-auto-run.md
+++ b/docs/progress/epic-3-auto-run.md
@@ -1,16 +1,18 @@
 ---
 epic_id: Epic-3
-status: in-progress
+status: complete
 scope: ["3.6a"]
 started: "2026-03-11T00:00:00Z"
-last_updated: "2026-03-11T00:10:00Z"
+last_updated: "2026-03-11T00:30:00Z"
 stories:
   "3.6a":
     {
-      status: review,
+      status: done,
       startedAt: "2026-03-11T00:01:00Z",
-      commit: "e80257cc0053d0d7fc109d7592265bb8e3f31420",
+      commit: "037a512",
       coverage: 99,
+      pr: 276,
+      reviewRounds: 2,
     }
 ---
 
@@ -18,9 +20,9 @@ stories:
 
 # Epic 3 Auto-Run Progress
 
-| Story | Status       | PR  | Coverage | Review Rounds | Duration |
-| ----- | ------------ | --- | -------- | ------------- | -------- |
-| 3.6a  | 🔍 In Review | -   | 99%      | -             | -        |
+| Story | Status  | PR   | Coverage | Review Rounds | Duration |
+| ----- | ------- | ---- | -------- | ------------- | -------- |
+| 3.6a  | ✅ Done | #276 | 99%      | 2             | ~30min   |
 
 ## Activity Log
 
@@ -29,3 +31,7 @@ stories:
 - [00:01] Story 3.6a: Implementation started
 - [00:10] Story 3.6a: Implementation complete, 79 tests passing, coverage 99.51%
 - [00:10] Story 3.6a: Committed (e80257c), entering review
+- [00:15] Story 3.6a: Review round 1 — 3 Important, 5 Minor, 0 Critical
+- [00:20] Story 3.6a: Fixer addressed all 3 Important findings (037a512)
+- [00:25] Story 3.6a: Review round 2 — clean, all fixes verified, recommendation: merge
+- [00:30] Story 3.6a: PR #276 created, CI passing (all gates green except Code Review Gate)

--- a/docs/progress/story-3-6a-review-round-2.md
+++ b/docs/progress/story-3-6a-review-round-2.md
@@ -1,0 +1,56 @@
+# Story 3.6a Code Review Findings - Round 2
+
+**Reviewer:** Agent (Fresh Context)
+**Date:** 2026-03-11
+**Branch:** story-3-6a-ui-foundation-design-system-setup
+
+## Round 1 Fix Verification
+
+### Fix 1: ThemeToggle in mobile bottom nav (Important #1) -- VERIFIED
+
+**File:** `frontend/src/components/NavRail.tsx`, line 150
+
+The `<ThemeToggle />` component is now rendered as the last element inside the mobile bottom `<nav>` (line 150), matching the desktop rail placement at line 120. Both desktop and mobile nav now include the theme toggle. The NavRail test at `frontend/test/components/NavRail.test.tsx` line 65-69 confirms the ThemeToggle button is rendered (checking for `getAllByRole("button", { name: /toggle theme/i })`). AC6 (Task 6.3) requirement is satisfied.
+
+### Fix 2: ErrorBoundary uses Button component (Important #2) -- VERIFIED
+
+**File:** `frontend/src/components/ui/error-boundary.tsx`, lines 3, 47-49
+
+The `Button` component is properly imported from `@/components/ui/button` (line 3) and used in the render method (line 47) instead of a raw `<button>` element. No duplicated Tailwind utility classes remain. The error-boundary test at line 54 correctly queries for the button by role, and both the click recovery test (line 58) and keyboard accessibility test (line 97) pass. This is a clean fix.
+
+### Fix 3: Check icon restored in success toast (Important #3) -- VERIFIED
+
+**File:** `frontend/src/lib/toast.tsx`, lines 2, 10
+
+The `Check` icon is imported from `lucide-react` (line 2) and passed as the `icon` property in the success toast options (line 10: `icon: <Check className="w-4 h-4 text-primary" />`). This matches the original `SaveModal.tsx` implementation. The file extension was correctly changed from `.ts` to `.tsx` to support JSX syntax. The toast test at line 25 verifies an icon is passed via `expect.anything()`.
+
+## Critical Issues (Must Fix)
+
+None found.
+
+## Important Issues (Should Fix)
+
+None found.
+
+## Minor Issues (Nice to Have)
+
+None found. The 5 minor issues from Round 1 remain as-is (they were categorized as nice-to-have and not required to fix). No new issues were introduced by the three fixes.
+
+## What Was Checked
+
+- **All three Round 1 fix files** read and verified against the original findings
+- **Full diff** reviewed (`git diff origin/main...story-3-6a-ui-foundation-design-system-setup --stat`): 25 files changed, 1251 insertions, 184 deletions -- no unexpected files
+- **Test suite:** All 79 tests across 15 files pass (vitest run)
+- **Type checking:** `tsc --noEmit` completes with zero errors
+- **No new regressions** introduced by the fixes -- the Button import in error-boundary is clean, the toast.tsx JSX extension is correct, and the ThemeToggle additions in NavRail are minimal and correct
+- **Hardcoded secrets scan:** No AWS account IDs, access keys, resource IDs, API keys, private key material, connection strings, or ARNs found in any changed files
+- **Architecture compliance:** No new dependencies introduced, all imports use established patterns (`@/components/ui/*`, `@/lib/*`, `lucide-react`, `sonner`)
+
+## Summary
+
+- **Total findings:** 0 (new in Round 2)
+- **Critical:** 0
+- **Important:** 0
+- **Minor:** 0
+- **Round 1 fixes verified:** 3/3
+- **Recommendation:** **Merge.** All three Important issues from Round 1 have been correctly fixed. Tests pass (79/79), TypeScript compiles cleanly, and no new issues were introduced by the fixes. The implementation satisfies all 7 acceptance criteria. The 5 Minor items from Round 1 remain as optional future improvements but do not block merge.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,12 @@
-import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { SignedIn, SignedOut, RedirectToSignIn } from "@clerk/clerk-react";
+import { ThemeProvider } from "next-themes";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AppProvider } from "@/lib/store";
 import { AppLayout } from "@/components/AppLayout";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
 import Homepage from "@/pages/Homepage";
 import Library from "@/pages/Library";
 import Projects from "@/pages/Projects";
@@ -21,32 +22,6 @@ const queryClient = new QueryClient({
   },
 });
 
-class ErrorBoundary extends React.Component<
-  { children: React.ReactNode },
-  { error: Error | null }
-> {
-  constructor(props: { children: React.ReactNode }) {
-    super(props);
-    this.state = { error: null };
-  }
-  static getDerivedStateFromError(error: Error) {
-    return { error };
-  }
-  render() {
-    if (this.state.error) {
-      return (
-        <div style={{ color: "red", padding: 20, fontFamily: "monospace" }}>
-          <h2>Something went wrong</h2>
-          <pre style={{ whiteSpace: "pre-wrap" }}>
-            {this.state.error.message}
-          </pre>
-        </div>
-      );
-    }
-    return this.props.children;
-  }
-}
-
 /** Wraps children so only signed-in users see them; others get redirected to Clerk sign-in. */
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   return (
@@ -61,30 +36,36 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
 
 const App = () => (
   <ErrorBoundary>
-    <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
-        <AppProvider>
-          <Sonner position="bottom-center" />
-          <BrowserRouter>
-            <Routes>
-              <Route path="/" element={<Homepage />} />
-              <Route
-                element={
-                  <ProtectedRoute>
-                    <AppLayout />
-                  </ProtectedRoute>
-                }
-              >
-                <Route path="/app" element={<Library />} />
-                <Route path="/projects" element={<Projects />} />
-                <Route path="/projects/:id" element={<ProjectWorkspace />} />
-              </Route>
-              <Route path="*" element={<NotFound />} />
-            </Routes>
-          </BrowserRouter>
-        </AppProvider>
-      </TooltipProvider>
-    </QueryClientProvider>
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="system"
+      storageKey="alh-theme"
+    >
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <AppProvider>
+            <Sonner position="bottom-center" />
+            <BrowserRouter>
+              <Routes>
+                <Route path="/" element={<Homepage />} />
+                <Route
+                  element={
+                    <ProtectedRoute>
+                      <AppLayout />
+                    </ProtectedRoute>
+                  }
+                >
+                  <Route path="/app" element={<Library />} />
+                  <Route path="/projects" element={<Projects />} />
+                  <Route path="/projects/:id" element={<ProjectWorkspace />} />
+                </Route>
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </BrowserRouter>
+          </AppProvider>
+        </TooltipProvider>
+      </QueryClientProvider>
+    </ThemeProvider>
   </ErrorBoundary>
 );
 

--- a/frontend/src/components/NavRail.tsx
+++ b/frontend/src/components/NavRail.tsx
@@ -147,6 +147,7 @@ export function NavRail() {
             </span>
           </button>
         ))}
+        <ThemeToggle />
       </nav>
     </>
   );

--- a/frontend/src/components/NavRail.tsx
+++ b/frontend/src/components/NavRail.tsx
@@ -15,6 +15,7 @@ import {
 import { useApp } from "@/lib/store";
 import { cn } from "@/lib/utils";
 import quetzalLogo from "@/assets/quetzal-logo.png";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 interface NavItem {
   id: string;
@@ -116,6 +117,7 @@ export function NavRail() {
               </TooltipContent>
             </Tooltip>
           ))}
+          <ThemeToggle />
         </div>
       </nav>
 

--- a/frontend/src/components/SaveModal.tsx
+++ b/frontend/src/components/SaveModal.tsx
@@ -10,8 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useApp } from "@/lib/store";
 import { useCreateSave } from "@/api/saves";
-import { toast } from "sonner";
-import { Check } from "lucide-react";
+import { showToast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 
 export function SaveModal() {
@@ -54,11 +53,7 @@ export function SaveModal() {
       {
         onSuccess: () => {
           setSaveModalOpen(false);
-          toast("Saved.", {
-            icon: <Check className="w-4 h-4 text-primary" />,
-            className: "quetzal-glow",
-            duration: 4000,
-          });
+          showToast.success("Saved.");
         },
         onError: (err) => {
           setError(err.message || "Failed to save");

--- a/frontend/src/components/SaveRow.tsx
+++ b/frontend/src/components/SaveRow.tsx
@@ -1,31 +1,11 @@
 import { formatDistanceToNowStrict } from "date-fns";
-import {
-  FileText,
-  Video,
-  Github,
-  GraduationCap,
-  Podcast,
-  BookOpen,
-  Link2,
-  ExternalLink,
-  FolderPlus,
-} from "lucide-react";
+import { ExternalLink, FolderPlus } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import type { Resource } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { useState } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
-
-const TYPE_ICONS: Record<string, React.ElementType> = {
-  article: FileText,
-  video: Video,
-  github_repo: Github,
-  repository: Github,
-  course: GraduationCap,
-  podcast: Podcast,
-  documentation: BookOpen,
-  other: Link2,
-};
+import { getContentTypeIcon } from "@/lib/content-type-icons";
 
 const TUTORIAL_INDICATOR: Record<string, { label: string; className: string }> =
   {
@@ -65,7 +45,7 @@ export function SaveRow({
     );
   }
 
-  const Icon = TYPE_ICONS[resource.contentType] || Link2;
+  const Icon = getContentTypeIcon(resource.contentType);
   const timeAgo = formatDistanceToNowStrict(new Date(resource.createdAt), {
     addSuffix: false,
   });

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,24 @@
+import { Sun, Moon, Monitor } from "lucide-react";
+import { useTheme } from "next-themes";
+
+const THEME_CYCLE = { system: "light", light: "dark", dark: "system" } as const;
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  const currentTheme = (theme ?? "system") as keyof typeof THEME_CYCLE;
+  const nextTheme = THEME_CYCLE[currentTheme] ?? "system";
+
+  const Icon =
+    currentTheme === "dark" ? Moon : currentTheme === "light" ? Sun : Monitor;
+
+  return (
+    <button
+      onClick={() => setTheme(nextTheme)}
+      className="flex items-center justify-center w-10 h-10 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-all duration-150"
+      aria-label="Toggle theme"
+    >
+      <Icon className="w-[18px] h-[18px]" />
+    </button>
+  );
+}

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,86 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+};

--- a/frontend/src/components/ui/error-boundary.tsx
+++ b/frontend/src/components/ui/error-boundary.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+  className?: string;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    this.props.onError?.(error, errorInfo);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div
+          className={cn(
+            "flex flex-col items-center justify-center min-h-[200px] p-8 text-center",
+            this.props.className
+          )}
+        >
+          <h2 className="text-lg font-semibold text-destructive mb-2">
+            Something went wrong
+          </h2>
+          <p className="text-sm text-muted-foreground mb-4 max-w-md font-mono">
+            {this.state.error.message}
+          </p>
+          <button
+            onClick={() => this.setState({ error: null })}
+            className="inline-flex items-center justify-center rounded-md text-sm font-medium h-10 px-4 py-2 bg-primary text-primary-foreground hover:bg-primary/90 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/ui/error-boundary.tsx
+++ b/frontend/src/components/ui/error-boundary.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;
@@ -43,12 +44,9 @@ export class ErrorBoundary extends React.Component<
           <p className="text-sm text-muted-foreground mb-4 max-w-md font-mono">
             {this.state.error.message}
           </p>
-          <button
-            onClick={() => this.setState({ error: null })}
-            className="inline-flex items-center justify-center rounded-md text-sm font-medium h-10 px-4 py-2 bg-primary text-primary-foreground hover:bg-primary/90 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-          >
+          <Button onClick={() => this.setState({ error: null })}>
             Try again
-          </button>
+          </Button>
         </div>
       );
     }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -16,7 +16,7 @@
     --popover: 0 0% 100%;
     --popover-foreground: 220 20% 12%;
 
-    --primary: 162 72% 32%;
+    --primary: 239 84% 57%;
     --primary-foreground: 0 0% 100%;
 
     --secondary: 220 14% 96%;
@@ -26,11 +26,11 @@
     --muted-foreground: 220 9% 46%;
     --muted-lighter: 220 13% 91%;
 
-    --accent: 162 72% 32%;
+    --accent: 239 84% 57%;
     --accent-foreground: 0 0% 100%;
-    --accent-soft: 162 50% 95%;
+    --accent-soft: 239 70% 96%;
 
-    --brand: 162 72% 32%;
+    --brand: 162 83% 34%;
     --brand-foreground: 0 0% 100%;
     --brand-soft: 162 50% 95%;
 
@@ -39,18 +39,18 @@
 
     --border: 220 13% 91%;
     --input: 220 13% 87%;
-    --ring: 162 72% 32%;
+    --ring: 239 84% 57%;
 
     --radius: 0.375rem;
 
     --sidebar-background: 0 0% 98%;
     --sidebar-foreground: 220 15% 30%;
-    --sidebar-primary: 162 72% 32%;
+    --sidebar-primary: 239 84% 57%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 162 50% 95%;
-    --sidebar-accent-foreground: 162 72% 22%;
+    --sidebar-accent: 239 70% 96%;
+    --sidebar-accent-foreground: 239 84% 47%;
     --sidebar-border: 220 13% 91%;
-    --sidebar-ring: 162 72% 32%;
+    --sidebar-ring: 239 84% 57%;
 
     --nav-width: 56px;
   }
@@ -66,8 +66,8 @@
     --popover: 220 18% 10%;
     --popover-foreground: 210 20% 92%;
 
-    --primary: 162 60% 45%;
-    --primary-foreground: 220 20% 7%;
+    --primary: 239 80% 66%;
+    --primary-foreground: 0 0% 100%;
 
     --secondary: 220 18% 14%;
     --secondary-foreground: 210 20% 92%;
@@ -76,9 +76,9 @@
     --muted-foreground: 220 9% 50%;
     --muted-lighter: 220 18% 18%;
 
-    --accent: 162 60% 45%;
-    --accent-foreground: 220 20% 7%;
-    --accent-soft: 162 40% 14%;
+    --accent: 239 80% 66%;
+    --accent-foreground: 0 0% 100%;
+    --accent-soft: 239 50% 18%;
 
     --brand: 162 60% 45%;
     --brand-foreground: 220 20% 7%;
@@ -89,16 +89,16 @@
 
     --border: 220 18% 18%;
     --input: 220 18% 18%;
-    --ring: 162 60% 45%;
+    --ring: 239 80% 66%;
 
     --sidebar-background: 220 20% 7%;
     --sidebar-foreground: 210 15% 80%;
-    --sidebar-primary: 162 60% 45%;
+    --sidebar-primary: 239 80% 66%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 162 40% 14%;
-    --sidebar-accent-foreground: 162 60% 70%;
+    --sidebar-accent: 239 50% 18%;
+    --sidebar-accent-foreground: 239 80% 80%;
     --sidebar-border: 220 18% 18%;
-    --sidebar-ring: 162 60% 45%;
+    --sidebar-ring: 239 80% 66%;
   }
 }
 

--- a/frontend/src/lib/content-type-icons.ts
+++ b/frontend/src/lib/content-type-icons.ts
@@ -1,0 +1,35 @@
+import {
+  Video,
+  Podcast,
+  FileText,
+  Github,
+  Mail,
+  Wrench,
+  MessageSquare,
+  Linkedin,
+  GraduationCap,
+  BookOpen,
+  Link2,
+} from "lucide-react";
+
+export const CONTENT_TYPE_ICONS = {
+  video: Video,
+  podcast: Podcast,
+  article: FileText,
+  github_repo: Github,
+  repository: Github,
+  newsletter: Mail,
+  tool: Wrench,
+  reddit: MessageSquare,
+  linkedin: Linkedin,
+  course: GraduationCap,
+  documentation: BookOpen,
+  other: Link2,
+} as const;
+
+export type ContentType = keyof typeof CONTENT_TYPE_ICONS;
+
+/** Returns the Lucide icon component for the given content type, falling back to Link2 for unknown types. */
+export function getContentTypeIcon(type: string): React.ElementType {
+  return CONTENT_TYPE_ICONS[type as ContentType] ?? CONTENT_TYPE_ICONS.other;
+}

--- a/frontend/src/lib/toast.ts
+++ b/frontend/src/lib/toast.ts
@@ -1,0 +1,36 @@
+import { toast } from "sonner";
+
+export const showToast = {
+  /** Success toast with Quetzal Green glow, auto-dismisses at 4s */
+  success(message: string) {
+    toast(message, {
+      duration: 4000,
+      className: "quetzal-glow",
+    });
+  },
+
+  /** Error toast that persists until manually dismissed */
+  error(message: string) {
+    toast.error(message, {
+      duration: Infinity,
+    });
+  },
+
+  /** Info toast, auto-dismisses at 5s */
+  info(message: string) {
+    toast(message, {
+      duration: 5000,
+    });
+  },
+
+  /** Toast with undo action button */
+  undo(message: string, onUndo: () => void) {
+    toast(message, {
+      action: {
+        label: "Undo",
+        onClick: onUndo,
+      },
+      duration: 8000,
+    });
+  },
+};

--- a/frontend/src/lib/toast.tsx
+++ b/frontend/src/lib/toast.tsx
@@ -1,4 +1,5 @@
 import { toast } from "sonner";
+import { Check } from "lucide-react";
 
 export const showToast = {
   /** Success toast with Quetzal Green glow, auto-dismisses at 4s */
@@ -6,6 +7,7 @@ export const showToast = {
     toast(message, {
       duration: 4000,
       className: "quetzal-glow",
+      icon: <Check className="w-4 h-4 text-primary" />,
     });
   },
 

--- a/frontend/test/components/AppLayout.test.tsx
+++ b/frontend/test/components/AppLayout.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AppLayout } from "../../src/components/AppLayout";
+import { AppProvider } from "../../src/lib/store";
+import { TooltipProvider } from "../../src/components/ui/tooltip";
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "system", setTheme: vi.fn() }),
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("@clerk/clerk-react", () => ({
+  useAuth: () => ({ getToken: vi.fn().mockResolvedValue("test-token") }),
+}));
+
+afterEach(cleanup);
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+function renderWithProviders() {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/app"]}>
+        <TooltipProvider>
+          <AppProvider>
+            <AppLayout />
+          </AppProvider>
+        </TooltipProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe("AppLayout", () => {
+  it("renders NavRail navigation elements", () => {
+    renderWithProviders();
+    // NavRail renders two nav elements (desktop + mobile)
+    const navs = document.querySelectorAll("nav");
+    expect(navs.length).toBe(2);
+  });
+
+  it("renders main content area", () => {
+    renderWithProviders();
+    const main = document.querySelector("main");
+    expect(main).toBeInTheDocument();
+  });
+
+  it("renders mobile nav with Library and Projects labels", () => {
+    renderWithProviders();
+    // Mobile bottom nav shows text labels
+    expect(screen.getAllByText("Library").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Projects").length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/test/components/EmptyState.test.tsx
+++ b/frontend/test/components/EmptyState.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { EmptyState } from "../../src/components/EmptyState";
+import { AppProvider } from "../../src/lib/store";
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "system", setTheme: vi.fn() }),
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+afterEach(cleanup);
+
+function renderWithProviders(variant: "library" | "projects" | "search") {
+  return render(
+    <AppProvider>
+      <EmptyState variant={variant} />
+    </AppProvider>
+  );
+}
+
+describe("EmptyState", () => {
+  it("renders library variant with save CTA", () => {
+    renderWithProviders("library");
+    expect(screen.getByText(/Save anything you/)).toBeInTheDocument();
+    expect(screen.getByText(/Save your first URL/)).toBeInTheDocument();
+  });
+
+  it("renders library variant with starter projects", () => {
+    renderWithProviders("library");
+    expect(screen.getByText("Build a Custom GPT")).toBeInTheDocument();
+    expect(
+      screen.getByText("AI Automation for Your Day Job")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Build a RAG Pipeline")).toBeInTheDocument();
+  });
+
+  it("renders projects variant", () => {
+    renderWithProviders("projects");
+    expect(screen.getByText(/Projects connect your saves/)).toBeInTheDocument();
+    expect(screen.getByText(/Create your first project/)).toBeInTheDocument();
+  });
+
+  it("renders search variant with no-results message", () => {
+    renderWithProviders("search");
+    expect(screen.getByText(/Nothing matches that/)).toBeInTheDocument();
+  });
+});

--- a/frontend/test/components/NavRail.test.tsx
+++ b/frontend/test/components/NavRail.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { NavRail } from "../../src/components/NavRail";
+import { AppProvider } from "../../src/lib/store";
+import { TooltipProvider } from "../../src/components/ui/tooltip";
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "system", setTheme: vi.fn() }),
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+afterEach(cleanup);
+
+function renderNavRail(path = "/app") {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <TooltipProvider>
+        <AppProvider>
+          <NavRail />
+        </AppProvider>
+      </TooltipProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("NavRail", () => {
+  it("renders nav buttons (desktop + mobile)", () => {
+    renderNavRail();
+    // Mobile bottom nav shows first 4 items with text labels
+    expect(screen.getAllByText("Save").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Search").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Library").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Projects").length).toBeGreaterThan(0);
+  });
+
+  it("renders desktop and mobile nav elements", () => {
+    renderNavRail();
+    const navs = document.querySelectorAll("nav");
+    expect(navs.length).toBe(2); // Desktop rail + mobile bottom
+  });
+
+  it("highlights active Library item at /app", () => {
+    renderNavRail("/app");
+    // Mobile nav shows text "Library" with text-primary when active
+    const libraryLabels = screen.getAllByText("Library");
+    const activeParent = libraryLabels.find((el) =>
+      el.closest("button")?.className.includes("text-primary")
+    );
+    expect(activeParent).toBeDefined();
+  });
+
+  it("highlights active Projects item at /projects", () => {
+    renderNavRail("/projects");
+    const projectsLabels = screen.getAllByText("Projects");
+    const activeParent = projectsLabels.find((el) =>
+      el.closest("button")?.className.includes("text-primary")
+    );
+    expect(activeParent).toBeDefined();
+  });
+
+  it("renders ThemeToggle button", () => {
+    renderNavRail();
+    expect(
+      screen.getAllByRole("button", { name: /toggle theme/i }).length
+    ).toBeGreaterThan(0);
+  });
+
+  it("Save button triggers action without error", async () => {
+    const user = userEvent.setup();
+    renderNavRail();
+    const saveLabels = screen.getAllByText("Save");
+    const saveButton = saveLabels[0].closest("button")!;
+    await user.click(saveButton);
+    // No error thrown = save modal state change worked
+  });
+});

--- a/frontend/test/components/ThemeToggle.test.tsx
+++ b/frontend/test/components/ThemeToggle.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeToggle } from "../../src/components/ThemeToggle";
+
+const setThemeMock = vi.fn();
+let currentTheme = "system";
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({
+    theme: currentTheme,
+    setTheme: setThemeMock,
+  }),
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  currentTheme = "system";
+});
+
+describe("ThemeToggle", () => {
+  it("renders a button with accessible label", () => {
+    render(<ThemeToggle />);
+    const button = screen.getByRole("button", { name: /toggle theme/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  it("cycles from system to light on click", async () => {
+    const user = userEvent.setup();
+    currentTheme = "system";
+    render(<ThemeToggle />);
+    const button = screen.getByRole("button", { name: /toggle theme/i });
+    await user.click(button);
+    expect(setThemeMock).toHaveBeenCalledWith("light");
+  });
+
+  it("cycles from light to dark on click", async () => {
+    const user = userEvent.setup();
+    currentTheme = "light";
+    render(<ThemeToggle />);
+    const button = screen.getByRole("button", { name: /toggle theme/i });
+    await user.click(button);
+    expect(setThemeMock).toHaveBeenCalledWith("dark");
+  });
+
+  it("cycles from dark to system on click", async () => {
+    const user = userEvent.setup();
+    currentTheme = "dark";
+    render(<ThemeToggle />);
+    const button = screen.getByRole("button", { name: /toggle theme/i });
+    await user.click(button);
+    expect(setThemeMock).toHaveBeenCalledWith("system");
+  });
+
+  it("is keyboard accessible with Enter", async () => {
+    const user = userEvent.setup();
+    currentTheme = "light";
+    render(<ThemeToggle />);
+    const button = screen.getByRole("button", { name: /toggle theme/i });
+    button.focus();
+    await user.keyboard("{Enter}");
+    expect(setThemeMock).toHaveBeenCalledWith("dark");
+  });
+});

--- a/frontend/test/components/ui/badge.test.tsx
+++ b/frontend/test/components/ui/badge.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { Badge } from "../../../src/components/ui/badge";
+
+afterEach(cleanup);
+
+describe("Badge", () => {
+  it("renders with text content", () => {
+    render(<Badge>Label</Badge>);
+    expect(screen.getByText("Label")).toBeInTheDocument();
+  });
+
+  it("renders default variant with primary colors", () => {
+    render(<Badge>Default</Badge>);
+    expect(screen.getByText("Default").className).toContain("bg-primary");
+  });
+
+  it("renders secondary variant", () => {
+    render(<Badge variant="secondary">Secondary</Badge>);
+    expect(screen.getByText("Secondary").className).toContain("bg-secondary");
+  });
+
+  it("renders destructive variant", () => {
+    render(<Badge variant="destructive">Error</Badge>);
+    expect(screen.getByText("Error").className).toContain("bg-destructive");
+  });
+
+  it("renders outline variant", () => {
+    render(<Badge variant="outline">Outline</Badge>);
+    expect(screen.getByText("Outline").className).toContain("text-foreground");
+  });
+
+  it("renders project status variants", () => {
+    render(<Badge variant="exploring">Exploring</Badge>);
+    expect(screen.getByText("Exploring").className).toContain("bg-muted");
+
+    render(<Badge variant="building">Building</Badge>);
+    expect(screen.getByText("Building").className).toContain("bg-accent-soft");
+
+    render(<Badge variant="completed">Completed</Badge>);
+    expect(screen.getByText("Completed").className).toContain("bg-brand-soft");
+
+    render(<Badge variant="paused">Paused</Badge>);
+    expect(screen.getByText("Paused").className).toContain("opacity-60");
+  });
+
+  it("renders tag variant", () => {
+    render(<Badge variant="tag">Tag</Badge>);
+    const el = screen.getByText("Tag");
+    expect(el.className).toContain("border-border");
+  });
+
+  it("accepts custom className", () => {
+    render(<Badge className="my-class">Custom</Badge>);
+    expect(screen.getByText("Custom")).toHaveClass("my-class");
+  });
+});

--- a/frontend/test/components/ui/button.test.tsx
+++ b/frontend/test/components/ui/button.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Button } from "../../../src/components/ui/button";
+
+afterEach(cleanup);
+
+describe("Button", () => {
+  it("renders with children text", () => {
+    render(<Button>Click me</Button>);
+    expect(
+      screen.getByRole("button", { name: "Click me" })
+    ).toBeInTheDocument();
+  });
+
+  it("fires click handler", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>Click</Button>);
+    await user.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders default variant", () => {
+    render(<Button>Default</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toContain("bg-primary");
+  });
+
+  it("renders destructive variant", () => {
+    render(<Button variant="destructive">Delete</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toContain("bg-destructive");
+  });
+
+  it("renders outline variant", () => {
+    render(<Button variant="outline">Outline</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toContain("border");
+  });
+
+  it("renders ghost variant", () => {
+    render(<Button variant="ghost">Ghost</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toContain("hover:bg-accent-soft");
+  });
+
+  it("respects disabled state", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <Button disabled onClick={onClick}>
+        Disabled
+      </Button>
+    );
+    const btn = screen.getByRole("button");
+    expect(btn).toBeDisabled();
+    await user.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("supports keyboard activation with Enter", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>KB</Button>);
+    const btn = screen.getByRole("button");
+    btn.focus();
+    await user.keyboard("{Enter}");
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports keyboard activation with Space", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>KB</Button>);
+    const btn = screen.getByRole("button");
+    btn.focus();
+    await user.keyboard(" ");
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders different sizes", () => {
+    const { rerender } = render(<Button size="sm">Small</Button>);
+    expect(screen.getByRole("button").className).toContain("h-9");
+
+    rerender(<Button size="lg">Large</Button>);
+    expect(screen.getByRole("button").className).toContain("h-11");
+
+    rerender(<Button size="icon">Icon</Button>);
+    expect(screen.getByRole("button").className).toContain("w-10");
+  });
+
+  it("accepts custom className", () => {
+    render(<Button className="custom-class">Custom</Button>);
+    expect(screen.getByRole("button")).toHaveClass("custom-class");
+  });
+});

--- a/frontend/test/components/ui/card.test.tsx
+++ b/frontend/test/components/ui/card.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from "../../../src/components/ui/card";
+
+describe("Card", () => {
+  it("renders children", () => {
+    render(<Card>Card content</Card>);
+    expect(screen.getByText("Card content")).toBeInTheDocument();
+  });
+
+  it("composes header, content, and footer", () => {
+    render(
+      <Card>
+        <CardHeader>
+          <CardTitle>Title</CardTitle>
+          <CardDescription>Description</CardDescription>
+        </CardHeader>
+        <CardContent>Body</CardContent>
+        <CardFooter>Footer</CardFooter>
+      </Card>
+    );
+    expect(screen.getByText("Title")).toBeInTheDocument();
+    expect(screen.getByText("Description")).toBeInTheDocument();
+    expect(screen.getByText("Body")).toBeInTheDocument();
+    expect(screen.getByText("Footer")).toBeInTheDocument();
+  });
+
+  it("accepts custom className", () => {
+    const { container } = render(<Card className="custom-class">Test</Card>);
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+
+  it("forwards ref", () => {
+    const ref = { current: null as HTMLDivElement | null };
+    render(<Card ref={ref}>Ref test</Card>);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+});

--- a/frontend/test/components/ui/dialog.test.tsx
+++ b/frontend/test/components/ui/dialog.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogTrigger,
+} from "../../../src/components/ui/dialog";
+
+afterEach(cleanup);
+
+describe("Dialog", () => {
+  it("opens when trigger is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <Dialog>
+        <DialogTrigger>Open</DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Test Dialog</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+    );
+
+    await user.click(screen.getByText("Open"));
+    await waitFor(() => {
+      expect(screen.getByText("Test Dialog")).toBeInTheDocument();
+    });
+  });
+
+  it("closes when close button is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <Dialog defaultOpen>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Closable</DialogTitle>
+            <DialogDescription>Description</DialogDescription>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+    );
+
+    expect(screen.getByText("Closable")).toBeInTheDocument();
+    const closeButton = screen.getByRole("button", { name: /close/i });
+    await user.click(closeButton);
+    await waitFor(() => {
+      expect(screen.queryByText("Closable")).not.toBeInTheDocument();
+    });
+  });
+
+  it("dismisses with Escape key", async () => {
+    const user = userEvent.setup();
+    render(
+      <Dialog defaultOpen>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>ESC Test</DialogTitle>
+            <DialogDescription>Description</DialogDescription>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+    );
+
+    expect(screen.getByText("ESC Test")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(screen.queryByText("ESC Test")).not.toBeInTheDocument();
+    });
+  });
+
+  it("calls onOpenChange when state changes", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Dialog onOpenChange={onChange}>
+        <DialogTrigger>Open</DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Change</DialogTitle>
+            <DialogDescription>Description</DialogDescription>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+    );
+
+    await user.click(screen.getByText("Open"));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/frontend/test/components/ui/error-boundary.test.tsx
+++ b/frontend/test/components/ui/error-boundary.test.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ErrorBoundary } from "../../../src/components/ui/error-boundary";
+
+afterEach(cleanup);
+
+// Suppress React error boundary console errors during tests
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+function ThrowingComponent({ message }: { message: string }) {
+  throw new Error(message);
+}
+
+describe("ErrorBoundary", () => {
+  it("renders children when no error occurs", () => {
+    render(
+      <ErrorBoundary>
+        <div>Working content</div>
+      </ErrorBoundary>
+    );
+    expect(screen.getByText("Working content")).toBeInTheDocument();
+  });
+
+  it("catches thrown error and shows error message", () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent message="Test explosion" />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(screen.getByText("Test explosion")).toBeInTheDocument();
+  });
+
+  it("shows a 'Try again' button that resets the error state", async () => {
+    const user = userEvent.setup();
+    let shouldThrow = true;
+
+    function MaybeThrow() {
+      if (shouldThrow) throw new Error("Temporary error");
+      return <div>Recovered</div>;
+    }
+
+    render(
+      <ErrorBoundary>
+        <MaybeThrow />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText("Temporary error")).toBeInTheDocument();
+    const buttons = screen.getAllByRole("button", { name: /try again/i });
+    expect(buttons.length).toBeGreaterThan(0);
+
+    shouldThrow = false;
+    await user.click(buttons[0]);
+
+    expect(screen.getByText("Recovered")).toBeInTheDocument();
+  });
+
+  it("calls onError callback when error occurs", () => {
+    const onError = vi.fn();
+    render(
+      <ErrorBoundary onError={onError}>
+        <ThrowingComponent message="Callback test" />
+      </ErrorBoundary>
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Callback test" }),
+      expect.any(Object)
+    );
+  });
+
+  it("retry button is keyboard accessible", async () => {
+    const user = userEvent.setup();
+    let shouldThrow = true;
+
+    function MaybeThrow() {
+      if (shouldThrow) throw new Error("Keyboard test");
+      return <div>Keyboard recovered</div>;
+    }
+
+    render(
+      <ErrorBoundary>
+        <MaybeThrow />
+      </ErrorBoundary>
+    );
+
+    const buttons = screen.getAllByRole("button", { name: /try again/i });
+    buttons[0].focus();
+    expect(buttons[0]).toHaveFocus();
+
+    shouldThrow = false;
+    await user.keyboard("{Enter}");
+
+    expect(screen.getByText("Keyboard recovered")).toBeInTheDocument();
+  });
+});

--- a/frontend/test/components/ui/skeleton.test.tsx
+++ b/frontend/test/components/ui/skeleton.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { Skeleton } from "../../../src/components/ui/skeleton";
+
+afterEach(cleanup);
+
+describe("Skeleton", () => {
+  it("renders with pulse animation class", () => {
+    const { container } = render(<Skeleton />);
+    expect(container.firstChild).toHaveClass("animate-pulse");
+  });
+
+  it("renders with rounded-md class", () => {
+    const { container } = render(<Skeleton />);
+    expect(container.firstChild).toHaveClass("rounded-md");
+  });
+
+  it("renders with bg-muted class", () => {
+    const { container } = render(<Skeleton />);
+    expect(container.firstChild).toHaveClass("bg-muted");
+  });
+
+  it("accepts custom className", () => {
+    const { container } = render(<Skeleton className="w-20 h-4" />);
+    expect(container.firstChild).toHaveClass("w-20");
+    expect(container.firstChild).toHaveClass("h-4");
+  });
+});

--- a/frontend/test/components/ui/toast.test.tsx
+++ b/frontend/test/components/ui/toast.test.tsx
@@ -15,13 +15,14 @@ beforeEach(() => {
 });
 
 describe("showToast", () => {
-  it("success calls toast with Quetzal Green class and 4s duration", () => {
+  it("success calls toast with Quetzal Green class, Check icon, and 4s duration", () => {
     showToast.success("Saved!");
     expect(toast).toHaveBeenCalledWith(
       "Saved!",
       expect.objectContaining({
         duration: 4000,
         className: "quetzal-glow",
+        icon: expect.anything(),
       })
     );
   });

--- a/frontend/test/components/ui/toast.test.tsx
+++ b/frontend/test/components/ui/toast.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { toast } from "sonner";
+import { showToast } from "../../../src/lib/toast";
+
+vi.mock("sonner", () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("showToast", () => {
+  it("success calls toast with Quetzal Green class and 4s duration", () => {
+    showToast.success("Saved!");
+    expect(toast).toHaveBeenCalledWith(
+      "Saved!",
+      expect.objectContaining({
+        duration: 4000,
+        className: "quetzal-glow",
+      })
+    );
+  });
+
+  it("error calls toast.error that persists until dismissed", () => {
+    showToast.error("Something failed");
+    expect(toast.error).toHaveBeenCalledWith(
+      "Something failed",
+      expect.objectContaining({
+        duration: Infinity,
+      })
+    );
+  });
+
+  it("info calls toast with 5s auto-dismiss", () => {
+    showToast.info("FYI");
+    expect(toast).toHaveBeenCalledWith(
+      "FYI",
+      expect.objectContaining({
+        duration: 5000,
+      })
+    );
+  });
+
+  it("undo calls toast with action button that invokes callback", () => {
+    const onUndo = vi.fn();
+    showToast.undo("Deleted", onUndo);
+    expect(toast).toHaveBeenCalledWith(
+      "Deleted",
+      expect.objectContaining({
+        action: expect.objectContaining({
+          label: "Undo",
+          onClick: onUndo,
+        }),
+      })
+    );
+  });
+});

--- a/frontend/test/lib/content-type-icons.test.ts
+++ b/frontend/test/lib/content-type-icons.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import {
+  CONTENT_TYPE_ICONS,
+  getContentTypeIcon,
+  type ContentType,
+} from "../../src/lib/content-type-icons";
+
+describe("content-type-icons", () => {
+  const ALL_TYPES: ContentType[] = [
+    "video",
+    "podcast",
+    "article",
+    "github_repo",
+    "repository",
+    "newsletter",
+    "tool",
+    "reddit",
+    "linkedin",
+    "course",
+    "documentation",
+    "other",
+  ];
+
+  it("exports CONTENT_TYPE_ICONS with all expected types", () => {
+    for (const type of ALL_TYPES) {
+      expect(CONTENT_TYPE_ICONS[type]).toBeDefined();
+    }
+  });
+
+  it("maps each type to a valid React component", () => {
+    for (const type of ALL_TYPES) {
+      const icon = CONTENT_TYPE_ICONS[type];
+      // Lucide icons are forwardRef objects with render function
+      expect(typeof icon === "function" || typeof icon === "object").toBe(true);
+    }
+  });
+
+  describe("getContentTypeIcon", () => {
+    it("returns the correct icon for each known type", () => {
+      for (const type of ALL_TYPES) {
+        const icon = getContentTypeIcon(type);
+        expect(icon).toBe(CONTENT_TYPE_ICONS[type]);
+      }
+    });
+
+    it("returns Link2 fallback for unknown types", () => {
+      const fallback = getContentTypeIcon("unknown_type");
+      expect(fallback).toBe(CONTENT_TYPE_ICONS.other);
+    });
+
+    it("returns Link2 fallback for empty string", () => {
+      const fallback = getContentTypeIcon("");
+      expect(fallback).toBe(CONTENT_TYPE_ICONS.other);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements Story 3.6a: UI Foundation & Design System Setup (Closes #275)

- **Dual-accent color palette**: Indigo Ink (`--primary`/`--accent`) for interactive elements, Quetzal Green (`--brand`) for brand moments, with full light/dark mode token sets
- **Toast helper**: `showToast.success/error/info/undo` wrapper around Sonner with brand glow animation and Check icon
- **Content-type icon extraction**: Centralized `getContentTypeIcon()` with 12 content types and fallback, replacing inline maps
- **Card component**: Standard shadcn Card pattern (Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter)
- **ErrorBoundary**: Class component with retry, `onError` callback, uses design system `Button`
- **ThemeToggle**: System → Light → Dark cycle via next-themes, rendered in both desktop rail and mobile bottom nav
- **79 tests passing** across 13 test files, 99%+ component coverage

## Changes

- `frontend/src/index.css` — Updated CSS custom properties for dual-accent palette
- `frontend/src/lib/toast.tsx` — New toast helper with Check icon
- `frontend/src/lib/content-type-icons.ts` — Extracted icon registry
- `frontend/src/components/ui/card.tsx` — New Card component
- `frontend/src/components/ui/error-boundary.tsx` — New ErrorBoundary
- `frontend/src/components/ThemeToggle.tsx` — New theme toggle
- `frontend/src/App.tsx` — ThemeProvider integration, ErrorBoundary import
- `frontend/src/components/NavRail.tsx` — ThemeToggle in desktop + mobile nav
- `frontend/src/components/SaveModal.tsx` — Migrated to showToast
- `frontend/src/components/SaveRow.tsx` — Migrated to getContentTypeIcon
- 13 new/updated test files with 79 passing tests

## Test plan

- [x] All 79 frontend tests pass (`npx vitest run`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Lint passes (`npx eslint .`)
- [x] 99%+ component coverage
- [x] Code review: 2 rounds, all Important findings resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)